### PR TITLE
AB#28021 Corect time field bug

### DIFF
--- a/src/utils/form/transformRecord.ts
+++ b/src/utils/form/transformRecord.ts
@@ -31,9 +31,13 @@ export const transformRecord = async (
             break;
           case 'time':
             if (record[value] != null && !(record[value] instanceof Date)) {
-              const hours = record[value].slice(0, 2);
-              const minutes = record[value].slice(3);
-              record[value] = new Date(Date.UTC(1970, 0, 1, hours, minutes));
+              if (record[value].match(/^\d\d:\d\d$/)) {
+                const hours = record[value].slice(0, 2);
+                const minutes = record[value].slice(3);
+                record[value] = new Date(Date.UTC(1970, 0, 1, hours, minutes));
+              } else {
+                record[value] = new Date(record[value]);
+              }
             }
             break;
           case 'file':


### PR DESCRIPTION
# Description
Correct the time field bug for ticket [AB#28021](https://dev.azure.com/WHOHQ/2888b816-2d79-49ef-a86e-561e6cd456a0/_workitems/edit/28021). This PR allows to take into account incomming times in ISO formats, for example a string like `"1970-01-01T14:05.00.000Z"` to represents `14:05`.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See [this PR on frontend](https://github.com/ReliefApplications/oort-frontend/pull/707)

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
