### PR TITLE
AB#37525

### DIFF
--- a/src/schema/mutation/editStep.ts
+++ b/src/schema/mutation/editStep.ts
@@ -1,3 +1,4 @@
+import mongoose from 'mongoose';
 import {
   GraphQLNonNull,
   GraphQLID,
@@ -10,6 +11,22 @@ import { StepType } from '../types';
 import { Dashboard, Form, Step, Workflow } from '../../models';
 import { AppAbility } from '../../security/defineAbilityFor';
 import { canAccessContent } from '../../security/accessFromApplicationPermissions';
+import { isArray } from 'lodash';
+
+/** Simple form permission change type */
+type SimplePermissionChange =
+  | {
+      add?: string[];
+      remove?: string[];
+    }
+  | string[];
+
+/** Type for the permission argument */
+type PermissionChange = {
+  canSee?: SimplePermissionChange;
+  canUpdate?: SimplePermissionChange;
+  canDelete?: SimplePermissionChange;
+};
 
 export default {
   /*  Finds a step from its id and update it, if user is authorized.
@@ -60,13 +77,54 @@ export default {
       update,
       args.name && { name: args.name },
       args.type && { type: args.type },
-      args.content && { content: args.content },
-      args.permissions && { permissions: args.permissions }
+      args.content && { content: args.content }
     );
+
+    const permissionsUpdate: any = {};
+    // Updating permissions
+    if (args.permissions) {
+      const permissions: PermissionChange = args.permissions;
+      for (const permission in permissions) {
+        if (isArray(permissions[permission])) {
+          // if it's an array, replace the old value with the provided list
+          permissionsUpdate['permissions.' + permission] =
+            permissions[permission];
+        } else {
+          const obj = permissions[permission];
+          if (obj.add && obj.add.length) {
+            const pushRoles = {
+              [`permissions.${permission}`]: { $each: obj.add },
+            };
+
+            if (permissionsUpdate.$push)
+              Object.assign(permissionsUpdate.$push, pushRoles);
+            else Object.assign(permissionsUpdate, { $push: pushRoles });
+          }
+          if (obj.remove && obj.remove.length) {
+            const pullRoles = {
+              [`permissions.${permission}`]: {
+                $in: obj.remove.map(
+                  (role: any) => new mongoose.Types.ObjectId(role)
+                ),
+              },
+            };
+
+            if (permissionsUpdate.$pull)
+              Object.assign(permissionsUpdate.$pull, pullRoles);
+            else Object.assign(permissionsUpdate, { $pull: pullRoles });
+          }
+        }
+      }
+    }
+
     const filters = Step.accessibleBy(ability, 'update')
       .where({ _id: args.id })
       .getFilter();
-    let step = await Step.findOneAndUpdate(filters, update, { new: true });
+    let step = await Step.findOneAndUpdate(
+      filters,
+      { ...update, ...permissionsUpdate },
+      { new: true }
+    );
     if (!step) {
       const workflow = await Workflow.findOne({ steps: args.id }, 'id');
       if (!workflow)

--- a/src/schema/mutation/editStep.ts
+++ b/src/schema/mutation/editStep.ts
@@ -28,10 +28,11 @@ type PermissionChange = {
   canDelete?: SimplePermissionChange;
 };
 
+/**
+ * Find a step from its id and update it, if user is authorized.
+ * Throw an error if not logged or authorized, or arguments are invalid.
+ */
 export default {
-  /*  Finds a step from its id and update it, if user is authorized.
-        Throws an error if not logged or authorized, or arguments are invalid.
-    */
   type: StepType,
   args: {
     id: { type: new GraphQLNonNull(GraphQLID) },

--- a/src/schema/mutation/editUser.ts
+++ b/src/schema/mutation/editUser.ts
@@ -5,10 +5,11 @@ import { AppAbility } from '../../security/defineAbilityFor';
 import { UserType } from '../types';
 import { PositionAttributeInputType } from '../inputs';
 
+/**
+ * Edits an user's roles, providing its id and the list of roles.
+ * Throws an error if not logged or authorized.
+ */
 export default {
-  /*  Edits an user's roles, providing its id and the list of roles.
-        Throws an error if not logged or authorized.
-    */
   type: UserType,
   args: {
     id: { type: new GraphQLNonNull(GraphQLID) },


### PR DESCRIPTION
# Description

This PR changes the editPage, editStep, editResource and editForm mutations so they can now receive only the roles to be changed through arguments, instead of a list with all of the roles. 

```
/** Simple form permission change type */
type SimplePermissionChange =
  | {
      add?: string[];
      remove?: string[];
    }
  | string[];

/** Access form permission change type */
type AccessPermissionChange =
  | {
      add?: { role: string; access?: any }[];
      remove?: { role: string; access?: any }[];
      update?: { [role: string]: { access: any } }[];
    }
  | { role: string; access?: any }[];
```
**NOTE:** To prevent stuff from breaking, I kept the old behavior as well. If an array is provided instead of an object, it'll overwrite all the permissions.

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)


# How Has This Been Tested?

By playing around in the role summary using [this branch](https://github.com/ReliefApplications/oort-frontend/pull/870).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
