### PR TITLE
OORT-387

### DIFF
--- a/src/schema/mutation/editForm.ts
+++ b/src/schema/mutation/editForm.ts
@@ -356,7 +356,9 @@ export default {
           for (const field of deletedFields) {
             // We remove the field from the resource
             const index = oldFields.findIndex((x) => x.name === field.name);
-            oldFields.splice(index, 1);
+            if (index >= 0) {
+              oldFields.splice(index, 1);
+            }
           }
         }
 


### PR DESCRIPTION
# Description

Correct a bug on fields deletion on form: when we delete a field, all the fields after that field were also deleted in the corresponding resource structure.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a form with some fields, select them all in the query tab of a widget, then delete one of the fields (not the last one). Before, the removed field and all the following ones were displayed as broken in the query tab of the widgets because they did not exist in the resource anymore, now it is the case for only the removed one.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
