### PR TITLE
AB#35867

### DIFF
--- a/src/setup/migrateStandaloneForms.ts
+++ b/src/setup/migrateStandaloneForms.ts
@@ -1,0 +1,112 @@
+import mongoose from 'mongoose';
+import * as dotenv from 'dotenv';
+import { Form, Resource, Record } from '../models';
+dotenv.config();
+
+/** Migrate standalone forms to resource linked ones */
+const migrateForms = async () => {
+  // getting forms not linked to resources
+  const standaloneForms = await Form.find({ resource: { $exists: false } });
+
+  // gets conflicting resource by name
+  const conflictingResources = (
+    await Resource.find({
+      name: { $in: standaloneForms.map((x) => x.name) },
+    })
+  ).map((x) => x.name);
+
+  // deals with name conflicts
+  const forms = standaloneForms.filter((f) => {
+    if (conflictingResources.includes(f.name)) {
+      console.error(
+        `Error migrating form ${f.name}: Resource with same name already exists`
+      );
+      return false;
+    }
+    return true;
+  });
+
+  if (forms.length === 0) {
+    console.log('No forms to migrate');
+    return;
+  }
+
+  // creates new resources from the filtered forms
+  const newResources = forms.map(
+    (form) =>
+      new Resource({
+        name: form.name,
+        fields: form.fields,
+        permissions: {
+          canSee: form.permissions.canSee,
+          canUpdate: form.permissions.canUpdate,
+          canDelete: form.permissions.canDelete,
+        },
+        layouts: form.layouts,
+      })
+  );
+
+  const resources = await Resource.insertMany(newResources);
+  console.log(
+    `\nCreated resources: ${resources.map((x) => x.name).join(', ')}`
+  );
+
+  // add resource id to forms and all its records
+  for (const form of forms) {
+    const resourceID = resources.find((r) => r.name === form.name)._id;
+
+    await Form.updateOne(
+      { _id: form._id },
+      {
+        $set: {
+          resource: resourceID,
+          layouts: [],
+          core: true,
+        },
+      }
+    );
+    console.log(`\nLinked resource in ${form.name} form and removed layouts`);
+    await Record.updateMany({ form: form._id }, { resource: resourceID });
+    console.log(`Linked resource in all of ${form.name} form's records`);
+  }
+
+  console.log('\nMigration complete');
+};
+
+/**
+ * Initialize the database
+ */
+// eslint-disable-next-line no-undef
+if (process.env.COSMOS_DB_PREFIX) {
+  mongoose.connect(
+    `${process.env.COSMOS_DB_PREFIX}://${process.env.COSMOS_DB_USER}:${process.env.COSMOS_DB_PASS}@${process.env.COSMOS_DB_HOST}:${process.env.COSMOS_DB_PORT}/?ssl=true&retrywrites=false&maxIdleTimeMS=120000&appName=@${process.env.COSMOS_APP_NAME}@`,
+    {
+      useCreateIndex: true,
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      autoIndex: true,
+    }
+  );
+} else {
+  if (process.env.DB_PREFIX === 'mongodb+srv') {
+    mongoose.connect(
+      `${process.env.DB_PREFIX}://${process.env.DB_USER}:${process.env.DB_PASS}@${process.env.DB_HOST}/${process.env.DB_NAME}?retryWrites=true&w=majority`,
+      {
+        useCreateIndex: true,
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+        autoIndex: true,
+      }
+    );
+  } else {
+    mongoose.connect(
+      `${process.env.DB_PREFIX}://${process.env.DB_USER}:${process.env.DB_PASS}@${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}?ssl=true&replicaSet=globaldb&retrywrites=false&maxIdleTimeMS=120000&appName=@${process.env.APP_NAME}@`
+    );
+  }
+}
+mongoose.connection.once('open', async () => {
+  await migrateForms();
+  mongoose.connection.close(() => {
+    console.log('connection closed');
+  });
+});


### PR DESCRIPTION
# Description

This PR adds a script that makes the migration of forms that aren't linked to any resource to a core form.

**PROBLEM**: Grids created using the forms were broken after the migration. The layouts are no longer available, and I think the issue is coming from the GetCustomSourceQuery, that is returning the id of the form instead of the resource (and I moved the layouts from the form document to the resources).

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

By running the script locally. As expected, a resource was created for each of the forms that hadn't one, their ID were added to the form document and every record of that form.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
