### PR TITLE
OORT-538 Reference data can only be saved if we change 2 fields

### DIFF
--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -66,7 +66,7 @@ export default {
         validateGraphQLFieldName(field, context.i18next);
       }
     }
-    if (Object.keys(update).length <= 1) {
+    if (Object.keys(update).length < 1) {
       throw new GraphQLError(
         context.i18next.t('errors.invalidEditReferenceDataArguments')
       );

--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -66,6 +66,7 @@ export default {
         validateGraphQLFieldName(field, context.i18next);
       }
     }
+    // We need at least one field in order to update the api reference data
     if (Object.keys(update).length < 1) {
       throw new GraphQLError(
         context.i18next.t('errors.invalidEditReferenceDataArguments')


### PR DESCRIPTION
# Description
Reference data can only be saved if we change 2 fields
so we can edit fields one by one.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
please update refrence data with type graphql and change signle fields like name

## Sreenshots
![image](https://user-images.githubusercontent.com/111883188/206457008-bead4d83-de23-4282-9aa8-8f81a5f58182.png)

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

