### PR TITLE
OORT-259 Create multiple series in charts

### DIFF
--- a/src/schema/query/recordsAggregation.ts
+++ b/src/schema/query/recordsAggregation.ts
@@ -346,10 +346,18 @@ export default {
     // Build mapping step
     if (args.withMapping) {
       if (args.aggregation.mapping) {
+        // use "category" and "value" by default, but fallback
+        // to xAxis and yAxis for retro-compatibility
         pipeline.push({
           $project: {
-            category: `$${args.aggregation.mapping.xAxis}`,
-            field: `$${args.aggregation.mapping.yAxis}`,
+            category: `$${
+              args.aggregation.mapping.category ||
+              args.aggregation.mapping.xAxis
+            }`,
+            value: `$${
+              args.aggregation.mapping.value || args.aggregation.mapping.yAxis
+            }`,
+            seriesItem: `$${args.aggregation.mapping.seriesItem}`,
             id: '$_id',
           },
         });

--- a/src/schema/query/recordsAggregation.ts
+++ b/src/schema/query/recordsAggregation.ts
@@ -357,7 +357,7 @@ export default {
             value: `$${
               args.aggregation.mapping.value || args.aggregation.mapping.yAxis
             }`,
-            seriesItem: `$${args.aggregation.mapping.seriesItem}`,
+            seriesItem: `$${args.aggregation.mapping.seriesItem || undefined}`,
             id: '$_id',
           },
         });

--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -57,9 +57,15 @@ const buildPipeline = (
         break;
       }
       case PipelineStage.GROUP: {
+        const ids = { category: { $toString: `$${stage.form.groupBy}` } };
+        if (stage.form.groupBySeries) {
+          Object.assign(ids, {
+            seriesItem: { $toString: `$${stage.form.groupBySeries}` },
+          });
+        }
         pipeline.push({
           $group: {
-            _id: { $toString: `$${stage.form.groupBy}` },
+            _id: ids,
             ...addFields(stage.form.addFields),
           },
         });


### PR DESCRIPTION
# Description

Allow to create multiple series in bar, column and line charts. 

Change names of `xAxis` and `yAxis` to `category` and `value` so as to be correct for all charts (previous names were incorrect for pie, donut and bar charts).

Take into account the new `seriesItem` field (with an `undefined` value by default to prevent the case where `seriesItem` is equal to `""` and throw an error).

Add the possibility to create GROUP stages in pipeline for aggregation with 2 fields for the id of the group by operation.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

*(see the PR on the frontend repo for breaking changes)*

# How Has This Been Tested?

*(see the PR on the frontend repo)*

## Sreenshots

*(see the PR on the frontend repo)*

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
