### PR TITLE
AB#27037

### DIFF
--- a/src/utils/query/queryBuilder.ts
+++ b/src/utils/query/queryBuilder.ts
@@ -48,6 +48,7 @@ const buildFields = (fields: any[], withId = true): any => {
             sortField: ${x.sort.field ? `"${x.sort.field}"` : null},
             sortOrder: "${x.sort.order}",
             filter: ${filterToString(x.filter)}
+            first: ${x.first},
           ) {
             ${['canUpdate\ncanDelete\n'].concat(buildFields(x.fields))}
           }` + '\n'

--- a/src/utils/schema/introspection/getSchema.ts
+++ b/src/utils/schema/introspection/getSchema.ts
@@ -219,11 +219,11 @@ export const getSchema = (
           if (field.type === GraphQLID) {
             o += `extend type ${x} { ${glField}: ${glRelatedType} }`;
           } else {
-            o += `extend type ${x} { ${glField}(filter: JSON, sortField: String, sortOrder: String): [${glRelatedType}] }`;
+            o += `extend type ${x} { ${glField}(filter: JSON, sortField: String, sortOrder: String, first: Int): [${glRelatedType}] }`;
           }
           o += `extend type ${metaName} { ${glField}: ${glRelatedMetaType} }`;
           if (!extendedFields.includes(key)) {
-            o += `extend type ${glRelatedType} { ${glRelatedField}(filter: JSON, sortField: String, sortOrder: String): [${x}] }
+            o += `extend type ${glRelatedType} { ${glRelatedField}(filter: JSON, sortField: String, sortOrder: String, first: Int): [${x}] }
                           extend type ${glRelatedMetaType} { ${glRelatedField}: ${metaName} }`;
           }
           extendedFields.push(key);
@@ -242,7 +242,7 @@ export const getSchema = (
           if (field.type === GraphQLID) {
             o += `extend type ${x} { ${glField}: ${glRelatedType} }`;
           } else {
-            o += `extend type ${x} { ${glField}(filter: JSON, sortField: String, sortOrder: String): [${glRelatedType}] }`;
+            o += `extend type ${x} { ${glField}(filter: JSON, sortField: String, sortOrder: String, first: Int): [${glRelatedType}] }`;
           }
           o += `extend type ${metaName} { ${glField}: ${glRelatedMetaType} }`;
         }

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -77,7 +77,12 @@ export const getEntityResolver = (
         return Object.assign({}, resolvers, {
           [field.name]: (
             entity,
-            args = { sortField: null, sortOrder: 'asc', filter: {} }
+            args = {
+              sortField: null,
+              sortOrder: 'asc',
+              filter: {},
+              first: null,
+            }
           ) => {
             const mongooseFilter = args.filter
               ? getFilter(args.filter, relatedFields)
@@ -89,9 +94,9 @@ export const getEntityResolver = (
               { _id: { $in: recordIds } },
               { archived: { $ne: true } }
             );
-            return Record.find(mongooseFilter).sort([
-              [getSortField(args.sortField), args.sortOrder],
-            ]);
+            return Record.find(mongooseFilter)
+              .sort([[getSortField(args.sortField), args.sortOrder]])
+              .limit(args.first);
           },
         });
       }

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -100,9 +100,9 @@ export const getEntityResolver = (
                   { _id: { $in: recordIds } },
                   { archived: { $ne: true } }
                 );
-                return Record.find(mongooseFilter).sort([
-                  [getSortField(args.sortField), args.sortOrder],
-                ]).limit(args.first);;
+                return Record.find(mongooseFilter)
+                  .sort([[getSortField(args.sortField), args.sortOrder]])
+                  .limit(args.first);
               } else {
                 return null;
               }


### PR DESCRIPTION
# Description

This PR implements a cap for the number of records from a related form. The information is being stored, per field, in the grid settings.

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

By selecting records with custom resources questions and previewing the generated email. You can change the amount of records by changing the `RELATED_RECORDS_CAP` variable in the `query-builder-forms.ts` in the frontend, or directly in the database.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Linting does not generate new warnings
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
