### PR TITLE
Oort 208

### DIFF
--- a/.scripts/check-i18n.js
+++ b/.scripts/check-i18n.js
@@ -50,19 +50,38 @@ const setDefaultValue = (json, defaultValue) => {
   return newJson;
 };
 
+
+let listOfJson = [];
+let listOfFileNames = [];
+
+//Getting the name of all the files in the I18n folder except for 'test.json'
+listOfFileNames = fs.readdirSync(I18N_FOLDER_PATH);
+const indexTestJson = listOfFileNames.indexOf('test.json');
+if (indexTestJson > -1) {
+  listOfFileNames.splice(indexTestJson); 
+}
+
+//Putting all the JSONs in a list
+listOfJson = listOfFileNames.map(filename=>require('../'+I18N_FOLDER_PATH+filename));
+
+//Sort all the JSONs
+listOfJson = listOfJson.map(json=>sortJson(json));
+
 // Check that translation files are sorted.
-const sortedEnJson = sortJson(enJson);
-fs.writeFile(
-  I18N_FOLDER_PATH + 'en.json',
-  JSON.stringify(sortedEnJson, null, '\t'),
-  (err) => {
-    if (err) {
-      console.error(err);
-      return;
+for(let i in listOfJson){
+  fs.writeFile(
+    I18N_FOLDER_PATH + listOfFileNames[i],
+    JSON.stringify(listOfJson[i], null, '\t'),
+    (err) => {
+      if (err) {
+        console.error(err);
+        return;
+      }
+      // else success
     }
-    // else success
-  }
-);
+  );
+}
+
 
 // Update the i18n test file.
 const testJson = setDefaultValue(enJson, DEFAULT_VALUE);

--- a/.scripts/check-i18n.js
+++ b/.scripts/check-i18n.js
@@ -1,13 +1,23 @@
 const fs = require('fs');
+/** Translation files are stored there */
 const I18N_FOLDER_PATH = 'src/i18n/';
-const enJson = require('../'+I18N_FOLDER_PATH+'en.json');
 
+const DEFAULT_LANGUAGE = 'en';
+const TEST_LANGUAGE = 'test';
+
+/** Default language */
+const DEFAULT_I18N = require('../' +
+  I18N_FOLDER_PATH +
+  DEFAULT_LANGUAGE +
+  '.json');
 
 /** Default value that will be used as key in test translation file. */
 const DEFAULT_VALUE = ' ****** ';
 
-// Regex matching everything that is not between double brackets
-// Can be improved to match even values without brackets and leave the spaces before and after brackets
+/**
+ * Regex matching everything that is not between double brackets.
+ * Can be improved to match even values without brackets and leave the spaces before and after brackets.
+ */
 const REGEX_VALUE_VARIABLE = new RegExp(/([^{}]+(?={{))|((?<=}})[^{}]+)/, 'g');
 
 /**
@@ -30,7 +40,7 @@ const sortJson = (json) => {
 };
 
 /**
- * Writes in a new JSON default value for each key.
+ * Write in a new JSON default value for each key.
  *
  * @param {*} json json to copy
  * @param {*} defaultValue default placeholder value
@@ -51,87 +61,97 @@ const setDefaultValue = (json, defaultValue) => {
 };
 
 /**
- * Gets all keys (including nested) in JSON Object
+ * Update translation file
  *
- * @param {*} json json to inspect and extract the keys from
- * @param {*} ret_array array in which we will return the keys
- * @returns ret_array, containing all the keys
+ * @param {*} lang language
+ * @param {*} json json value
  */
- function getAllJsonKeys(json, ret_array = []) {
-  for (key in json) {
-      if (typeof(json[key]) === 'object') {
-          ret_array.push(key);
-          getAllJsonKeys(json[key], ret_array);
-      } else {
-          ret_array.push(key);
-      }
-  }
-  return ret_array
-}
-
-
-let listOfJson = [];
-let listOfFileNames = [];
-
-//Getting the name of all the files in the I18n folder except for 'test.json'
-listOfFileNames = fs.readdirSync(I18N_FOLDER_PATH);
-const indexTestJson = listOfFileNames.indexOf('test.json');
-if (indexTestJson > -1) {
-  listOfFileNames.splice(indexTestJson,1); 
-}
-
-//Putting all the JSONs in a list
-listOfJson = listOfFileNames.map(filename=>require('../'+I18N_FOLDER_PATH+filename));
-
-//Sort all the JSONs
-listOfJson = listOfJson.map(json=>sortJson(json));
-let enJsonSorted = sortJson(enJson);
-
-//Create a list of all the JSONs files except en.json
-let listOfJSONWithoutEn = JSON.parse(JSON.stringify(listOfJson));
-const indexEnJson = listOfFileNames.indexOf('en.json');
-if (indexEnJson > -1) {
-  listOfJSONWithoutEn.splice(indexEnJson,1); 
-}
-
-//Check that the "non-english" files have the same keys than en.json
-let allKeysEn = [];
-getAllJsonKeys(enJsonSorted,allKeysEn);
-listOfJSONWithoutEn.map(element=>{
-  let allKeys = [];
-  getAllJsonKeys(element,allKeys);
-  if(allKeys.toString() !== allKeysEn.toString()){
-    console.error('Error : One of the other languages does not contain exactly the same keys as en.json');
-    return;
-  }
-  // else success
-})
-
-// Check that translation files are sorted.
-for(let i in listOfJson){
-  fs.writeFile(
-    I18N_FOLDER_PATH + listOfFileNames[i],
-    JSON.stringify(listOfJson[i], null, '\t'),
+const updateFile = (lang, json) => {
+  fs.writeFileSync(
+    I18N_FOLDER_PATH + lang + '.json',
+    JSON.stringify(json, null, '\t'),
     (err) => {
       if (err) {
-        console.error(err);
-        return;
+        throw(err);
       }
       // else success
     }
   );
-}
+};
 
-// Update the i18n test file.
-const testJson = setDefaultValue(enJsonSorted, DEFAULT_VALUE);
-fs.writeFile(
-  I18N_FOLDER_PATH + 'test.json',
-  JSON.stringify(testJson, null, '\t'),
-  (err) => {
-    if (err) {
-      console.error(err);
-      return;
+/**
+ * Check the translation key in a JSON.
+ *
+ * @param {*} module module name
+ * @param {*} language language to test
+ * @param {*} json language json
+ * @param {*} baseLanguage language reference
+ * @param {*} baseJson language reference json
+ * @returns
+ */
+const checkTranslationKeys = (
+  language,
+  json,
+  baseLanguage,
+  baseJson,
+  prefix
+) => {
+  prefix = prefix || '';
+  for (const key of Object.keys(baseJson)) {
+    if (typeof baseJson[key] === 'string') {
+      if (!json[key] || typeof json[key] !== 'string') {
+        throw `Missing key: ${prefix + key} in ${language} translation.`;
+      }
+    } else {
+      if (!json[key] || typeof json[key] === 'string') {
+        throw `Incorrect key: ${prefix + key} in ${language} translation.`;
+      } else {
+        checkTranslationKeys(
+          language,
+          json[key],
+          baseLanguage,
+          baseJson[key],
+          prefix + key + '.'
+        );
+      }
     }
-    // else success
   }
-);
+};
+
+try {
+  // Build dictionnary from files
+  let filenames = fs.readdirSync(I18N_FOLDER_PATH);
+  let languages = filenames
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => name.split('.json')[0]);
+
+  let dictionnary = languages.map((lang) => ({
+    lang: lang,
+    value: require('../' + I18N_FOLDER_PATH + lang + '.json'),
+  }));
+
+  // Sort the files
+  dictionnary
+    .filter((x) => x.lang !== TEST_LANGUAGE)
+    .map((x) => {
+      x.value = sortJson(x.value);
+      updateFile(x.lang, x.value);
+    });
+
+  // Check the files content
+  dictionnary
+    .filter((x) => ![TEST_LANGUAGE, DEFAULT_LANGUAGE].includes(x.lang))
+    .forEach((x) =>
+      checkTranslationKeys(x.lang, x.value, DEFAULT_LANGUAGE, DEFAULT_I18N)
+    );
+
+  // Update the i18n test file.
+  const testJson = setDefaultValue(
+    dictionnary.find((x) => x.lang === DEFAULT_LANGUAGE).value,
+    DEFAULT_VALUE
+  );
+  updateFile(TEST_LANGUAGE, testJson);
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
# Description

This is the back-end adaptation of the modifications made to the check-i18n.js file in the front-end.

Because we added recently the possibility to translate the platform in French, the check-i18n.js file was not complete enough. So I added the sorting of all the language files, not only en.json.
We now also check that all the keys in all the language files are identical to those of the en.json (same keys in the same order because we already sorted them alphabetically).

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

The tests have been the same than in the front-end.

- [x] Run the script when the language files are already sorted and have the same keys => it works
- [x] Run the script when the language files are not sorted already but have the same keys => we can check that they are sorted - [x] with the script and that we have no error message when checking the correspondance of the keys
- [x] Run the script when the keys are not the same in en.json and fr.json => we have the right error message

# Checklist:

- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [x] My changes generate no new warnings
