### PR TITLE
OORT-268

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,76 +1,79 @@
 {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "plugins": [
-        "import",
-        "@typescript-eslint",
-        "prettier",
-        "jsdoc"
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["import", "@typescript-eslint", "prettier", "jsdoc"],
+  "parserOptions": {
+    "ecmaVersion": 11,
+    "sourceType": "module",
+    "project": "./tsconfig.json"
+  },
+  "extends": [
+    "airbnb-typescript/base",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:jsdoc/recommended",
+    "prettier"
+  ],
+  "rules": {
+    "prettier/prettier": 2,
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "quotes": [1, "single", { "avoidEscape": true }],
+    "eol-last": [1, "always"],
+    "@typescript-eslint/naming-convention": [
+      1,
+      {
+        "selector": "default",
+        "format": ["camelCase"]
+      },
+      {
+        "selector": ["variable"],
+        "modifiers": ["const"],
+        "format": ["camelCase", "UPPER_CASE"]
+      },
+      {
+        "selector": ["variable"],
+        "modifiers": ["const", "exported"],
+        "format": ["camelCase", "PascalCase"]
+      },
+      {
+        "selector": ["class", "interface", "typeAlias"],
+        "format": ["PascalCase"]
+      },
+      {
+        "selector": ["typeProperty", "parameter"],
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow"
+      },
+      {
+        "selector": ["objectLiteralProperty"],
+        "format": null
+      },
+      {
+        "selector": ["enumMember"],
+        "format": ["camelCase", "UPPER_CASE"]
+      }
     ],
-    "parserOptions": {
-        "ecmaVersion": 11,
-        "sourceType": "module",
-        "project": "./tsconfig.json"
-    },
-    "extends": [
-        "airbnb-typescript/base",
-        "plugin:@typescript-eslint/eslint-recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:jsdoc/recommended",
-        "prettier"
+    "jsdoc/require-jsdoc": [
+      1,
+      {
+        "exemptEmptyConstructors": false,
+        "contexts": [
+          "TSInterfaceDeclaration",
+          "TSEnumDeclaration",
+          "Program > VariableDeclaration[kind='const']",
+          "ExportNamedDeclaration > VariableDeclaration > VariableDeclarator > ArrowFunctionExpression"
+        ],
+        "require": {
+          "ClassDeclaration": true,
+          "FunctionDeclaration": true,
+          "MethodDefinition": true,
+          "ClassExpression": true
+        }
+      }
     ],
-    "rules": {
-        "prettier/prettier": 2,
-        "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off",
-        "quotes": [1, "single", { "avoidEscape": true }],
-        "eol-last": [1, "always"],
-        "@typescript-eslint/naming-convention": [
-            1,
-            {
-                "selector": "default",
-                "format": ["camelCase"]
-            },
-            {
-                "selector": ["variable"],
-                "modifiers": ["const"],
-                "format": ["camelCase", "UPPER_CASE"]
-            },
-            {
-                "selector": ["variable"],
-                "modifiers": ["const", "exported"],
-                "format": ["camelCase", "PascalCase"]
-            },
-            {
-                "selector": ["class", "interface", "typeAlias"],
-                "format": ["PascalCase"]
-            },
-            {
-                "selector": ["typeProperty", "parameter"],
-                "format": ["camelCase"],
-                "leadingUnderscore": "allow"
-            },
-            {
-                "selector": ["objectLiteralProperty"],
-                "format": null
-            },
-            {
-                "selector": ["enumMember"],
-                "format": ["camelCase", "UPPER_CASE"]
-              }
-        ],
-        "jsdoc/require-jsdoc":[
-            1,
-            {
-                "require": {
-                    "ClassDeclaration": true,
-                    "FunctionDeclaration": true,
-                    "MethodDefinition": true
-                }
-            }
-        ],
-        "jsdoc/require-param-type": 0,
-        "jsdoc/require-returns-type": 0,
-        "jsdoc/require-description": 1
-    }
+    "jsdoc/require-param-type": 0,
+    "jsdoc/require-returns-type": 0,
+    "jsdoc/require-property-type": 0
+  }
 }


### PR DESCRIPTION
# Description

This PR implements the enforcement of JSDocs in the frontend.

## Rules included
JSDocs are *required* for:
  - Classes
  - Constructors
  - Methods 
  - const (I figured you meant global constants only, if that's not the case, replace `Program > VariableDeclaration[kind='const']` for `VariableDeclaration[kind='const']` in the 14th line)
  - Enumerations
  - Interfaces

Besides that, all the [recomended rules](https://www.npmjs.com/package/eslint-plugin-jsdoc#user-content-eslint-plugin-jsdoc-configuration) are being used as well:
  - [newline-after-description](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/newline-after-description.md)
  - [check-access](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-access.md)
  - [check-alignment](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-alignment.md)
  - [check-tag-names](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-tag-names.md)
  - [empty-tags](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/empty-tags.md)
  - [implements-on-classes](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/implements-on-classes.md)
  - [check-types](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-types.md)
  - [check-values](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-values.md)
  - [no-undefined-types](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/no-undefined-types.md)
  - [tag-lines](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/tag-lines.md)
  - [valid-types](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/valid-types.md)
  - [multiline-blocks](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/multiline-blocks.md)
  - [no-multi-asterisks](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/no-multi-asterisks.md)
  - [require-param](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param.md)
  - [require-param-description](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param-description.md)
  - [require-param-name](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param-name.md)
  - [require-property](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property.md)
  - [require-property-description](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property-description.md)
  - [require-property-name](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property-name.md)
  - [require-returns](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns.md)
  - [require-returns-check](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns-check.md)
  - [require-returns-description](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns-description.md)
  - [require-yields](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-yields.md)
  - [require-yields-check](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-yields-check.md)

With the expection of the following, which I mannualy disabled since were already using typescript by deafult
  - [require-param-type](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param-type.md)
  - [require-property-type](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property-type.md)
  - [require-returns-type](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-yields.md)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

By running `npm run lint` and looking through some of thw warnings that were raised

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
