### PR TITLE
AB#33768

### DIFF
--- a/src/schema/mutation/editRecord.ts
+++ b/src/schema/mutation/editRecord.ts
@@ -46,7 +46,7 @@ export default {
       });
       if (!args.version) {
         let template: Form | Resource;
-        if (args.template) {
+        if (args.template && parentForm.resource) {
           template = await Form.findById(args.template, 'fields resource');
           if (!template.resource.equals(parentForm.resource)) {
             throw new GraphQLError(errors.wrongTemplateProvided);

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -61,15 +61,17 @@ export const getEntityResolver = (name: string, data, id: string, ids) => {
       Object.assign({}, resolvers, {
         [fieldName]: (entity, args, context) => {
           const field = fields[fieldName];
-          const value = relationshipFields.includes(fieldName) ?
+          let value = relationshipFields.includes(fieldName) ?
             entity.data[fieldName.substr(0, fieldName.length - (fieldName.endsWith('_id') ? 3 : 4))] :
             entity.data[fieldName];
-          if (context.display && (args.display === undefined || args.display)) {
-            const formField = data[name].find(x => x.name === fieldName);
-            if (formField && (formField.choices || formField.choicesByUrl)) {
+          const formField = data[name].find(x => x.name === fieldName);
+          if (formField && (formField.choices || formField.choicesByUrl)) {
+            value = [...new Set(value)];
+            if (context.display && (args.display === undefined || args.display)) {
               return getDisplayText(formField, value, context);
             }
           }
+
           return field.type === 'String' ? value.toString() : value;
         },
       }),

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -64,14 +64,16 @@ export const getEntityResolver = (name: string, data, id: string, ids) => {
           let value = relationshipFields.includes(fieldName) ?
             entity.data[fieldName.substr(0, fieldName.length - (fieldName.endsWith('_id') ? 3 : 4))] :
             entity.data[fieldName];
-          const formField = data[name].find(x => x.name === fieldName);
-          if (formField && (formField.choices || formField.choicesByUrl)) {
+          // Removes duplicated values
+          if (Array.isArray(value)) {
             value = [...new Set(value)];
-            if (context.display && (args.display === undefined || args.display)) {
+          }
+          if (context.display && (args.display === undefined || args.display)) {
+            const formField = data[name].find(x => x.name === fieldName);
+            if (formField && (formField.choices || formField.choicesByUrl)) {
               return getDisplayText(formField, value, context);
             }
           }
-
           return field.type === 'String' ? value.toString() : value;
         },
       }),


### PR DESCRIPTION
# Description

This PR implements a check on `classicResolvers` for duplicate values on the choices array, if present, and removes the duplicates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually added a duplicate choice to a question record and fetched it in a grid view. The result from the query did, in fact, contain no duplicate entries. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
