### PR TITLE
AB#36494

### DIFF
--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -386,12 +386,12 @@ export class RecordHistory {
       return array.find((c) => c.name === name).title;
     };
 
-    const getResourcesIncrementalID = async (ids: string[]) => {
+    const getResourcesLabel = async (ids: string[], displayField: string) => {
       const recordFilters = Record.accessibleBy(this.options.ability, 'read')
         .where({ _id: { $in: ids }, archived: { $ne: true } })
         .getFilter();
       const records: Record[] = await Record.find(recordFilters);
-      return records.map((record) => record.incrementalId);
+      return records.map((record) => record.data[displayField] || '');
     };
 
     const getUsersFromID = async (ids: string[]) => {
@@ -550,9 +550,15 @@ export class RecordHistory {
           // no break for the resources
           case 'resources':
             if (change.old !== undefined)
-              change.old = await getResourcesIncrementalID(change.old);
+              change.old = await getResourcesLabel(
+                change.old,
+                field.displayField
+              );
             if (change.new !== undefined)
-              change.new = await getResourcesIncrementalID(change.new);
+              change.new = await getResourcesLabel(
+                change.new,
+                field.displayField
+              );
             break;
           case 'users':
             if (change.old !== undefined)


### PR DESCRIPTION
# Description

This PR changes the RecordHistory format fields function so it gets the specified display field instead of the record's incrementalID for the history view/download. As for the other types of custom questions, if I didn't misundertand this ticket, were already addressed by me in [AB#27480](https://github.com/ReliefApplications/oort-backend/pull/315) 

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

By setting a display field for the custom question (resource or resources) and checking/downloading the history for a record in that form. It should now display the value for the selected field instead of the incrementalID of the record

## Sreenshots

![image](https://user-images.githubusercontent.com/102038450/176262543-3ba9f646-1de6-469b-a5f6-be9a2edb2703.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
