### PR TITLE
AB#36028 Pagination bugs

### DIFF
--- a/src/schema/query/applications.ts
+++ b/src/schema/query/applications.ts
@@ -67,6 +67,7 @@ export default {
     if (!user) {
       throw new GraphQLError(errors.userNotLogged);
     }
+
     const ability: AppAbility = context.user.ability;
 
     const abilityFilters = Application.accessibleBy(
@@ -75,9 +76,9 @@ export default {
     ).getFilter();
     const queryFilters = getFilter(args.filter, FILTER_FIELDS);
     const filters: any[] = [queryFilters, abilityFilters];
+
     const sortField =
       SORT_FIELDS.find((x) => x.name === args.sortField) || DEFAULT_SORT_FIELD;
-
     const first = args.first || DEFAULT_FIRST;
     const cmpOperator = args.sortOrder === 'desc' ? '$lt' : '$gt';
     const cursorFilters = args.afterCursor

--- a/src/schema/query/applications.ts
+++ b/src/schema/query/applications.ts
@@ -1,19 +1,16 @@
-import { GraphQLError, GraphQLInt, GraphQLID } from 'graphql';
-import {
-  ApplicationConnectionType,
-  encodeCursor,
-  decodeCursor,
-} from '../types';
+import { GraphQLError, GraphQLInt, GraphQLString } from 'graphql';
+import GraphQLJSON from 'graphql-type-json';
+import { ApplicationConnectionType } from '../types';
 import { Application } from '../../models';
 import errors from '../../const/errors';
 import { AppAbility } from '../../security/defineAbilityFor';
-import GraphQLJSON from 'graphql-type-json';
 import getFilter from '../../utils/filter/getFilter';
+import { parseJSON } from '../../utils/schema';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
 
-/** Default filter fields */
+/** Available filter fields */
 const FILTER_FIELDS: { name: string; type: string }[] = [
   {
     name: 'status',
@@ -29,6 +26,29 @@ const FILTER_FIELDS: { name: string; type: string }[] = [
   },
 ];
 
+/** Available sort fields */
+const SORT_FIELDS: { name: string; type: string }[] = [
+  {
+    name: '_id',
+    type: 'text',
+  },
+  {
+    name: 'name',
+    type: 'text',
+  },
+  {
+    name: 'createdAt',
+    type: 'date',
+  },
+  {
+    name: 'modifiedAt',
+    type: 'date',
+  },
+];
+
+/** Default sort field */
+const DEFAULT_SORT_FIELD = SORT_FIELDS.find((x) => x.name === 'createdAt');
+
 export default {
   /*  List all applications available for the logged user.
         Throw GraphQL error if not logged.
@@ -36,8 +56,10 @@ export default {
   type: ApplicationConnectionType,
   args: {
     first: { type: GraphQLInt },
-    afterCursor: { type: GraphQLID },
+    afterCursor: { type: GraphQLJSON },
     filter: { type: GraphQLJSON },
+    sortField: { type: GraphQLString },
+    sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
     // Authentication check
@@ -53,27 +75,31 @@ export default {
     ).getFilter();
     const queryFilters = getFilter(args.filter, FILTER_FIELDS);
     const filters: any[] = [queryFilters, abilityFilters];
+    const sortField =
+      SORT_FIELDS.find((x) => x.name === args.sortField) || DEFAULT_SORT_FIELD;
 
     const first = args.first || DEFAULT_FIRST;
-    const afterCursor = args.afterCursor;
-    const cursorFilters = afterCursor
+    const cmpOperator = args.sortOrder === 'desc' ? '$lt' : '$gt';
+    const cursorFilters = args.afterCursor
       ? {
-          _id: {
-            $gt: decodeCursor(afterCursor),
+          [sortField.name]: {
+            [cmpOperator]: parseJSON(args.afterCursor, sortField.type),
           },
         }
       : {};
 
-    let items: any[] = await Application.find({
+    let items: Application[] = await Application.find({
       $and: [cursorFilters, ...filters],
-    }).limit(first + 1);
+    })
+      .sort({ [sortField.name]: args.sortOrder || 'asc' })
+      .limit(first + 1);
 
     const hasNextPage = items.length > first;
     if (hasNextPage) {
       items = items.slice(0, items.length - 1);
     }
     const edges = items.map((r) => ({
-      cursor: encodeCursor(r.id.toString()),
+      cursor: JSON.stringify(r[sortField.name]),
       node: r,
     }));
     return {

--- a/src/utils/schema/index.ts
+++ b/src/utils/schema/index.ts
@@ -1,2 +1,3 @@
 export * from './buildSchema';
 export * from './buildTypes';
+export * from './parseJSON';

--- a/src/utils/schema/parseJSON.ts
+++ b/src/utils/schema/parseJSON.ts
@@ -1,0 +1,17 @@
+/** List of available date and time types */
+const DATETIME_TYPES = ['Date', 'Datetime', 'Time', 'date', 'datetime', 'time'];
+
+/**
+ * Parse a JSON value to it type, including Date
+ *
+ * @param value The value as JSON to parse
+ * @param type The wanted type
+ * @returns The parsed value
+ */
+export const parseJSON = (value: string, type: string): any => {
+  const parsedValue = JSON.parse(value);
+  if (DATETIME_TYPES.includes(type)) {
+    return new Date(parsedValue);
+  }
+  return parsedValue;
+};


### PR DESCRIPTION
# Description

Correct a bug with pagination when documents are copy and paste from another database.

**Source of the bug:**
* The documents were not sorted by anything before applying the cursor filter

**Solution:**
* Sort the documents according to a field, and change the cursor to be the value of the sorted field (and not necessary the id)
* Add a possibility to choose the sorting field as an argument, and fix the default field to `createdAt`

**Warnings:**
* As requested, this fix is only made for `applications` and `forms`. Nevertheless, the same problem exists for all the documents types which use cursors (apiConfiguration, notifications, pullJobs, resources, ...)
* This fix, as a side effect, implements the ability to sort documents in requests. This feature was not available on 1.2.0, but is implemented on 1.3.0. I tried to use the same naming conventions, so that this fix can be adapted for the 1.3.0 by keeping exactly the same code as the 1.2.0 for the query functions.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Import applications and forms from another database, and try to display the list without errors.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
