### PR TITLE
AB#36495

### DIFF
--- a/src/utils/files/historyBuilder.ts
+++ b/src/utils/files/historyBuilder.ts
@@ -155,9 +155,11 @@ const historyBuilder = async (
   });
   worksheet.addRows(changeRows);
   whiteText.forEach((row) => {
-    ['A', 'B', 'C'].forEach((col) => {
-      worksheet.getCell(`${col}${row}`).font = headerStyles.font;
-    });
+    if (row > 0) {
+      ['A', 'B', 'C'].forEach((col) => {
+        worksheet.getCell(`${col}${row}`).font = headerStyles.font;
+      });
+    }
   });
 
   // write to a new buffer


### PR DESCRIPTION
# Description

Fixed a bug where some of the history export data was being formatted white.

The happening when the `whiteText` variable had negative values, the solution was to check if the values where positive before formatting the data to white.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] The history has been downloaded various times with different filters.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
