### PR TITLE
AB#26822

### DIFF
--- a/src/server/pullJobScheduler.ts
+++ b/src/server/pullJobScheduler.ts
@@ -179,8 +179,11 @@ export const insertRecords = async (data: any[], pullJob: PullJob): Promise<void
         // Adapt also linkedFields if any
         const linkedFields = linkedFieldsArray[unicityIndex];
         if (linkedFields) {
+          // Storing already assigned fields in the case we have different fields mapped to the same path
+          const alreadyAssignedFields = [];
           for (const linkedField of linkedFields) {
-            const mappedField = Object.keys(pullJob.mapping).find(key => pullJob.mapping[key] === linkedField);
+            const mappedField = Object.keys(pullJob.mapping).find(key => pullJob.mapping[key] === linkedField && !alreadyAssignedFields.includes(key));
+            alreadyAssignedFields.push(mappedField);
             mappedElement[mappedField] = element[`__${linkedField}`];
           }
         }


### PR DESCRIPTION
# Description

There was a problem in a pullJob very specific case used by the signal App. If an identifier is an array and other fields are coming mapped from the same array, they are called linkedFields. If multiple form fields were mapped to the same linkedField, we would assign only the first one because the function to retrieve the mapped field name was supposing mapping paths are unique.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested it with a pullJob from EIOS to map to Informations with the same bug they had in PROD. Now fixed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
