### PR TITLE
Feat 1.3.0/ab#41614 set limit of clustering emails to 1000 can be done with config package

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -23,6 +23,7 @@ module.exports = {
     from: '',
     fromPrefix: 'No reply',
     replyTo: '',
+    maxRecipients: 1000,
     host: '',
     port: '',
     user: '',

--- a/src/utils/email/sendEmail.ts
+++ b/src/utils/email/sendEmail.ts
@@ -12,7 +12,7 @@ const EMAIL_FROM = `${config.get('email.fromPrefix')} <${config.get(
 const EMAIL_REPLY_TO = config.get('email.replyTo') || config.get('email.from');
 
 /** Maximum number of recipients*/
-const MAX_RECIPIENTS = 50;
+const MAX_RECIPIENTS: number = config.get('email.maxRecipients');
 
 /** Nodemailer transport options */
 const TRANSPORT_OPTIONS = {


### PR DESCRIPTION
# Description
Currently, when sending emails we are clustering them by package of 50 recipients, but we can raise this limit to 1000

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
now you are able to send 1000 email to recipients

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

