### PR TITLE
AB#32931 Bypass the max recipients limitation

### DIFF
--- a/src/routes/email/index.ts
+++ b/src/routes/email/index.ts
@@ -147,31 +147,41 @@ router.post('/', async (req, res) => {
     });
   }
 
+  // Split the email in multiple emails with 50 recipients max per email
+  const MAX_RECIPIENTS = 50;
+  const recipientsList = [];
+  for (let i = 0; i < email.recipient.length; i += MAX_RECIPIENTS) {
+    const recipients = email.recipient.slice(
+      i,
+      Math.min(i + MAX_RECIPIENTS, email.recipient.length)
+    );
+    recipientsList.push(recipients);
+  }
+
   // Create reusable transporter object using the default SMTP transport
   const transporter = nodemailer.createTransport(TRANSPORT_OPTIONS);
 
-  // Send mail
+  // Send mails
   try {
-    const info = await transporter.sendMail({
-      from: EMAIL_FROM,
-      to: email.recipient,
-      subject: email.subject,
-      html: email.body,
-      attachments: email.attachments,
-      replyTo: EMAIL_REPLY_TO,
-    });
-    if (info.messageId) {
-      return res.status(200).send({ status: 'OK' });
-    } else {
-      return res
-        .status(400)
-        .send({ status: 'SMTP server failed to send the email' });
+    for (const recipients of recipientsList) {
+      const info = await transporter.sendMail({
+        from: EMAIL_FROM,
+        to: recipients,
+        subject: email.subject,
+        html: email.body,
+        attachments: email.attachments,
+        replyTo: EMAIL_REPLY_TO,
+      });
+      if (!info.messageId) {
+        throw new Error('Unexpected email sending response');
+      }
     }
+    return res.status(200).send({ status: 'OK' });
   } catch (err) {
     console.log(err);
     return res
       .status(400)
-      .send({ status: 'SMTP server failed to send the email' });
+      .send({ status: 'SMTP server failed to send the email', error: err });
   }
 });
 


### PR DESCRIPTION
# Description

Allow to send an email to more recipients than the maximum allowed by AWS, by splitting the recipient list in multiple lists and sending multiple emails.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

* Create a grid widget in a dashboard and add a button to send an email. 
* Add at least 50 emails in the recipient list (it is the maximum number allowed by AWS). It can be the same email, the backend does not eliminate duplicates (you can also create 50 different emails of course, or use email aliases with gmail for example - in my case, I use the last one).
* Try to send the mail. Check that you received it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
