### PR TITLE
Fix 1.3.0/AB#51124 history generation date field

### DIFF
--- a/src/schema/mutation/addRecord.mutation.ts
+++ b/src/schema/mutation/addRecord.mutation.ts
@@ -64,7 +64,7 @@ export default {
     }
 
     // Create the record instance
-    await transformRecord(args.data, form.fields);
+    transformRecord(args.data, form.fields);
     const record = new Record({
       incrementalId: await getNextId(
         String(form.resource ? form.resource : args.form)

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -119,7 +119,7 @@ export default {
           template = parentForm;
         }
       }
-      await transformRecord(args.data, template.fields);
+      transformRecord(args.data, template.fields);
       const update: any = {
         data: { ...oldRecord.data, ...args.data },
         //modifiedAt: new Date(),

--- a/src/schema/mutation/editRecords.mutation.ts
+++ b/src/schema/mutation/editRecords.mutation.ts
@@ -87,7 +87,7 @@ export default {
             }
             fields = template.fields;
           }
-          await transformRecord(data, fields);
+          transformRecord(data, fields);
           const version = new Version({
             createdAt: record.modifiedAt ? record.modifiedAt : record.createdAt,
             data: record.data,

--- a/src/server/pullJobScheduler.ts
+++ b/src/server/pullJobScheduler.ts
@@ -13,7 +13,7 @@ import fetch from 'node-fetch';
 // import * as CryptoJS from 'crypto-js';
 import mongoose from 'mongoose';
 import { getToken } from '@utils/proxy';
-import { getNextId } from '@utils/form';
+import { getNextId, transformRecord } from '@utils/form';
 import { logger } from '../services/logger.service';
 import * as cronValidator from 'cron-validator';
 import get from 'lodash/get';
@@ -160,7 +160,6 @@ const fetchRecordsServiceToService = (
  */
 const fetchRecordsPublic = (pullJob: PullJob): void => {
   const apiConfiguration: ApiConfiguration = pullJob.apiConfiguration;
-  logger.info('NEW PULLJOB');
   fetch(apiConfiguration.endpoint + pullJob.url, { method: 'get' })
     .then((res) => res.json())
     .then((json) => {
@@ -331,7 +330,6 @@ export const insertRecords = async (
       const mappedElement = mapData(
         pullJob.mapping,
         element,
-        form.fields,
         unicityConditions.concat(linkedFieldsArray.flat())
       );
       // Adapt identifiers after mapping so if arrays are involved, it will correspond to each element of the array
@@ -380,6 +378,7 @@ export const insertRecords = async (
           });
       // If everything is fine, push it in the array for saving
       if (!isDuplicate) {
+        transformRecord(mappedElement, form.fields);
         let record = new Record({
           incrementalId: await getNextId(
             String(form.resource ? form.resource : pullJob.convertTo)
@@ -417,14 +416,12 @@ export const insertRecords = async (
  *
  * @param mapping mapping
  * @param data data to map
- * @param fields list of form fields
  * @param skippedIdentifiers keys to skip
  * @returns mapped data
  */
 export const mapData = (
   mapping: any,
   data: any,
-  fields: any,
   skippedIdentifiers?: string[]
 ): any => {
   const out = {};
@@ -439,14 +436,7 @@ export const mapData = (
         if (!skippedIdentifiers.includes(identifier)) {
           // Access field
           // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          let value = accessFieldIncludingNested(data, identifier);
-          if (
-            Array.isArray(value) &&
-            fields.find((x) => x.name === key).type === 'text'
-          ) {
-            value = value.toString();
-          }
-          out[key] = value;
+          out[key] = accessFieldIncludingNested(data, identifier);
         }
       }
     }

--- a/src/utils/form/transformRecord.ts
+++ b/src/utils/form/transformRecord.ts
@@ -1,53 +1,70 @@
 /**
- * Edit the value of a record to comply with definition of the fields of its form.
+ * Format passed value to comply with field definition.
+ *
+ * @param field field corresponding to the value
+ * @param value value to format
+ * @returns formatted value
+ */
+export const formatValue = (field: any, value: any): any => {
+  switch (field.type) {
+    case 'date':
+      if (value != null) {
+        return new Date(value);
+      }
+      break;
+    case 'datetime':
+      if (value != null) {
+        return new Date(value);
+      }
+      break;
+    case 'datetime-local':
+      if (value != null) {
+        return new Date(value);
+      }
+      break;
+    case 'text':
+      if (value != null) {
+        if (Array.isArray(value)) {
+          return value.toString();
+        } else {
+          return value;
+        }
+      }
+      break;
+    case 'time':
+      if (value != null && !(value instanceof Date)) {
+        if (value.match(/^\d\d:\d\d$/)) {
+          const hours = value.slice(0, 2);
+          const minutes = value.slice(3);
+          return new Date(Date.UTC(1970, 0, 1, hours, minutes));
+        } else {
+          return new Date(value);
+        }
+      }
+      break;
+    case 'file':
+      if (value != null) {
+        return value.map((x) => ({ name: x.name }));
+      }
+      break;
+    default:
+      return;
+  }
+};
+
+/**
+ * Edit the value of a record's data to comply with definition of the fields of its form.
  *
  * @param record record to transform
  * @param fields definition of the forms
  * @returns record with edited field values
  */
-export const transformRecord = async (
-  record: any,
-  fields: any
-): Promise<any> => {
+export const transformRecord = (record: any, fields: any): Promise<any> => {
   for (const value in record) {
     if (Object.prototype.hasOwnProperty.call(record, value)) {
       const field = fields.find((x) => x.name === value);
       if (field) {
-        switch (field.type) {
-          case 'date':
-            if (record[value] != null) {
-              record[value] = new Date(record[value]);
-            }
-            break;
-          case 'datetime':
-            if (record[value] != null) {
-              record[value] = new Date(record[value]);
-            }
-            break;
-          case 'datetime-local':
-            if (record[value] != null) {
-              record[value] = new Date(record[value]);
-            }
-            break;
-          case 'time':
-            if (record[value] != null && !(record[value] instanceof Date)) {
-              if (record[value].match(/^\d\d:\d\d$/)) {
-                const hours = record[value].slice(0, 2);
-                const minutes = record[value].slice(3);
-                record[value] = new Date(Date.UTC(1970, 0, 1, hours, minutes));
-              } else {
-                record[value] = new Date(record[value]);
-              }
-            }
-            break;
-          case 'file':
-            if (record[value] != null) {
-              record[value].map((x) => (x = { name: x.name }));
-            }
-            break;
-          default:
-            break;
-        }
+        record[value] = formatValue(field, record[value]);
       } else {
         delete record[value];
       }

--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -687,22 +687,22 @@ export class RecordHistory {
             break;
           case 'date':
             if (change.old !== undefined)
-              change.old = change.old.toLocaleDateString();
+              change.old = new Date(change.old).toLocaleDateString();
             if (change.new !== undefined)
-              change.new = change.new.toLocaleDateString();
+              change.new = new Date(change.new).toLocaleDateString();
             break;
           case 'datetime':
           case 'datetimelocal':
             if (change.old !== undefined)
-              change.old = change.old.toLocaleString();
+              change.old = new Date(change.old).toLocaleString();
             if (change.new !== undefined)
-              change.new = change.new.toLocaleString();
+              change.new = new Date(change.new).toLocaleString();
             break;
           case 'time':
             if (change.old !== undefined)
-              change.old = change.old.toTimeString();
+              change.old = new Date(change.old).toTimeString();
             if (change.new !== undefined)
-              change.new = change.new.toTimeString();
+              change.new = new Date(change.new).toTimeString();
             break;
           default:
             // for all other cases, keep the values


### PR DESCRIPTION
# Description

During history generation, force date types even if it was stored as strings
During pullJobs, format records before storing them so we prevent date from being stored as strings.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with a pullJob from EIOS, now new records are correctly stored into the DB.
Also we can open history of old records.

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

