### PR TITLE
feat-1.4.0/AB#41414_date-operations

### DIFF
--- a/__tests__/schema/query/applications.test.ts
+++ b/__tests__/schema/query/applications.test.ts
@@ -38,7 +38,6 @@ describe('Applications query tests', () => {
     const result = await server.executeOperation({ query });
     expect(result.errors).toBeUndefined();
     expect(result).toHaveProperty(['data', 'applications', 'totalCount']);
-    console.log(result);
     expect(result.data?.applications.totalCount).toEqual(count);
   });
 });

--- a/src/const/calculatedFields.ts
+++ b/src/const/calculatedFields.ts
@@ -4,7 +4,7 @@
  * If type is 'field', the operator is the value for that the field with the name stored in value
  */
 interface SimpleOperator {
-  type: 'const' | 'field';
+  type: 'const' | 'field' | 'info';
   value: string | number | boolean;
 }
 

--- a/src/utils/aggregation/buildCalculatedFieldPipeline.ts
+++ b/src/utils/aggregation/buildCalculatedFieldPipeline.ts
@@ -1,4 +1,4 @@
-import { flattenDeep } from 'lodash';
+import { flattenDeep, isNil } from 'lodash';
 import {
   DateOperationTypes,
   DoubleOperatorOperationsTypes,
@@ -49,7 +49,7 @@ const operationMap: {
 };
 
 /**
- * If provided a simple operator, returns the value, otherwise retruns null
+ * If provided a simple operator, returns the value, otherwise returns null
  *
  * @param operator The operator to get value from
  * @returns The value of the operator, or null if it is not a simple operator
@@ -77,11 +77,11 @@ const resolveTodayOperator = (operator: Operator | null, path: string) => {
 
   const getValueString = () => {
     const value = getSimpleOperatorValue(operator);
-    if (value) return value;
+    if (!isNil(value)) return value; // check that not null or undefined, so 0 works
 
     // if is an expression, add to dependencies array,
     // that will be resolved before, since will be appended
-    // to the beggining of the pipeline
+    // to the beginning of the pipeline
     const auxPath = `${path}-today`;
     dependencies.unshift({
       operation: operator.value as Operation,
@@ -124,7 +124,7 @@ const resolveSingleOperator = (
 
     // if is an expression, add to dependencies array,
     // that will be resolved before, since will be appended
-    // to the beggining of the pipeline
+    // to the beginning of the pipeline
     const auxPath = `${path}-${operation}`;
     dependencies.unshift({
       operation: operator.value as Operation,

--- a/src/utils/aggregation/buildCalculatedFieldPipeline.ts
+++ b/src/utils/aggregation/buildCalculatedFieldPipeline.ts
@@ -14,6 +14,12 @@ type Dependency = {
   path: string;
 };
 
+/** Special date operators enum */
+enum specialDateOperators {
+  UPDATED_AT = 'updatedAt',
+  CREATED_AT = 'createdAt',
+}
+
 /** Maps each operation to its corresponding pipeline command name */
 const operationMap: {
   [key in Exclude<
@@ -43,6 +49,23 @@ const operationMap: {
 };
 
 /**
+ * If provided a simple operator, returns the value, otherwise retruns null
+ *
+ * @param operator The operator to get value from
+ * @returns The value of the operator, or null if it is not a simple operator
+ */
+const getSimpleOperatorValue = (operator: Operator) => {
+  if (operator.type === 'const') return operator.value;
+  if (operator.type === 'field') return `$data.${operator.value}`;
+  if (operator.type === 'info') {
+    if (operator.value === specialDateOperators.CREATED_AT) return '$createdAt';
+    if (operator.value === specialDateOperators.UPDATED_AT)
+      return '$modifiedAt';
+  }
+  return null;
+};
+
+/**
  * Creates the pipeline stage for a 'today' operation
  *
  * @param operator The operator for the operation, if any
@@ -53,8 +76,8 @@ const resolveTodayOperator = (operator: Operator | null, path: string) => {
   const dependencies: Dependency[] = [];
 
   const getValueString = () => {
-    if (operator.type === 'const') return operator.value;
-    if (operator.type === 'field') return `$data.${operator.value}`;
+    const value = getSimpleOperatorValue(operator);
+    if (value) return value;
 
     // if is an expression, add to dependencies array,
     // that will be resolved before, since will be appended
@@ -79,6 +102,7 @@ const resolveTodayOperator = (operator: Operator | null, path: string) => {
 
   return { step, dependencies };
 };
+
 /**
  * Creates the pipeline stage for an operation with a single operator
  *
@@ -95,8 +119,8 @@ const resolveSingleOperator = (
   const dependencies: Dependency[] = [];
 
   const getValueString = () => {
-    if (operator.type === 'const') return operator.value;
-    if (operator.type === 'field') return `$data.${operator.value}`;
+    const value = getSimpleOperatorValue(operator);
+    if (value) return value;
 
     // if is an expression, add to dependencies array,
     // that will be resolved before, since will be appended
@@ -158,9 +182,8 @@ const resolveDoubleOperator = (
 
   const getValueString = (i: number) => {
     const selectedOperator = i === 1 ? operator1 : operator2;
-    if (selectedOperator.type === 'const') return selectedOperator.value;
-    if (selectedOperator.type === 'field')
-      return `$data.${selectedOperator.value}`;
+    const value = getSimpleOperatorValue(selectedOperator);
+    if (value) return value;
 
     // if is an expression, add to dependencies array,
     // that will be resolved before, since will be appended
@@ -217,9 +240,8 @@ const resolveMultipleOperators = (
     $addFields: {
       [path.startsWith('aux.') ? path : `data.${path}`]: {
         [operationMap[operation]]: operators.map((operator, index) => {
-          if (operator.type === 'const') return operator.value;
-
-          if (operator.type === 'field') return `$data.${operator.value}`;
+          const value = getSimpleOperatorValue(operator);
+          if (value) return value;
 
           // if is an expression, add to dependencies array,
           // that will be resolved before, since will be appended

--- a/src/utils/aggregation/expressionFromString.ts
+++ b/src/utils/aggregation/expressionFromString.ts
@@ -183,6 +183,14 @@ const solveExp = (exp: string): Operator => {
     };
   }
 
+  // base case: info operator
+  if (exp.startsWith('info.')) {
+    return {
+      type: 'info',
+      value: exp.substring(5),
+    };
+  }
+
   // recursive case: is an expression
   if (exp.startsWith('calc.')) {
     const operation = exp.split('(')[0].split('.')[1].trim() as any;

--- a/src/utils/form/findDuplicateFields.ts
+++ b/src/utils/form/findDuplicateFields.ts
@@ -8,7 +8,6 @@ import i18next from 'i18next';
  * @param fields Question fields array
  */
 export const findDuplicateFields = (fields): void => {
-  console.log(fields);
   const names = fields.map((x) => x.name);
   const duplication = names.filter(
     (item, index) => names.indexOf(item) !== index

--- a/src/utils/form/transformRecord.ts
+++ b/src/utils/form/transformRecord.ts
@@ -22,7 +22,6 @@ export const transformRecord = async (
           case 'datetime-local':
             if (record[value] != null) {
               record[value] = getDateForMongo(record[value]).date;
-              console.log('record[value]', record[value]);
             }
             break;
           case 'time':


### PR DESCRIPTION
# Description

This PR includes changes two parse the `updatedAt` and `createdAt` info keys into the correct pipeline in the end, so they can be used in expressions.

## Type of change

- [x] Improvement (refactor or addition to existing functionality)


# How Has This Been Tested?

By setting up a derived field with an operation that can use dates as arguments and using {{info.createdAt}} as one of the arguments


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

