### PR TITLE
Oort 310 - Deprecated remove() function in mongoose

### DIFF
--- a/src/schema/mutation/deleteForm.ts
+++ b/src/schema/mutation/deleteForm.ts
@@ -71,8 +71,8 @@ export default {
       }
       return Form.findByIdAndRemove(args.id, null, () => {
         // Also deletes the records associated to that form.
-        Record.remove({ form: args.id }).exec();
-        Record.remove({ resource: form.resource }).exec();
+        Record.deleteOne({ form: args.id }).exec();
+        Record.deleteOne({ resource: form.resource }).exec();
         buildTypes();
       });
     } else {


### PR DESCRIPTION
# Description

The mongoose Model.remove() is depreciated, it is now replaced in the correct places of the backend.

In the ticket it was suggested to replace the remove() function in the deletion of layouts but actually this remove() function is not the mongoose deprecated function since the layouts object is not a real MongoDB document, it is only part of the Resource document.

![image](https://user-images.githubusercontent.com/103029022/174569284-99d45e9a-7934-4383-bc30-4e1052061599.png)

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Tested by removing forms from the platform

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings