### PR TITLE
OORT-422 Update createdAt / modifiedAt to be default to current date

### DIFF
--- a/src/models/application.model.ts
+++ b/src/models/application.model.ts
@@ -31,64 +31,69 @@ export interface Application extends Document {
 }
 
 /** Mongoose application schema declaration */
-const applicationSchema = new Schema<Application>({
-  name: String,
-  createdAt: Date,
-  modifiedAt: Date,
-  lockedBy: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
-  },
-  status: {
-    type: String,
-    enum: Object.values(status),
-  },
-  createdBy: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
-  },
-  pages: {
-    // id of pages linked to this application
-    type: [mongoose.Schema.Types.ObjectId],
-    ref: 'Page',
-  },
-  settings: mongoose.Schema.Types.Mixed,
-  description: String,
-  permissions: {
-    canSee: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canUpdate: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canDelete: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-  },
-  subscriptions: [
-    {
-      routingKey: String,
-      title: String,
-      convertTo: {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Form',
-      },
-      channel: {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Channel',
-      },
+const applicationSchema = new Schema<Application>(
+  {
+    name: String,
+    createdAt: Date,
+    modifiedAt: Date,
+    lockedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
     },
-  ],
-});
+    status: {
+      type: String,
+      enum: Object.values(status),
+    },
+    createdBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+    },
+    pages: {
+      // id of pages linked to this application
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: 'Page',
+    },
+    settings: mongoose.Schema.Types.Mixed,
+    description: String,
+    permissions: {
+      canSee: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+      canUpdate: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+      canDelete: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+    },
+    subscriptions: [
+      {
+        routingKey: String,
+        title: String,
+        convertTo: {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Form',
+        },
+        channel: {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Channel',
+        },
+      },
+    ],
+  },
+  {
+    timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },
+  }
+);
 
 // handle cascading deletion for applications
 addOnBeforeDeleteMany(applicationSchema, async (applications) => {

--- a/src/models/application.model.ts
+++ b/src/models/application.model.ts
@@ -34,8 +34,6 @@ export interface Application extends Document {
 const applicationSchema = new Schema<Application>(
   {
     name: String,
-    createdAt: Date,
-    modifiedAt: Date,
     lockedBy: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'User',

--- a/src/models/dashboard.model.ts
+++ b/src/models/dashboard.model.ts
@@ -11,12 +11,17 @@ export interface Dashboard extends Document {
 }
 
 /** Mongoose dashboard schema declaration */
-const dashboardSchema = new Schema<Dashboard>({
-  name: String,
-  createdAt: Date,
-  modifiedAt: Date,
-  structure: mongoose.Schema.Types.Mixed,
-});
+const dashboardSchema = new Schema<Dashboard>(
+  {
+    name: String,
+    createdAt: Date,
+    modifiedAt: Date,
+    structure: mongoose.Schema.Types.Mixed,
+  },
+  {
+    timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },
+  }
+);
 
 dashboardSchema.plugin(accessibleRecordsPlugin);
 

--- a/src/models/dashboard.model.ts
+++ b/src/models/dashboard.model.ts
@@ -14,8 +14,6 @@ export interface Dashboard extends Document {
 const dashboardSchema = new Schema<Dashboard>(
   {
     name: String,
-    createdAt: Date,
-    modifiedAt: Date,
     structure: mongoose.Schema.Types.Mixed,
   },
   {

--- a/src/models/form.model.ts
+++ b/src/models/form.model.ts
@@ -45,97 +45,102 @@ export interface FormModel extends AccessibleRecordModel<Form> {
 }
 
 /** Mongoose form schema declaration */
-const schema = new Schema<Form>({
-  name: String,
-  graphQLTypeName: String,
-  createdAt: Date,
-  modifiedAt: Date,
-  structure: mongoose.Schema.Types.Mixed,
-  core: Boolean,
-  status: {
-    type: String,
-    enum: Object.values(status),
-  },
-  permissions: {
-    canSee: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canUpdate: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canDelete: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canCreateRecords: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canSeeRecords: [
-      {
-        role: {
+const schema = new Schema<Form>(
+  {
+    name: String,
+    graphQLTypeName: String,
+    createdAt: Date,
+    modifiedAt: Date,
+    structure: mongoose.Schema.Types.Mixed,
+    core: Boolean,
+    status: {
+      type: String,
+      enum: Object.values(status),
+    },
+    permissions: {
+      canSee: [
+        {
           type: mongoose.Schema.Types.ObjectId,
           ref: 'Role',
         },
-        access: mongoose.Schema.Types.Mixed,
-      },
-    ],
-    canUpdateRecords: [
-      {
-        role: {
+      ],
+      canUpdate: [
+        {
           type: mongoose.Schema.Types.ObjectId,
           ref: 'Role',
         },
-        access: mongoose.Schema.Types.Mixed,
-      },
-    ],
-    canDeleteRecords: [
-      {
-        role: {
+      ],
+      canDelete: [
+        {
           type: mongoose.Schema.Types.ObjectId,
           ref: 'Role',
         },
-        access: mongoose.Schema.Types.Mixed,
-      },
-    ],
-    recordsUnicity: [
-      {
-        role: {
+      ],
+      canCreateRecords: [
+        {
           type: mongoose.Schema.Types.ObjectId,
           ref: 'Role',
         },
-        access: mongoose.Schema.Types.Mixed,
-      },
-    ],
+      ],
+      canSeeRecords: [
+        {
+          role: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Role',
+          },
+          access: mongoose.Schema.Types.Mixed,
+        },
+      ],
+      canUpdateRecords: [
+        {
+          role: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Role',
+          },
+          access: mongoose.Schema.Types.Mixed,
+        },
+      ],
+      canDeleteRecords: [
+        {
+          role: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Role',
+          },
+          access: mongoose.Schema.Types.Mixed,
+        },
+      ],
+      recordsUnicity: [
+        {
+          role: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Role',
+          },
+          access: mongoose.Schema.Types.Mixed,
+        },
+      ],
+    },
+    fields: {
+      // name of field, id if external resource
+      type: [mongoose.Schema.Types.Mixed],
+    },
+    resource: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Resource',
+    },
+    versions: {
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: 'Version',
+    },
+    channel: {
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: 'Channel',
+    },
+    layouts: [layoutSchema],
   },
-  fields: {
-    // name of field, id if external resource
-    type: [mongoose.Schema.Types.Mixed],
-  },
-  resource: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Resource',
-  },
-  versions: {
-    type: [mongoose.Schema.Types.ObjectId],
-    ref: 'Version',
-  },
-  channel: {
-    type: [mongoose.Schema.Types.ObjectId],
-    ref: 'Channel',
-  },
-  layouts: [layoutSchema],
-});
+  {
+    timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },
+  }
+);
 
 // Get GraphQL type name of the form
 schema.statics.getGraphQLTypeName = function (name: string): string {

--- a/src/models/form.model.ts
+++ b/src/models/form.model.ts
@@ -49,8 +49,6 @@ const schema = new Schema<Form>(
   {
     name: String,
     graphQLTypeName: String,
-    createdAt: Date,
-    modifiedAt: Date,
     structure: mongoose.Schema.Types.Mixed,
     core: Boolean,
     status: {

--- a/src/models/group.model.ts
+++ b/src/models/group.model.ts
@@ -2,20 +2,25 @@ import { AccessibleRecordModel, accessibleRecordsPlugin } from '@casl/mongoose';
 import mongoose, { Schema, Document } from 'mongoose';
 
 /** Mongoose group schema definition */
-const groupSchema = new Schema<Group>({
-  title: String,
-  description: String,
-  oid: String,
-  // TODO: add roles array (out of scope for this ticket)
-  modifiedAt: {
-    type: Date,
-    default: Date.now,
+const groupSchema = new Schema<Group>(
+  {
+    title: String,
+    description: String,
+    oid: String,
+    // TODO: add roles array (out of scope for this ticket)
+    modifiedAt: {
+      type: Date,
+      default: Date.now,
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
   },
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
-});
+  {
+    timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },
+  }
+);
 
 /** Group documents interface definition */
 export interface Group extends Document {

--- a/src/models/group.model.ts
+++ b/src/models/group.model.ts
@@ -8,14 +8,6 @@ const groupSchema = new Schema<Group>(
     description: String,
     oid: String,
     // TODO: add roles array (out of scope for this ticket)
-    modifiedAt: {
-      type: Date,
-      default: Date.now,
-    },
-    createdAt: {
-      type: Date,
-      default: Date.now,
-    },
   },
   {
     timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },

--- a/src/models/layout.model.ts
+++ b/src/models/layout.model.ts
@@ -4,14 +4,6 @@ import mongoose, { Schema, Document } from 'mongoose';
 export const layoutSchema = new Schema(
   {
     name: String,
-    createdAt: {
-      type: Date,
-      default: Date.now,
-    },
-    modifiedAt: {
-      type: Date,
-      default: Date.now,
-    },
     query: {
       type: mongoose.Schema.Types.Mixed,
     },

--- a/src/models/layout.model.ts
+++ b/src/models/layout.model.ts
@@ -1,23 +1,28 @@
 import mongoose, { Schema, Document } from 'mongoose';
 
 /** Mongoose layout schema declaration */
-export const layoutSchema = new Schema({
-  name: String,
-  createdAt: {
-    type: Date,
-    default: Date.now,
+export const layoutSchema = new Schema(
+  {
+    name: String,
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
+    modifiedAt: {
+      type: Date,
+      default: Date.now,
+    },
+    query: {
+      type: mongoose.Schema.Types.Mixed,
+    },
+    display: {
+      type: mongoose.Schema.Types.Mixed,
+    },
   },
-  modifiedAt: {
-    type: Date,
-    default: Date.now,
-  },
-  query: {
-    type: mongoose.Schema.Types.Mixed,
-  },
-  display: {
-    type: mongoose.Schema.Types.Mixed,
-  },
-});
+  {
+    timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },
+  }
+);
 
 /** Layout documents interface declaration */
 export interface Layout extends Document {

--- a/src/models/notification.model.ts
+++ b/src/models/notification.model.ts
@@ -2,20 +2,25 @@ import { AccessibleRecordModel, accessibleRecordsPlugin } from '@casl/mongoose';
 import mongoose, { Schema, Document } from 'mongoose';
 
 /** Mongoose notification schema declaration */
-const notificationSchema = new Schema({
-  action: String,
-  content: mongoose.Schema.Types.Mixed,
-  createdAt: { type: Date, expires: 3600 * 24 * 60 }, // After 60 days, the notification is erased
-  channel: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Channel',
-    required: true,
+const notificationSchema = new Schema(
+  {
+    action: String,
+    content: mongoose.Schema.Types.Mixed,
+    createdAt: { type: Date, expires: 3600 * 24 * 60 }, // After 60 days, the notification is erased
+    channel: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Channel',
+      required: true,
+    },
+    seenBy: {
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: 'User',
+    },
   },
-  seenBy: {
-    type: [mongoose.Schema.Types.ObjectId],
-    ref: 'User',
-  },
-});
+  {
+    timestamps: { createdAt: 'createdAt' },
+  }
+);
 
 /** Notification documents interface declaration */
 export interface Notification extends Document {

--- a/src/models/notification.model.ts
+++ b/src/models/notification.model.ts
@@ -6,7 +6,6 @@ const notificationSchema = new Schema(
   {
     action: String,
     content: mongoose.Schema.Types.Mixed,
-    createdAt: { type: Date, expires: 3600 * 24 * 60 }, // After 60 days, the notification is erased
     channel: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Channel',
@@ -18,9 +17,14 @@ const notificationSchema = new Schema(
     },
   },
   {
-    timestamps: { createdAt: 'createdAt' },
+    timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },
   }
 );
+
+// notificationSchema.index(
+//   { createdAt: 1 },
+//   { expireAfterSeconds: 3600 * 24 * 30 }
+// ); // After 60 days, the notification is erased
 
 /** Notification documents interface declaration */
 export interface Notification extends Document {

--- a/src/models/page.model.ts
+++ b/src/models/page.model.ts
@@ -24,37 +24,42 @@ export interface Page extends Document {
 }
 
 /** Mongoose page schema declaration */
-const pageSchema = new Schema<Page>({
-  name: String,
-  createdAt: Date,
-  modifiedAt: Date,
-  type: {
-    type: String,
-    enum: Object.values(contentType),
+const pageSchema = new Schema<Page>(
+  {
+    name: String,
+    createdAt: Date,
+    modifiedAt: Date,
+    type: {
+      type: String,
+      enum: Object.values(contentType),
+    },
+    // Can be either a workflow, a dashboard or a form ID
+    content: mongoose.Schema.Types.ObjectId,
+    permissions: {
+      canSee: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+      canUpdate: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+      canDelete: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+    },
   },
-  // Can be either a workflow, a dashboard or a form ID
-  content: mongoose.Schema.Types.ObjectId,
-  permissions: {
-    canSee: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canUpdate: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canDelete: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-  },
-});
+  {
+    timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },
+  }
+);
 
 // handle cascading deletion and references deletion for pages
 addOnBeforeDeleteMany(pageSchema, async (pages) => {
@@ -74,7 +79,8 @@ addOnBeforeDeleteMany(pageSchema, async (pages) => {
   // Delete references to the pages in applications containing these pages
   await Application.updateMany(
     { pages: { $in: pages } },
-    { modifiedAt: new Date(), $pull: { pages: { $in: pages } } }
+    //{ modifiedAt: new Date(), $pull: { pages: { $in: pages } } }
+    { $pull: { pages: { $in: pages } } }
   );
 });
 

--- a/src/models/page.model.ts
+++ b/src/models/page.model.ts
@@ -27,8 +27,6 @@ export interface Page extends Document {
 const pageSchema = new Schema<Page>(
   {
     name: String,
-    createdAt: Date,
-    modifiedAt: Date,
     type: {
       type: String,
       enum: Object.values(contentType),

--- a/src/models/record.model.ts
+++ b/src/models/record.model.ts
@@ -43,8 +43,6 @@ const recordSchema = new Schema<Record>(
       ref: 'Resource',
       required: false,
     },
-    createdAt: Date,
-    modifiedAt: Date,
     createdBy: {
       user: {
         type: mongoose.Schema.Types.ObjectId,

--- a/src/models/record.model.ts
+++ b/src/models/record.model.ts
@@ -27,55 +27,60 @@ export interface Record extends Document {
 }
 
 /** Mongoose record schema declaration */
-const recordSchema = new Schema<Record>({
-  incrementalId: {
-    type: String,
-    required: true,
-  },
-  form: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Form',
-    required: true,
-  },
-  resource: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Resource',
-    required: false,
-  },
-  createdAt: Date,
-  modifiedAt: Date,
-  createdBy: {
-    user: {
+const recordSchema = new Schema<Record>(
+  {
+    incrementalId: {
+      type: String,
+      required: true,
+    },
+    form: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'User',
+      ref: 'Form',
+      required: true,
     },
-    roles: {
-      type: [mongoose.Schema.Types.ObjectId],
-      ref: 'Role',
+    resource: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Resource',
+      required: false,
     },
-    positionAttributes: [
-      {
-        value: String,
-        category: {
-          type: mongoose.Schema.Types.ObjectId,
-          ref: 'PositionAttributeCategory',
-        },
+    createdAt: Date,
+    modifiedAt: Date,
+    createdBy: {
+      user: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
       },
-    ],
+      roles: {
+        type: [mongoose.Schema.Types.ObjectId],
+        ref: 'Role',
+      },
+      positionAttributes: [
+        {
+          value: String,
+          category: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'PositionAttributeCategory',
+          },
+        },
+      ],
+    },
+    archived: {
+      type: Boolean,
+      default: false,
+    },
+    data: {
+      type: mongoose.Schema.Types.Mixed,
+      required: true,
+    },
+    versions: {
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: 'Version',
+    },
   },
-  archived: {
-    type: Boolean,
-    default: false,
-  },
-  data: {
-    type: mongoose.Schema.Types.Mixed,
-    required: true,
-  },
-  versions: {
-    type: [mongoose.Schema.Types.ObjectId],
-    ref: 'Version',
-  },
-});
+  {
+    timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },
+  }
+);
 recordSchema.index(
   { incrementalId: 1, resource: 1 },
   { unique: true, partialFilterExpression: { resource: { $exists: true } } }

--- a/src/models/referenceData.model.ts
+++ b/src/models/referenceData.model.ts
@@ -42,7 +42,6 @@ const schema = new Schema<ReferenceData>(
   {
     name: String,
     graphQLTypeName: String,
-    modifiedAt: Date,
     type: {
       type: String,
       enum: Object.values(referenceDataType),

--- a/src/models/referenceData.model.ts
+++ b/src/models/referenceData.model.ts
@@ -38,45 +38,50 @@ export interface ReferenceDataModel
  * Reference data model.
  * Reference data are coming from external APIs.
  */
-const schema = new Schema<ReferenceData>({
-  name: String,
-  graphQLTypeName: String,
-  modifiedAt: Date,
-  type: {
-    type: String,
-    enum: Object.values(referenceDataType),
+const schema = new Schema<ReferenceData>(
+  {
+    name: String,
+    graphQLTypeName: String,
+    modifiedAt: Date,
+    type: {
+      type: String,
+      enum: Object.values(referenceDataType),
+    },
+    apiConfiguration: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'ApiConfiguration',
+    },
+    query: String,
+    fields: [String],
+    valueField: String,
+    path: String,
+    data: mongoose.Schema.Types.Mixed,
+    graphQLFilter: String,
+    permissions: {
+      canSee: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+      canUpdate: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+      canDelete: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+    },
   },
-  apiConfiguration: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'ApiConfiguration',
-  },
-  query: String,
-  fields: [String],
-  valueField: String,
-  path: String,
-  data: mongoose.Schema.Types.Mixed,
-  graphQLFilter: String,
-  permissions: {
-    canSee: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canUpdate: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canDelete: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-  },
-});
+  {
+    timestamps: { updatedAt: 'modifiedAt' },
+  }
+);
 
 // Get GraphQL type name of the form
 schema.statics.getGraphQLTypeName = function (name: string): string {

--- a/src/models/resource.model.ts
+++ b/src/models/resource.model.ts
@@ -31,10 +31,6 @@ const resourceSchema = new Schema<Resource>(
       required: true,
       unique: true,
     },
-    createdAt: {
-      type: Date,
-      default: Date.now,
-    },
     permissions: {
       canSee: [
         {

--- a/src/models/resource.model.ts
+++ b/src/models/resource.model.ts
@@ -24,82 +24,87 @@ export interface Resource extends Document {
 }
 
 /** Mongoose resource schema definition */
-const resourceSchema = new Schema<Resource>({
-  name: {
-    type: String,
-    required: true,
-    unique: true,
-  },
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
-  permissions: {
-    canSee: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canUpdate: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canDelete: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canCreateRecords: [
-      {
-        role: {
+const resourceSchema = new Schema<Resource>(
+  {
+    name: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
+    permissions: {
+      canSee: [
+        {
           type: mongoose.Schema.Types.ObjectId,
           ref: 'Role',
         },
-        filter: mongoose.Schema.Types.Mixed,
-        _id: false,
-      },
-    ],
-    canSeeRecords: [
-      {
-        role: {
+      ],
+      canUpdate: [
+        {
           type: mongoose.Schema.Types.ObjectId,
           ref: 'Role',
         },
-        filter: mongoose.Schema.Types.Mixed,
-        _id: false,
-      },
-    ],
-    canUpdateRecords: [
-      {
-        role: {
+      ],
+      canDelete: [
+        {
           type: mongoose.Schema.Types.ObjectId,
           ref: 'Role',
         },
-        filter: mongoose.Schema.Types.Mixed,
-        _id: false,
-      },
-    ],
-    canDeleteRecords: [
-      {
-        role: {
-          type: mongoose.Schema.Types.ObjectId,
-          ref: 'Role',
+      ],
+      canCreateRecords: [
+        {
+          role: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Role',
+          },
+          filter: mongoose.Schema.Types.Mixed,
+          _id: false,
         },
-        filter: mongoose.Schema.Types.Mixed,
-        _id: false,
-      },
-    ],
+      ],
+      canSeeRecords: [
+        {
+          role: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Role',
+          },
+          filter: mongoose.Schema.Types.Mixed,
+          _id: false,
+        },
+      ],
+      canUpdateRecords: [
+        {
+          role: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Role',
+          },
+          filter: mongoose.Schema.Types.Mixed,
+          _id: false,
+        },
+      ],
+      canDeleteRecords: [
+        {
+          role: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Role',
+          },
+          filter: mongoose.Schema.Types.Mixed,
+          _id: false,
+        },
+      ],
+    },
+    fields: {
+      // name of field, id if external resource
+      type: [mongoose.Schema.Types.Mixed],
+    },
+    layouts: [layoutSchema],
   },
-  fields: {
-    // name of field, id if external resource
-    type: [mongoose.Schema.Types.Mixed],
-  },
-  layouts: [layoutSchema],
-});
+  {
+    timestamps: { createdAt: 'createdAt' },
+  }
+);
 
 // handle cascading deletion for resources
 addOnBeforeDeleteMany(resourceSchema, async (resources) => {

--- a/src/models/setting.model.ts
+++ b/src/models/setting.model.ts
@@ -26,7 +26,6 @@ const userManagementSchema = new Schema({
 const settingSchema = new Schema(
   {
     userManagement: userManagementSchema,
-    modifiedAt: Date,
   },
   {
     timestamps: { updatedAt: 'modifiedAt' },

--- a/src/models/setting.model.ts
+++ b/src/models/setting.model.ts
@@ -23,10 +23,15 @@ const userManagementSchema = new Schema({
 });
 
 /** Mongoose settings schema declaration */
-const settingSchema = new Schema({
-  userManagement: userManagementSchema,
-  modifiedAt: Date,
-});
+const settingSchema = new Schema(
+  {
+    userManagement: userManagementSchema,
+    modifiedAt: Date,
+  },
+  {
+    timestamps: { updatedAt: 'modifiedAt' },
+  }
+);
 
 settingSchema.index({ name: 1 }, { unique: true });
 settingSchema.plugin(accessibleRecordsPlugin);

--- a/src/models/step.model.ts
+++ b/src/models/step.model.ts
@@ -24,37 +24,42 @@ export interface Step extends Document {
 }
 
 /** Mongoose step schema definition */
-const stepSchema = new Schema<Step>({
-  name: String,
-  createdAt: Date,
-  modifiedAt: Date,
-  type: {
-    type: String,
-    enum: Object.values(contentType),
+const stepSchema = new Schema<Step>(
+  {
+    name: String,
+    createdAt: Date,
+    modifiedAt: Date,
+    type: {
+      type: String,
+      enum: Object.values(contentType),
+    },
+    // Can be either a dashboard or a form ID
+    content: mongoose.Schema.Types.ObjectId,
+    permissions: {
+      canSee: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+      canUpdate: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+      canDelete: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Role',
+        },
+      ],
+    },
   },
-  // Can be either a dashboard or a form ID
-  content: mongoose.Schema.Types.ObjectId,
-  permissions: {
-    canSee: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canUpdate: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-    canDelete: [
-      {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Role',
-      },
-    ],
-  },
-});
+  {
+    timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },
+  }
+);
 
 // handle cascading deletion for steps
 addOnBeforeDeleteMany(stepSchema, async (steps) => {
@@ -67,7 +72,8 @@ addOnBeforeDeleteMany(stepSchema, async (steps) => {
   // REFERENCES DELETION
   await Workflow.updateMany(
     { steps: { $in: steps } },
-    { modifiedAt: new Date(), $pull: { steps: { $in: steps } } }
+    //{ modifiedAt: new Date(), $pull: { steps: { $in: steps } } }
+    { $pull: { steps: { $in: steps } } }
   );
 });
 

--- a/src/models/step.model.ts
+++ b/src/models/step.model.ts
@@ -27,8 +27,6 @@ export interface Step extends Document {
 const stepSchema = new Schema<Step>(
   {
     name: String,
-    createdAt: Date,
-    modifiedAt: Date,
     type: {
       type: String,
       enum: Object.values(contentType),

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -33,7 +33,6 @@ const userSchema = new Schema(
     externalAttributes: {
       type: mongoose.Schema.Types.Mixed,
     },
-    modifiedAt: Date,
     deleteAt: { type: Date, expires: 0 }, // Date of when we must remove the user
   },
   {

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -4,37 +4,42 @@ import { AppAbility } from '../security/defineUserAbility';
 import { PositionAttribute } from './positionAttribute.model';
 
 /** Mongoose user schema definition */
-const userSchema = new Schema({
-  username: String,
-  firstName: String,
-  lastName: String,
-  name: String,
-  oid: String,
-  roles: [
-    {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: 'Role',
+const userSchema = new Schema(
+  {
+    username: String,
+    firstName: String,
+    lastName: String,
+    name: String,
+    oid: String,
+    roles: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Role',
+      },
+    ],
+    groups: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Group',
+      },
+    ],
+    positionAttributes: {
+      type: [PositionAttribute.schema],
     },
-  ],
-  groups: [
-    {
+    favoriteApp: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'Group',
+      ref: 'Application',
     },
-  ],
-  positionAttributes: {
-    type: [PositionAttribute.schema],
+    externalAttributes: {
+      type: mongoose.Schema.Types.Mixed,
+    },
+    modifiedAt: Date,
+    deleteAt: { type: Date, expires: 0 }, // Date of when we must remove the user
   },
-  favoriteApp: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Application',
-  },
-  externalAttributes: {
-    type: mongoose.Schema.Types.Mixed,
-  },
-  modifiedAt: Date,
-  deleteAt: { type: Date, expires: 0 }, // Date of when we must remove the user
-});
+  {
+    timestamps: { updatedAt: 'modifiedAt' },
+  }
+);
 
 /** User documents interface definition */
 export interface User extends Document {

--- a/src/models/version.model.ts
+++ b/src/models/version.model.ts
@@ -4,7 +4,6 @@ import mongoose, { Schema, Document } from 'mongoose';
 /** Mongoose version schema declaration */
 const versionSchema = new Schema(
   {
-    createdAt: Date,
     data: mongoose.Schema.Types.Mixed,
     createdBy: mongoose.Schema.Types.ObjectId,
   },

--- a/src/models/version.model.ts
+++ b/src/models/version.model.ts
@@ -2,11 +2,16 @@ import { AccessibleRecordModel, accessibleRecordsPlugin } from '@casl/mongoose';
 import mongoose, { Schema, Document } from 'mongoose';
 
 /** Mongoose version schema declaration */
-const versionSchema = new Schema({
-  createdAt: Date,
-  data: mongoose.Schema.Types.Mixed,
-  createdBy: mongoose.Schema.Types.ObjectId,
-});
+const versionSchema = new Schema(
+  {
+    createdAt: Date,
+    data: mongoose.Schema.Types.Mixed,
+    createdBy: mongoose.Schema.Types.ObjectId,
+  },
+  {
+    timestamps: { createdAt: 'createdAt' },
+  }
+);
 
 /** Version documents interface declaration */
 export interface Version extends Document {

--- a/src/models/workflow.model.ts
+++ b/src/models/workflow.model.ts
@@ -13,15 +13,20 @@ export interface Workflow extends Document {
 }
 
 /** Mongoose workflow schema declaration */
-const workflowSchema = new Schema<Workflow>({
-  name: String,
-  createdAt: Date,
-  modifiedAt: Date,
-  steps: {
-    type: [mongoose.Schema.Types.ObjectId],
-    ref: 'Step',
+const workflowSchema = new Schema<Workflow>(
+  {
+    name: String,
+    createdAt: Date,
+    modifiedAt: Date,
+    steps: {
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: 'Step',
+    },
   },
-});
+  {
+    timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },
+  }
+);
 
 // handle cascading deletion for workflows
 addOnBeforeDeleteMany(workflowSchema, async (workflows) => {

--- a/src/models/workflow.model.ts
+++ b/src/models/workflow.model.ts
@@ -16,8 +16,6 @@ export interface Workflow extends Document {
 const workflowSchema = new Schema<Workflow>(
   {
     name: String,
-    createdAt: Date,
-    modifiedAt: Date,
     steps: {
       type: [mongoose.Schema.Types.ObjectId],
       ref: 'Step',

--- a/src/schema/mutation/addApplication.mutation.ts
+++ b/src/schema/mutation/addApplication.mutation.ts
@@ -44,7 +44,7 @@ export default {
       }
       const application = new Application({
         name: appName,
-        createdAt: new Date(),
+        //createdAt: new Date(),
         status: status.pending,
         createdBy: user.id,
         permissions: {
@@ -75,7 +75,7 @@ export default {
       const notification = new Notification({
         action: 'Application created',
         content: application,
-        createdAt: new Date(),
+        //createdAt: new Date(),
         channel: channel.id,
         seenBy: [],
       });

--- a/src/schema/mutation/addDashboard.mutation.ts
+++ b/src/schema/mutation/addDashboard.mutation.ts
@@ -22,7 +22,7 @@ export default {
       if (args.name !== '') {
         const dashboard = new Dashboard({
           name: args.name,
-          createdAt: new Date(),
+          //createdAt: new Date(),
         });
         return dashboard.save();
       }

--- a/src/schema/mutation/addForm.mutation.ts
+++ b/src/schema/mutation/addForm.mutation.ts
@@ -70,7 +70,7 @@ export default {
         // create resource
         const resource = new Resource({
           name: args.name,
-          createdAt: new Date(),
+          //createdAt: new Date(),
           permissions: defaultResourcePermissions,
         });
         await resource.save();
@@ -78,7 +78,7 @@ export default {
         const form = new Form({
           name: args.name,
           graphQLTypeName: Form.getGraphQLTypeName(args.name),
-          createdAt: new Date(),
+          //createdAt: new Date(),
           status: status.pending,
           resource,
           core: true,
@@ -94,6 +94,7 @@ export default {
           resource: args.resource,
           core: true,
         });
+        console.log('coreForm ==>> ', coreForm);
         // create the form following the template or the core form
         let fields = coreForm.fields;
         let structure = coreForm.structure;
@@ -107,7 +108,7 @@ export default {
         }
         const form = new Form({
           name: args.name,
-          createdAt: new Date(),
+          //createdAt: new Date(),
           status: status.pending,
           resource,
           structure,
@@ -119,6 +120,7 @@ export default {
         return form;
       }
     } catch (error) {
+      console.log('error ===>> ', error);
       throw new GraphQLError(context.i18next.t('errors.resourceDuplicated'));
     }
   },

--- a/src/schema/mutation/addPage.mutation.ts
+++ b/src/schema/mutation/addPage.mutation.ts
@@ -55,7 +55,7 @@ export default {
         pageName = 'Workflow';
         const workflow = new Workflow({
           name: pageName,
-          createdAt: new Date(),
+          //createdAt: new Date(),
         });
         await workflow.save();
         content = workflow._id;
@@ -65,7 +65,7 @@ export default {
         pageName = 'Dashboard';
         const dashboard = new Dashboard({
           name: pageName,
-          createdAt: new Date(),
+          //createdAt: new Date(),
         });
         await dashboard.save();
         content = dashboard._id;
@@ -86,7 +86,7 @@ export default {
     const roles = await Role.find({ application: application._id });
     const page = new Page({
       name: pageName,
-      createdAt: new Date(),
+      //createdAt: new Date(),
       type: args.type,
       content,
       permissions: {
@@ -98,7 +98,7 @@ export default {
     await page.save();
     // Link the new page to the corresponding application by updating this application.
     const update = {
-      modifiedAt: new Date(),
+      //modifiedAt: new Date(),
       $push: { pages: page.id },
     };
     await application.updateOne(update);

--- a/src/schema/mutation/addRecord.mutation.ts
+++ b/src/schema/mutation/addRecord.mutation.ts
@@ -70,8 +70,8 @@ export default {
         String(form.resource ? form.resource : args.form)
       ),
       form: args.form,
-      createdAt: new Date(),
-      modifiedAt: new Date(),
+      //createdAt: new Date(),
+      //modifiedAt: new Date(),
       data: args.data,
       resource: form.resource ? form.resource : null,
       createdBy: {
@@ -96,7 +96,7 @@ export default {
       const notification = new Notification({
         action: `New record - ${form.name}`,
         content: record,
-        createdAt: new Date(),
+        //createdAt: new Date(),
         channel: channel.id,
         seenBy: [],
       });

--- a/src/schema/mutation/addReferenceData.mutation.ts
+++ b/src/schema/mutation/addReferenceData.mutation.ts
@@ -37,7 +37,7 @@ export default {
         const referenceData = new ReferenceData({
           name: args.name,
           graphQLTypeName: ReferenceData.getGraphQLTypeName(args.name),
-          modifiedAt: new Date(),
+          //modifiedAt: new Date(),
           type: undefined,
           valueField: '',
           fields: [],

--- a/src/schema/mutation/addStep.mutation.ts
+++ b/src/schema/mutation/addStep.mutation.ts
@@ -58,7 +58,7 @@ export default {
         stepName = 'Dashboard';
         const dashboard = new Dashboard({
           name: stepName,
-          createdAt: new Date(),
+          //createdAt: new Date(),
         });
         await dashboard.save();
         args.content = dashboard._id;
@@ -73,7 +73,7 @@ export default {
       const roles = await Role.find({ application: application._id });
       const step = new Step({
         name: stepName,
-        createdAt: new Date(),
+        //createdAt: new Date(),
         type: args.type,
         content: args.content,
         permissions: {
@@ -85,7 +85,7 @@ export default {
       await step.save();
       // Link the new step to the corresponding application by updating this application.
       const update = {
-        modifiedAt: new Date(),
+        //modifiedAt: new Date(),
         $push: { steps: step.id },
       };
       await Workflow.findByIdAndUpdate(args.workflow, update);

--- a/src/schema/mutation/addSubscription.mutation.ts
+++ b/src/schema/mutation/addSubscription.mutation.ts
@@ -60,7 +60,7 @@ export default {
     );
 
     const update = {
-      modifiedAt: new Date(),
+      //modifiedAt: new Date(),
       $push: { subscriptions: subscription },
     };
 

--- a/src/schema/mutation/addWorkflow.mutation.ts
+++ b/src/schema/mutation/addWorkflow.mutation.ts
@@ -40,12 +40,12 @@ export default {
         // Create a workflow.
         const workflow = new Workflow({
           name: args.name,
-          createdAt: new Date(),
+          //createdAt: new Date(),
         });
         await workflow.save();
         // Link the new workflow to the corresponding page by updating this page.
         const update = {
-          modifiedAt: new Date(),
+          //modifiedAt: new Date(),
           content: workflow._id,
         };
         await Page.findByIdAndUpdate(args.page, update);

--- a/src/schema/mutation/convertRecord.mutation.ts
+++ b/src/schema/mutation/convertRecord.mutation.ts
@@ -53,8 +53,8 @@ export default {
           String(oldForm.resource ? oldForm.resource : args.form)
         ),
         form: args.form,
-        createdAt: new Date(),
-        modifiedAt: new Date(),
+        //createdAt: new Date(),
+        //modifiedAt: new Date(),
         data,
         resource: oldForm.resource,
         versions: oldVersions,
@@ -63,7 +63,7 @@ export default {
     } else {
       const update: any = {
         form: args.form,
-        modifiedAt: new Date(),
+        //modifiedAt: new Date(),
       };
       return Record.findByIdAndUpdate(args.id, update, { new: true });
     }

--- a/src/schema/mutation/deleteApplication.mutation.ts
+++ b/src/schema/mutation/deleteApplication.mutation.ts
@@ -33,7 +33,7 @@ export default {
     const notification = new Notification({
       action: 'Application deleted',
       content: application,
-      createdAt: new Date(),
+      //createdAt: new Date(),
       channel: channel.id,
       seenBy: [],
     });

--- a/src/schema/mutation/duplicateApplication.mutation.ts
+++ b/src/schema/mutation/duplicateApplication.mutation.ts
@@ -36,7 +36,7 @@ export default {
       if (args.name !== '') {
         const application = new Application({
           name: args.name,
-          createdAt: new Date(),
+          //createdAt: new Date(),
           status: status.pending,
           createdBy: user.id,
           pages: copiedPages,

--- a/src/schema/mutation/duplicatePage.mutation.ts
+++ b/src/schema/mutation/duplicatePage.mutation.ts
@@ -46,7 +46,7 @@ export default {
           permissions
         );
         const update = {
-          modifiedAt: new Date(),
+          //modifiedAt: new Date(),
           $push: { pages: newPage.id },
         };
         await Application.findByIdAndUpdate(args.application, update);

--- a/src/schema/mutation/editDashboard.mutation.ts
+++ b/src/schema/mutation/editDashboard.mutation.ts
@@ -41,12 +41,10 @@ export default {
     }
     // do the update on dashboard
     const updateDashboard: {
-      modifiedAt?: Date;
+      //modifiedAt?: Date;
       structure?: any;
       name?: string;
-    } = {
-      modifiedAt: new Date(),
-    };
+    } = {};
     Object.assign(
       updateDashboard,
       args.structure && { structure: args.structure },

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -93,9 +93,10 @@ export default {
     }
 
     // Initialize the update object --- TODO = put interface
-    const update: any = {
+    /* const update: any = {
       modifiedAt: new Date(),
-    };
+    }; */
+    const update: any = {};
 
     // Update name
     if (args.name) {
@@ -487,7 +488,7 @@ export default {
       update.fields = fields;
       // Update version
       const version = new Version({
-        createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
+        //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
         data: form.structure,
       });
       await version.save();

--- a/src/schema/mutation/editPage.mutation.ts
+++ b/src/schema/mutation/editPage.mutation.ts
@@ -61,12 +61,17 @@ export default {
     }
 
     // update name
-    const update: {
+    /* const update: {
       modifiedAt?: Date;
       name?: string;
     } = {
       modifiedAt: new Date(),
-    };
+    }; */
+
+    const update: {
+      name?: string;
+    } = {};
+
     Object.assign(update, args.name && { name: args.name });
 
     // Updating permissions

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -93,7 +93,7 @@ export default {
       await transformRecord(args.data, template.fields);
       const update: any = {
         data: { ...oldRecord.data, ...args.data },
-        modifiedAt: new Date(),
+        //modifiedAt: new Date(),
         $push: { versions: version._id },
       };
       const ownership = getOwnership(template.fields, args.data); // Update with template during merge
@@ -117,7 +117,7 @@ export default {
       });
       const update: any = {
         data: oldVersion.data,
-        modifiedAt: new Date(),
+        //modifiedAt: new Date(),
         $push: { versions: version._id },
       };
       const record = Record.findByIdAndUpdate(args.id, update, { new: true });

--- a/src/schema/mutation/editRecords.mutation.ts
+++ b/src/schema/mutation/editRecords.mutation.ts
@@ -91,7 +91,7 @@ export default {
           });
           const update: any = {
             data: { ...record.data, ...data },
-            modifiedAt: new Date(),
+            //modifiedAt: new Date(),
             $push: { versions: version._id },
           };
           const ownership = getOwnership(record.form.fields, args.data); // Update with template during merge

--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -40,7 +40,7 @@ export default {
     const ability: AppAbility = user.ability;
     // Build update
     const update = {
-      modifiedAt: new Date(),
+      //modifiedAt: new Date(),
       ...args,
     };
     delete update.id;

--- a/src/schema/mutation/editSetting.mutation.ts
+++ b/src/schema/mutation/editSetting.mutation.ts
@@ -31,7 +31,7 @@ export default {
       );
     // Perform update on DB
     const update = {
-      modifiedAt: new Date(),
+      //modifiedAt: new Date(),
     };
     Object.assign(
       update,

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -79,7 +79,7 @@ export default {
 
     // defining what to update
     const update = {
-      modifiedAt: new Date(),
+      //modifiedAt: new Date(),
     };
     Object.assign(
       update,
@@ -127,7 +127,7 @@ export default {
     // update the dashboard if needed
     if (step.type === contentType.dashboard) {
       const dashboardUpdate = {
-        modifiedAt: new Date(),
+        //modifiedAt: new Date(),
       };
       Object.assign(dashboardUpdate, args.name && { name: args.name });
       await Dashboard.findByIdAndUpdate(step.content, dashboardUpdate);

--- a/src/schema/mutation/editWorkflow.mutation.ts
+++ b/src/schema/mutation/editWorkflow.mutation.ts
@@ -43,10 +43,11 @@ export default {
 
     // do the update
     const update = Object.assign(
-      { modifiedAt: new Date() },
+      {},
       args.name && { name: args.name },
       args.steps && { steps: args.steps }
     );
+    console.log('update ==>> ', update);
     workflow = await Workflow.findByIdAndUpdate(args.id, update, { new: true });
 
     // update the page or step

--- a/src/schema/mutation/publishNotification.mutation.ts
+++ b/src/schema/mutation/publishNotification.mutation.ts
@@ -33,7 +33,7 @@ export default {
     const notification = new Notification({
       action: args.action,
       content: args.content,
-      createdAt: new Date(),
+      //createdAt: new Date(),
       channel: args.channel,
       seenBy: [],
     });


### PR DESCRIPTION
# Description
to do in the model files, it is possible with mongoose to tell that by default some fields are equal to a value

there should be some examples in the code already

meaning that we can also remove all places where we declare that createdAt is equal to new Date()

same for modifiedAt, if relevant ( but perhaps we should put that in a pre save ?

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
I have changed the createdAt and modifiedAt date from manully update to automatically update. so you will need to check crud and listing page with sorting functionality

# Checklist:

( * == Mandatory ) 

- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings

