### PR TITLE
OORT-290 Improve Record History

### DIFF
--- a/src/models/history.ts
+++ b/src/models/history.ts
@@ -1,3 +1,5 @@
+import { Version } from './version';
+
 export type Change = {
   type: 'add' | 'remove' | 'modify';
   displayType: string;
@@ -8,9 +10,10 @@ export type Change = {
 };
 
 export type RecordHistory = {
-  created: Date;
+  createdAt: Date;
   createdBy: string;
   changes: Change[];
+  version?: Version;
 }[];
 
 export type RecordHistoryMeta = {

--- a/src/routes/download/index.ts
+++ b/src/routes/download/index.ts
@@ -161,7 +161,7 @@ router.get('/form/records/:id/history', async (req, res) => {
         let isInDateRange = true;
 
         // filtering by date
-        const date = new Date(version.created);
+        const date = new Date(version.createdAt);
         if (filters.fromDate && filters.fromDate > date) isInDateRange = false;
         if (filters.toDate && filters.toDate < date) isInDateRange = false;
 

--- a/src/routes/download/index.ts
+++ b/src/routes/download/index.ts
@@ -157,21 +157,30 @@ router.get('/form/records/:id/history', async (req, res) => {
           ability,
         }
       ).getHistory();
-      const history = unfilteredHistory.filter((version) => {
-        let isInDateRange = true;
+      const history = unfilteredHistory
+        .filter((version) => {
+          let isInDateRange = true;
 
-        // filtering by date
-        const date = new Date(version.createdAt);
-        if (filters.fromDate && filters.fromDate > date) isInDateRange = false;
-        if (filters.toDate && filters.toDate < date) isInDateRange = false;
+          // filtering by date
+          const date = new Date(version.createdAt);
+          if (filters.fromDate && filters.fromDate > date)
+            isInDateRange = false;
+          if (filters.toDate && filters.toDate < date) isInDateRange = false;
 
-        // filtering by field
-        const changesField =
-          !filters.field ||
-          !!version.changes.find((item) => item.field === filters.field);
+          // filtering by field
+          const changesField =
+            !filters.field ||
+            !!version.changes.find((item) => item.field === filters.field);
 
-        return isInDateRange && changesField;
-      });
+          return isInDateRange && changesField;
+        })
+        .map((version) => {
+          // filter by field for each verison
+          version.changes = version.changes.filter(
+            (change) => change.field === filters.field
+          );
+          return version;
+        });
 
       const type: 'csv' | 'xlsx' =
         req.query.type.toString() === 'csv' ? 'csv' : 'xlsx';

--- a/src/schema/types/historyVersion.ts
+++ b/src/schema/types/historyVersion.ts
@@ -1,5 +1,6 @@
 import { GraphQLObjectType, GraphQLString, GraphQLList } from 'graphql';
 import { GraphQLDateTime } from 'graphql-iso-date';
+import { VersionType } from './version';
 
 /**
  * GraphQL Object Type of Single history change.
@@ -22,8 +23,9 @@ const changeType = new GraphQLObjectType({
 export const HistoryVersionType = new GraphQLObjectType({
   name: 'HistoryVersion',
   fields: () => ({
-    created: { type: GraphQLDateTime },
+    createdAt: { type: GraphQLDateTime },
     createdBy: { type: GraphQLString },
     changes: { type: GraphQLList(changeType) },
+    version: { type: VersionType },
   }),
 });

--- a/src/utils/files/historyBuilder.ts
+++ b/src/utils/files/historyBuilder.ts
@@ -119,8 +119,8 @@ const historyBuilder = async (
   history.forEach((version) => {
     let firstChange = true;
     for (const change of version.changes) {
-      const date = version.created.toLocaleDateString(options.dateLocale);
-      const time = version.created.toLocaleTimeString(options.dateLocale);
+      const date = version.createdAt.toLocaleDateString(options.dateLocale);
+      const time = version.createdAt.toLocaleTimeString(options.dateLocale);
       if (changeValueIsObject(change)) {
         const keys = Object.keys(change.new) || Object.keys(change.old);
         for (const key of keys) {

--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -315,7 +315,7 @@ export class RecordHistory {
     if (versions.length === 0) {
       difference = this.getDifference(null, this.record.data);
       res.push({
-        created: this.record.createdAt,
+        createdAt: this.record.createdAt,
         createdBy: this.record.createdBy?.user?.name,
         changes: difference,
       });
@@ -324,17 +324,19 @@ export class RecordHistory {
 
     difference = this.getDifference(null, versions[0].data);
     res.push({
-      created: versions[0].createdAt,
+      createdAt: versions[0].createdAt,
       createdBy: this.record.createdBy?.user?.name,
       changes: difference,
+      version: versions[0],
     });
 
     for (let i = 1; i < versions.length; i++) {
       difference = this.getDifference(versions[i - 1].data, versions[i].data);
       res.push({
-        created: versions[i].createdAt,
+        createdAt: versions[i].createdAt,
         createdBy: versions[i - 1].createdBy?.name,
         changes: difference,
+        version: versions[i],
       });
     }
     difference = this.getDifference(
@@ -342,7 +344,7 @@ export class RecordHistory {
       this.record.data
     );
     res.push({
-      created: this.record.modifiedAt,
+      createdAt: this.record.modifiedAt,
       createdBy: versions[versions.length - 1].createdBy?.name,
       changes: difference,
     });


### PR DESCRIPTION
# Description

Improve the record history:
* Filter only changes related to a field when we download record versions with a selected filtering field
* Rename on the RecordHistory type the property `created` to `createdAt` so as to match the pattern of `Version` object for revert operation
* Add for the RecordHistory schema the `version` object with which it is related to, so as to be able to show the revert preview

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Open the history of a record, filter by a field, and download the file. The changes on other field made within the same version should not be present in the file.
Try to open the revert preview on a record history version and to revert it. It should work (with the corresponding PR for the front-end)

## Sreenshots
Before:
![image](https://user-images.githubusercontent.com/103410601/172804280-df060aa4-60b3-4ff2-8401-7c8e89be2d80.png)
After:
![image](https://user-images.githubusercontent.com/103410601/172804329-32774152-07fe-4d2d-b44e-da1abb8cead4.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have included screenshots describing my changes if relevant
