### PR TITLE
Feat 1.4.0/ab#40211 summary cards search bar to browse through templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "node-cron": "^3.0.0",
         "node-fetch": "^2.6.1",
         "nodemailer": "^6.7.2",
-        "pascal-case": "^3.1.2",
         "passport": "^0.4.1",
         "passport-azure-ad": "^4.2.1",
         "passport-keycloak-bearer": "^2.1.0",
@@ -10519,14 +10518,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -11301,15 +11292,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/node-cache": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
@@ -12004,15 +11986,6 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/passport": {
@@ -23914,14 +23887,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -24525,15 +24490,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
-    "no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "requires": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node-cache": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
@@ -25021,15 +24977,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-    },
-    "pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
     },
     "passport": {
       "version": "0.4.1",

--- a/src/routes/summarycards/index.ts
+++ b/src/routes/summarycards/index.ts
@@ -14,7 +14,7 @@ router.get('/templates', async (req, res) => {
   const ability: AppAbility = req.context.user.ability;
   const abilityFilters = Dashboard.accessibleBy(ability, 'read').getFilter();
 
-  let query: any = [{ 'structure.component': 'summaryCard' }];
+  const query: any = [{ 'structure.component': 'summaryCard' }];
 
   if (!!req.query.q) {
     query.push({

--- a/src/routes/summarycards/index.ts
+++ b/src/routes/summarycards/index.ts
@@ -13,6 +13,18 @@ const router = express.Router();
 router.get('/templates', async (req, res) => {
   const ability: AppAbility = req.context.user.ability;
   const abilityFilters = Dashboard.accessibleBy(ability, 'read').getFilter();
+
+  let query: any = [{ 'structure.component': 'summaryCard' }];
+
+  if (!!req.query.q) {
+    query.push({
+      $or: [
+        { name: { $regex: req.query.q, $options: 'i' } },
+        { 'structure.settings.title': { $regex: req.query.q, $options: 'i' } },
+      ],
+    });
+  }
+
   const cards = await Dashboard.aggregate([
     {
       $match: {
@@ -24,7 +36,7 @@ router.get('/templates', async (req, res) => {
     },
     {
       $match: {
-        'structure.component': 'summaryCard',
+        $and: query,
       },
     },
     {


### PR DESCRIPTION
# Description

we want to be able to filter them by text ( widget name / dashboard name ) . The filter must apply on both fields, and be optional


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
when you will create new summary card that time you are able to search card by widget name and dasboard name

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

