### PR TITLE
OORT-388

### DIFF
--- a/src/schema/mutation/editForm.ts
+++ b/src/schema/mutation/editForm.ts
@@ -356,7 +356,7 @@ export default {
           for (const field of deletedFields) {
             // We remove the field from the resource
             const index = oldFields.findIndex((x) => x.name === field.name);
-            oldFields.splice(index, 1);
+            if (index >= 0) oldFields.splice(index, 1);
           }
         }
 


### PR DESCRIPTION
# Description

The bug was happening because of how the slice function works, if the index was -1 (that would happen if there were no field match) it'd remove the last element of the array.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

* Create a form with a question
* Edit that form by removing that question and creating another one (at once)
* The form and resource will be updated properly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
