### PR TITLE
Oort 187

### DIFF
--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -158,7 +158,7 @@ export const extractFields = async (object, fields, core): Promise<void> => {
             if (element.hasOther) {
               choices.push({
                 value: 'other',
-                text: 'Other',
+                text: element.otherText ? element.otherText : 'Other',
               });
             }
             Object.assign(field, {


### PR DESCRIPTION
# Description

Use the custom label defined by the user for the "other" option in drop-down fields in a form, instead of the hard-coded one "Other", to display in grid widget.
If no custom label is defined, it displays "Other".


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Create a form with a drop-down field, add an "other" option with a custom label, and create one record for the form. Then display the records of this form in a grid widget: the custom label should appear in the drop-down list, instead of the previous text "Other".

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
