### PR TITLE
OORT-228 Fix issues with permissions

### DIFF
--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -130,7 +130,7 @@ export const getEntityResolver = (name: string, data, id: string, ids) => {
       if (ability.can('update', 'Record')) {
         return true;
       } else {
-        const form = await Form.findById(entity.form);
+        const form = await Form.findById(entity.form, 'permissions');
         const permissionFilters = getFormPermissionFilter(
           user,
           form,
@@ -152,7 +152,7 @@ export const getEntityResolver = (name: string, data, id: string, ids) => {
       if (ability.can('delete', 'Record')) {
         return true;
       } else {
-        const form = await Form.findById(entity.form);
+        const form = await Form.findById(entity.form, 'permissions');
         const permissionFilters = getFormPermissionFilter(
           user,
           form,

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -127,7 +127,7 @@ export const getEntityResolver = (name: string, data, id: string, ids) => {
     canUpdate: async (entity, args, context) => {
       const user = context.user;
       const ability: AppAbility = user.ability;
-      if (ability.can('update', entity)) {
+      if (ability.can('update', 'Record')) {
         return true;
       } else {
         const form = await Form.findById(entity.form);
@@ -149,7 +149,7 @@ export const getEntityResolver = (name: string, data, id: string, ids) => {
     canDelete: async (entity, args, context) => {
       const user = context.user;
       const ability: AppAbility = user.ability;
-      if (ability.can('delete', entity)) {
+      if (ability.can('delete', 'Record')) {
         return true;
       } else {
         const form = await Form.findById(entity.form);

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -39,18 +39,18 @@ const recordAggregation = (sortField: string, sortOrder: string): any => {
         from: 'users',
         localField: 'createdBy.user',
         foreignField: '_id',
-        as: 'createdBy.user',
+        as: '_createdBy.user',
       },
     },
     {
       $unwind: {
-        path: '$createdBy.user',
+        path: '$_createdBy.user',
         preserveNullAndEmptyArrays: true,
       },
     },
     {
       $addFields: {
-        'createdBy.user.id': { $toString: '$createdBy.user._id' },
+        '_createdBy.user.id': { $toString: '$_createdBy.user._id' },
         lastVersion: {
           $arrayElemAt: ['$versions', -1],
         },
@@ -69,26 +69,26 @@ const recordAggregation = (sortField: string, sortOrder: string): any => {
         from: 'users',
         localField: 'lastVersion.createdBy',
         foreignField: '_id',
-        as: 'lastUpdatedBy',
+        as: '_lastUpdatedBy',
       },
     },
     {
       $addFields: {
-        lastUpdatedBy: {
-          $arrayElemAt: ['$lastUpdatedBy', -1],
+        _lastUpdatedBy: {
+          $arrayElemAt: ['$_lastUpdatedBy', -1],
         },
       },
     },
     {
       $addFields: {
-        'lastUpdatedBy.user': {
-          $ifNull: ['$lastUpdatedBy', '$createdBy.user'],
+        '_lastUpdatedBy.user': {
+          $ifNull: ['$_lastUpdatedBy', '$_createdBy.user'],
         },
       },
     },
     {
       $addFields: {
-        'lastUpdatedBy.user.id': { $toString: '$lastUpdatedBy.user._id' },
+        '_lastUpdatedBy.user.id': { $toString: '$_lastUpdatedBy.user._id' },
         lastVersion: {
           $arrayElemAt: ['$versions', -1],
         },

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -43,7 +43,10 @@ const recordAggregation = (sortField: string, sortOrder: string): any => {
       },
     },
     {
-      $unwind: '$createdBy.user',
+      $unwind: {
+        path: '$createdBy.user',
+        preserveNullAndEmptyArrays: true,
+      },
     },
     {
       $addFields: {

--- a/src/utils/schema/resolvers/Query/getSortField.ts
+++ b/src/utils/schema/resolvers/Query/getSortField.ts
@@ -3,13 +3,13 @@ const defaultSortFields: { name: string; path: string }[] = [
   { name: 'incrementalId', path: 'incrementalId' },
   { name: 'createdAt', path: 'createdAt' },
   { name: 'modifiedAt', path: 'modifiedAt' },
-  { name: 'form', path: 'form.name' },
-  { name: 'createdBy.id', path: 'createdBy.user._id' },
-  { name: 'createdBy.name', path: 'createdBy.user.name' },
-  { name: 'createdBy.username', path: 'createdBy.user.username' },
-  { name: 'lastUpdatedBy.id', path: 'lastUpdatedBy.user._id' },
-  { name: 'lastUpdatedBy.name', path: 'lastUpdatedBy.user.name' },
-  { name: 'lastUpdatedBy.username', path: 'lastUpdatedBy.user.username' },
+  { name: 'form', path: '_form.name' },
+  { name: 'createdBy.id', path: '_createdBy.user._id' },
+  { name: 'createdBy.name', path: '_createdBy.user.name' },
+  { name: 'createdBy.username', path: '_createdBy.user.username' },
+  { name: 'lastUpdatedBy.id', path: '_lastUpdatedBy.user._id' },
+  { name: 'lastUpdatedBy.name', path: '_lastUpdatedBy.user.name' },
+  { name: 'lastUpdatedBy.username', path: '_lastUpdatedBy.user.username' },
 ];
 
 export default (sortField) => {

--- a/src/utils/schema/resolvers/Query/getUserFilter.ts
+++ b/src/utils/schema/resolvers/Query/getUserFilter.ts
@@ -48,7 +48,7 @@ const buildUserMongoFilter = (
           return;
         }
 
-        const fieldName = `${field}.user.${subField}`;
+        const fieldName = `_${field}.user.${subField}`;
         const value = filter.value;
         let intValue: number;
 


### PR DESCRIPTION
# Description

Fix issues:

- CanUpdate and CanDelete for admin when records permissions are set up -> We were using ability in the wrong way.
- Cannot see records with createdBy.user = null -> Added a parameter to the $unwind
- Cannot see records in resources table/grid widget when there are canSeeRecords permissions set up on createdBy.user -> Applied same fix as for the form (prefix looked up fields with an underscore)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Copied configuration from prefecture on local. Tested with Initial user role and Admin role if I was able to see everything as expected.

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
