### PR TITLE
feat-1.4.0/AB#41419_filtering_calculated_cols

### DIFF
--- a/src/const/calculatedFields.ts
+++ b/src/const/calculatedFields.ts
@@ -18,6 +18,12 @@ interface RecursiveOperator {
 
 export type Operator = SimpleOperator | RecursiveOperator;
 
+export type OperationTypes =
+  | SingleOperatorOperationsTypes
+  | DoubleOperatorOperationsTypes
+  | MultipleOperatorsOperationsTypes
+  | 'today';
+
 /** Interface for the 'today' operation */
 interface TodayOperation {
   operation: 'today';

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -7,6 +7,10 @@ import { buildTypes } from '../../utils/schema';
 import { AppAbility } from '../../security/defineUserAbility';
 import { isArray } from 'lodash';
 import { findDuplicateFields } from '../../utils/form';
+import {
+  getExpressionFromString,
+  OperationTypeMap,
+} from '../../utils/aggregation/expressionFromString';
 
 /** Simple resource permission change type */
 type SimplePermissionChange =
@@ -217,11 +221,15 @@ export default {
       const calculatedField: CalculatedFieldChange = args.calculatedField;
       // Add new calculated field
       if (calculatedField.add) {
+        const expression = getExpressionFromString(
+          calculatedField.add.expression
+        );
         const pushCalculatedField = {
           fields: {
+            isCalculated: true,
             name: calculatedField.add.name,
             expression: calculatedField.add.expression,
-            type: 'calculated',
+            type: OperationTypeMap[expression.operation] ?? 'text',
           },
         };
 

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -255,8 +255,13 @@ export default {
       }
       // Update existing field
       if (calculatedField.update) {
+        const expression = getExpressionFromString(
+          calculatedField.update.expression
+        );
         const updateCalculatedFields = {
           'fields.$[element].expression': calculatedField.update.expression,
+          'fields.$[element].type':
+            OperationTypeMap[expression.operation] ?? 'text',
           'fields.$[element].name': calculatedField.update.name,
         };
 

--- a/src/utils/aggregation/expressionFromString.ts
+++ b/src/utils/aggregation/expressionFromString.ts
@@ -4,6 +4,7 @@ import {
   DoubleOperatorOperationsTypes,
   MultipleOperatorsOperationsTypes,
   Operator,
+  OperationTypes,
 } from '../../const/calculatedFields';
 
 /** All the available operations with single operators */
@@ -42,14 +43,37 @@ const MULTIPLE_OPERATORS_OPERATIONS: MultipleOperatorsOperationsTypes[] = [
   'concat',
 ];
 
-/** All the available operations */
-const AVAILABLE_OPERATIONS = [
-  ...SINGLE_OPERATORS_OPERATIONS,
-  ...DOUBLE_OPERATORS_OPERATIONS,
-  ...MULTIPLE_OPERATORS_OPERATIONS,
-  'today',
-];
+/** Map of operations to field type */
+export const OperationTypeMap: { [key in OperationTypes]: string } = {
+  add: 'numeric',
+  sub: 'numeric',
+  mul: 'numeric',
+  div: 'numeric',
+  gte: 'boolean',
+  gt: 'boolean',
+  lte: 'boolean',
+  lt: 'boolean',
+  eq: 'boolean',
+  ne: 'boolean',
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  millisecond: 'numeric',
+  exists: 'boolean',
+  size: 'numeric',
+  date: 'date',
+  datediff: 'numeric',
+  and: 'boolean',
+  or: 'boolean',
+  concat: 'text',
+  today: 'date',
+};
 
+/** All the available operations */
+const AVAILABLE_OPERATIONS = Object.keys(OperationTypeMap);
 /**
  * Gets the expected number of arguments for an operation and its type
  *

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -210,7 +210,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
     // Build aggregation for calculated fields
     const calculatedFieldsAggregation: any[] = [];
     fields
-      .filter((f) => f.type === 'calculated')
+      .filter((f) => f.isCalculated)
       .forEach((f) =>
         calculatedFieldsAggregation.push(
           ...buildCalculatedFieldPipeline(f.expression, f.name)


### PR DESCRIPTION
# Description

This PR refactors the code a bit for calculated columns and how they are identified. 
Before, we were using the type of the field `type === 'calculated'`. Now in order to work with the current setup we have for metadata, I added a new prop `isCalculated` to the calculated fields and am getting the type from the outermost operation.

## Type of change
- [x] Improvement (refactor or addition to existing functionality)


# How Has This Been Tested?
By setting up filters with the frontend, and checking they work

## Sreenshots
![Peek 2022-10-03 14-38](https://user-images.githubusercontent.com/102038450/196521093-a7ff2df4-a752-49a9-ad28-fab6014c084e.gif)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

