### PR TITLE
AB#24829

### DIFF
--- a/src/const/defaultRecordFields.ts
+++ b/src/const/defaultRecordFields.ts
@@ -40,51 +40,66 @@ export const defaultRecordFields: {
   field: string;
   type: GraphQLType;
   filterType: GraphQLType;
+  selectable: boolean;
 }[] = [
   {
     field: 'id',
     type: GraphQLID,
     filterType: GraphQLID,
+    selectable: true,
   },
   {
     field: 'incrementalId',
     type: GraphQLID,
     filterType: GraphQLID,
+    selectable: true,
   },
   {
     field: 'createdAt',
     type: GraphQLDateTime,
     filterType: GraphQLDateTime,
+    selectable: true,
   },
   {
     field: 'modifiedAt',
     type: GraphQLDateTime,
     filterType: GraphQLDateTime,
+    selectable: true,
   },
   {
     field: 'createdBy',
     type: UserType,
     filterType: GraphQLID,
+    selectable: true,
   },
   {
     field: 'lastUpdatedBy',
     type: UserType,
     filterType: GraphQLID,
+    selectable: true,
   },
   {
     field: 'canUpdate',
     type: GraphQLBoolean,
     filterType: GraphQLBoolean,
+    selectable: false,
   },
   {
     field: 'canDelete',
     type: GraphQLBoolean,
     filterType: GraphQLBoolean,
+    selectable: false,
   },
 ];
 
 export const defaultRecordFieldsFlat: string[] = defaultRecordFields.map(
   (x) => x.field
+);
+
+export const selectableRecordFieldsFlat: string[] = defaultRecordFields.reduce(
+  (fields, field): string[] =>
+    field.selectable ? [...fields, field.field] : fields,
+  []
 );
 
 export const defaultMetaFields: { field: string; type: GraphQLType }[] = [

--- a/src/const/defaultRecordFields.ts
+++ b/src/const/defaultRecordFields.ts
@@ -96,11 +96,12 @@ export const defaultRecordFieldsFlat: string[] = defaultRecordFields.map(
   (x) => x.field
 );
 
-export const selectableRecordFieldsFlat: string[] = defaultRecordFields.reduce(
-  (fields, field): string[] =>
-    field.selectable ? [...fields, field.field] : fields,
-  []
-);
+export const selectableDefaultRecordFieldsFlat: string[] =
+  defaultRecordFields.reduce(
+    (fields, field): string[] =>
+      field.selectable ? [...fields, field.field] : fields,
+    []
+  );
 
 export const defaultMetaFields: { field: string; type: GraphQLType }[] = [
   { field: 'id', type: GraphQLJSON },

--- a/src/schema/query/recordsAggregation.ts
+++ b/src/schema/query/recordsAggregation.ts
@@ -9,13 +9,14 @@ import mongoose from 'mongoose';
 import { UserType } from '../types';
 import {
   defaultRecordFields,
-  selectableRecordFieldsFlat,
+  selectableDefaultRecordFieldsFlat,
 } from '../../const/defaultRecordFields';
 
+/**
+ * Takes an aggregation configuration as parameter.
+ * Returns aggregated records data.
+ */
 export default {
-  /* Take an aggregation configuration as parameter.
-        Returns aggregated records data.
-    */
   type: GraphQLJSON,
   args: {
     aggregation: { type: new GraphQLNonNull(GraphQLJSON) },
@@ -251,7 +252,7 @@ export default {
             });
           }
           pipeline.push({
-            $addFields: selectableRecordFieldsFlat.reduce(
+            $addFields: selectableDefaultRecordFieldsFlat.reduce(
               (fields, selectableField) => {
                 if (!selectableField.includes('By')) {
                   return Object.assign(fields, {
@@ -302,7 +303,7 @@ export default {
                 },
               },
               {
-                $addFields: selectableRecordFieldsFlat.reduce(
+                $addFields: selectableDefaultRecordFieldsFlat.reduce(
                   (fields, selectableField) => {
                     if (!selectableField.includes('By')) {
                       return Object.assign(fields, {
@@ -328,7 +329,7 @@ export default {
           ...(args.aggregation.sourceFields as any[]).reduce(
             (o, field) =>
               Object.assign(o, {
-                [field]: selectableRecordFieldsFlat.includes(field)
+                [field]: selectableDefaultRecordFieldsFlat.includes(field)
                   ? 1
                   : `$data.${field}`,
               }),

--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -25,12 +25,8 @@ export default (pipeline: any[], settings: any[], form: Form, context): any => {
   for (const stage of settings) {
     switch (stage.type) {
       case PipelineStage.FILTER: {
-        let filters = JSON.stringify(
-          getFilter(stage.form, form.fields, context)
-        );
-        filters = filters.split('data.').join('');
         pipeline.push({
-          $match: JSON.parse(filters),
+          $match: getFilter(stage.form, form.fields, context, ''),
         });
         break;
       }

--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -86,9 +86,18 @@ const buildPipeline = (
         break;
       }
       case PipelineStage.UNWIND: {
-        pipeline.push({
-          $unwind: `$${stage.form.field}`,
-        });
+        if (stage.form.field.includes('.')) {
+          const fieldArray: string[] = stage.form.field.split('.');
+          for (let i = 0; i < fieldArray.length; i++) {
+            pipeline.push({
+              $unwind: `$${fieldArray.slice(0, i + 1).join('.')}`,
+            });
+          }
+        } else {
+          pipeline.push({
+            $unwind: `$${stage.form.field}`,
+          });
+        }
         break;
       }
       case PipelineStage.CUSTOM: {

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -32,12 +32,18 @@ const DATE_TYPES: string[] = ['date', 'datetime', 'datetime-local'];
  * @param filter filter to transform to mongo filter.
  * @param fields list of structure fields
  * @param context request context
+ * @param prefix prefix to access field
  * @returns Mongo filter.
  */
-const buildMongoFilter = (filter: any, fields: any[], context: any): any => {
+const buildMongoFilter = (
+  filter: any,
+  fields: any[],
+  context: any,
+  prefix: string
+): any => {
   if (filter.filters) {
     const filters = filter.filters
-      .map((x: any) => buildMongoFilter(x, fields, context))
+      .map((x: any) => buildMongoFilter(x, fields, context, prefix))
       .filter((x) => x);
     if (filters.length > 0) {
       switch (filter.logic) {
@@ -64,7 +70,7 @@ const buildMongoFilter = (filter: any, fields: any[], context: any): any => {
       if (filter.operator) {
         const fieldName = FLAT_DEFAULT_FIELDS.includes(filter.field)
           ? filter.field
-          : `data.${filter.field}`;
+          : `${prefix}${filter.field}`;
         const type: string =
           fields.find((x) => x.name === filter.field)?.type || '';
         let value = filter.value;
@@ -264,9 +270,14 @@ const buildMongoFilter = (filter: any, fields: any[], context: any): any => {
   }
 };
 
-export default (filter: any, fields: any[], context?: any) => {
+export default (
+  filter: any,
+  fields: any[],
+  context?: any,
+  prefix = 'data.'
+) => {
   const expandedFields = fields.concat(DEFAULT_FIELDS);
   const mongooseFilter =
-    buildMongoFilter(filter, expandedFields, context) || {};
+    buildMongoFilter(filter, expandedFields, context, prefix) || {};
   return mongooseFilter;
 };

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -39,7 +39,7 @@ const buildMongoFilter = (
   filter: any,
   fields: any[],
   context: any,
-  prefix: string
+  prefix = ''
 ): any => {
   if (filter.filters) {
     const filters = filter.filters


### PR DESCRIPTION
# Description

Added the possibility to use OBJECT fields in the aggregation builder with only one step of nesting. Making the lookups before running the rest of the pipeline.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with a bunch of object fields: 
- CreatedBy
- LastUpdatedBy
- Resource field
- Resources field
- Related resource field

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
