### PR TITLE
fix-1.3.0/AB#35599_related-cols

### DIFF
--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -229,7 +229,7 @@ export const getEntityResolver = (
                     },
                     { archived: { $ne: true } }
                   );
-                  mongooseFilter[`data.${x.name}`] = entity.id;
+                  mongooseFilter[`data.${x.name}`] = entity.id.toString();
                   return Record.find(mongooseFilter).sort([
                     [getSortField(args.sortField), args.sortOrder],
                   ]);


### PR DESCRIPTION
# Description

This PR fixes an issue that was being caused because the in the filters for the related records was passed an oid instead of a string, that is how the ids are being stored in the data structure of a record

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] create a resource A
- [x] create a resource B, with 'resources' question redirecting to A
- [x] create two dashboards, one for A, one for B, both displaying the list of related records
- [x] create some A records
- [x] create some B records, each B record linked to some A records
- [x] the dashboard B should display correct number of linked A resources
- [x] the dashboard A should now also display any linked B resource

## Sreenshots

![image](https://user-images.githubusercontent.com/102038450/198099753-c640cce3-d512-4b46-af52-7c2754dfc56c.png)
![image](https://user-images.githubusercontent.com/102038450/198099984-65e92628-d558-441b-ad7f-c349c5f8d2c2.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

