### PR TITLE
Feat 1.4.0/ab#41415 calculated columns logical operations

### DIFF
--- a/src/const/calculatedFields.ts
+++ b/src/const/calculatedFields.ts
@@ -4,7 +4,7 @@
  * If type is 'field', the operator is the value for that the field with the name stored in value
  */
 interface SimpleOperator {
-  type: 'const' | 'field' | 'info';
+  type: 'const' | 'field' | 'info' | 'cond';
   value: string | number | boolean;
 }
 
@@ -65,11 +65,19 @@ export type MultipleOperatorsOperationsTypes =
   | 'mul'
   | 'and'
   | 'or'
+  | 'concat'
   | 'if'
-  | 'concat';
+  | 'bool';
 /** Interface for an operation with multiple operators */
 interface MultipleOperatorsOperation {
   operation: MultipleOperatorsOperationsTypes;
+  operators: Operator[];
+}
+
+export type ConditionOperatorsOperationsTypes = '&&' | '||';
+/** Interface for an operation with multiple operators */
+interface ConditionOperatorsOperation {
+  operation: ConditionOperatorsOperationsTypes;
   operators: Operator[];
 }
 
@@ -77,4 +85,5 @@ export type Operation =
   | MultipleOperatorsOperation
   | TodayOperation
   | SingleOperatorOperation
-  | DoubleOperatorOperation;
+  | DoubleOperatorOperation
+  | ConditionOperatorsOperation;

--- a/src/const/calculatedFields.ts
+++ b/src/const/calculatedFields.ts
@@ -65,6 +65,7 @@ export type MultipleOperatorsOperationsTypes =
   | 'mul'
   | 'and'
   | 'or'
+  | 'if'
   | 'concat';
 /** Interface for an operation with multiple operators */
 interface MultipleOperatorsOperation {

--- a/src/utils/aggregation/buildCalculatedFieldPipeline.ts
+++ b/src/utils/aggregation/buildCalculatedFieldPipeline.ts
@@ -46,6 +46,7 @@ const operationMap: {
   and: '$and',
   or: '$or',
   concat: '$concat',
+  if: '$if',
 };
 
 /**
@@ -359,6 +360,29 @@ const buildPipeline = (op: Operation, path: string): any[] => {
           )
         );
       pipeline.push(step);
+      break;
+    }
+    case 'if': {
+      const fields = [];
+      const conditions = [];
+      for (const operator of op.operators) {
+        if (operator.type == 'field') {
+          fields.push(getSimpleOperatorValue(operator));
+        } else {
+          conditions.push(operator.value);
+        }
+      }
+      fields.push(true);
+
+      const step = {
+        $addFields: {
+          [`data.${path}`]: {
+            $cond: [...[{ $eq: fields }], ...conditions],
+          },
+        },
+      };
+      pipeline.push(step);
+
       break;
     }
   }

--- a/src/utils/aggregation/buildCalculatedFieldPipeline.ts
+++ b/src/utils/aggregation/buildCalculatedFieldPipeline.ts
@@ -424,12 +424,12 @@ const buildPipeline = (op: Operation, path: string): any[] => {
       let queryCondition;
       if (!!conditions) {
         if (logicalArr.length < 2)
-          throw new Error(`Invalid Expression for boolean operation`);
+          throw new Error('Invalid Expression for boolean operation');
 
         queryCondition = [{ [conditions]: logicalArr }, ...resultArr];
       } else {
         if (logicalArr.length < 1)
-          throw new Error(`Invalid Expression for boolean operation`);
+          throw new Error('Invalid Expression for boolean operation');
         queryCondition = [...logicalArr, ...resultArr];
       }
 

--- a/src/utils/aggregation/expressionFromString.ts
+++ b/src/utils/aggregation/expressionFromString.ts
@@ -40,6 +40,7 @@ const MULTIPLE_OPERATORS_OPERATIONS: MultipleOperatorsOperationsTypes[] = [
   'and',
   'or',
   'concat',
+  'if',
 ];
 
 /** All the available operations */
@@ -86,11 +87,19 @@ const getExpectedNumberOfArgs = (
       operation as MultipleOperatorsOperationsTypes
     )
   ) {
-    return {
-      max: Infinity,
-      min: 2,
-      type: 'MULTIPLE',
-    };
+    if (operation !== 'if') {
+      return {
+        max: Infinity,
+        min: 2,
+        type: 'MULTIPLE',
+      };
+    } else {
+      return {
+        max: 3,
+        min: 1,
+        type: 'MULTIPLE',
+      };
+    }
   }
   if (operation === 'today') {
     return {

--- a/src/utils/aggregation/expressionFromString.ts
+++ b/src/utils/aggregation/expressionFromString.ts
@@ -3,6 +3,7 @@ import {
   SingleOperatorOperationsTypes,
   DoubleOperatorOperationsTypes,
   MultipleOperatorsOperationsTypes,
+  ConditionOperatorsOperationsTypes,
   Operator,
 } from '../../const/calculatedFields';
 
@@ -41,6 +42,13 @@ const MULTIPLE_OPERATORS_OPERATIONS: MultipleOperatorsOperationsTypes[] = [
   'or',
   'concat',
   'if',
+  'bool',
+];
+
+/** This varaible use for condition */
+const CONDITION_OPERATORS_OPERATIONS: ConditionOperatorsOperationsTypes[] = [
+  '&&',
+  '||',
 ];
 
 /** All the available operations */
@@ -48,6 +56,7 @@ const AVAILABLE_OPERATIONS = [
   ...SINGLE_OPERATORS_OPERATIONS,
   ...DOUBLE_OPERATORS_OPERATIONS,
   ...MULTIPLE_OPERATORS_OPERATIONS,
+  ...CONDITION_OPERATORS_OPERATIONS,
   'today',
 ];
 
@@ -87,16 +96,22 @@ const getExpectedNumberOfArgs = (
       operation as MultipleOperatorsOperationsTypes
     )
   ) {
-    if (operation !== 'if') {
+    if (operation == 'if') {
       return {
-        max: Infinity,
-        min: 2,
+        max: 3,
+        min: 3,
+        type: 'MULTIPLE',
+      };
+    } else if (operation == 'bool') {
+      return {
+        max: 7,
+        min: 3,
         type: 'MULTIPLE',
       };
     } else {
       return {
-        max: 3,
-        min: 1,
+        max: Infinity,
+        min: 2,
         type: 'MULTIPLE',
       };
     }
@@ -162,22 +177,29 @@ const solveExp = (exp: string): Operator => {
   // base case: constant
   if (!exp.startsWith('{{')) {
     let value: boolean | number | string = exp;
-
     if (
       (exp.startsWith('"') && exp.endsWith('"')) ||
       (exp.startsWith("'") && exp.endsWith("'"))
-    )
+    ) {
       value = exp.substring(1, exp.length - 1);
-    else if (!isNaN(Number(exp))) value = Number(exp);
-    else if (exp === 'true') value = true;
+    } else if (!isNaN(Number(exp))) {
+      value = Number(exp);
+    } else if (exp === 'true') value = true;
     else if (exp === 'false') value = false;
     else if (exp === 'null') value = null;
     else throw new Error(`Unexpected operator: ${exp}`);
 
-    return {
-      type: 'const',
-      value,
-    };
+    if (value == '&&' || value == '||') {
+      return {
+        type: 'cond',
+        value,
+      };
+    } else {
+      return {
+        type: 'const',
+        value,
+      };
+    }
   }
 
   // starts with '{{'


### PR DESCRIPTION
# Description
When calculating columns, common logical operations are allowed to compute booleans
```
>, >=, <, <=, =
and, or
```

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Step 1: add two or more number fields in the form

Step 2: Then add one record with number value in the form

Step 3: I have added one calculated boolean field in the database
this is for testing with single condition
`{{calc.bool( {{data.cust_form_field_1}} ; '>';  {{data.cust_form_field_2}} )}}`

this is for testing with mutltiple condition
`{{calc.bool( {{data.cust_form_field_1}} ; '>';  {{data.cust_form_field_2}}; '&&'; {{data.cust_form_field_3}}; '>'; {{data.cust_form_field_2}} )}}`

Step 4: then run this query from playground
allCustomFieldForms

Step 5: if condition is true then it will return TRUE otherwise return false


# Checklist:
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

