### PR TITLE
Feat/oort 543 reorganize i18n messages

### DIFF
--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -40,7 +40,7 @@ describe('End-to-end tests', () => {
     expect(response.body.errors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          message: i18next.t('errors.userNotLogged'),
+          message: i18next.t('common.errors.userNotLogged'),
         }),
       ])
     );
@@ -72,7 +72,7 @@ describe('End-to-end tests', () => {
     /* expect(response.body.errors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          message: i18next.t('errors.permissionNotGranted'),
+          message: i18next.t('common.errors.permissionNotGranted'),
         }),
       ])
     ); */

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,65 +1,288 @@
 {
-	"errors": {
-		"authenticationTokenNotFound": "Missing bearer token.",
-		"coreFieldMissing": "Core field missing : {{name}}. Please implement this field.",
-		"dataFieldDuplicated": "Data name duplicated : {{name}}. Please provide different value names for all questions.",
-		"dataNotFound": "Data not found",
-		"duplicatedGraphQLTypeName": "A form or a reference data with a similar name already exists. Please provide a different name.",
-		"fileCannotBeUploaded": "File cannot be uploaded.",
-		"fileExtensionNotAllowed": "File extension not allowed",
-		"fileSizeLimitReached": "File size exceed 5MB",
-		"formResDuplicated": "A form or a resource with that name already exists.",
-		"groupsFromServiceDisabled": "Fetching groups from service not available.",
-		"groupsManualCreationDisabled": "Manual creation of groups is disabled.",
-		"incrementalIdError": "Error with the incremental ID for records",
-		"internalServerError": "Internal Server Error",
-		"invalidAPI": "API cannot be reached.",
-		"invalidAddAggregationArguments": "Resource and aggregation must be provided when you are added new Aggregation",
-		"invalidAddApiConfigurationArguments": "API name must be provided.",
-		"invalidAddApplicationArguments": "Application name must be provided.",
-		"invalidAddDashboardArguments": "Dashboard name must be provided.",
-		"invalidAddFormArguments": "Form should either correspond to a new resource or existing resource.",
-		"invalidAddPageArguments": "Page type must be an available type and linked application ID must be provided.",
-		"invalidAddReferenceDataArguments": "Name must be provided.",
-		"invalidAddStepArguments": "Step type must be an available type and linked workflow ID must be provided.",
-		"invalidAddWorkflowArguments": "Page id must be provided.",
-		"invalidAggregation": "Error with the aggregation format passed, missing a core parameter such as dataSource, pipeline, etc.",
-		"invalidCORS": "The CORS policy for this site does not allow access from the specified Origin.",
-		"invalidConversion": "Cannot convert this record to this target form type.",
-		"invalidCustomStage": "Custom stage cannot be parsed correctly.",
-		"invalidDeleteAggregationArguments": "Resource and aggregation id must be provided when you are delete Aggregation",
-		"invalidEditAggregationArguments": "Resource and aggregation and aggregation id must be provided when you are update Aggregation",
-		"invalidEditApiConfigurationArguments": "Either name, status, authType, endpoint, pingUrl, settings or permissions must be provided.",
-		"invalidEditApplicationArguments": "Either name, status, pages, settings or permissions must be provided.",
-		"invalidEditDashboardArguments": "Either name or structure must be provided.",
-		"invalidEditPageArguments": "Either name or permissions must be provided.",
-		"invalidEditRecordArguments": "Either data or version must be provided.",
-		"invalidEditReferenceDataArguments": "Either name, type, apiConfiguration, query, fields, valueField, path, data or permissions must be provided.",
-		"invalidEditResourceArguments": "Either fields or permissions must be provided.",
-		"invalidEditRolesArguments": "Either permissions or channels must be provided.",
-		"invalidEditStepArguments": "Either name, type, content or permissions must be provided.",
-		"invalidEditUserArguments": "Either groups or roles must be provided.",
-		"invalidEditWorkflowArguments": "Either name or steps must be provided.",
-		"invalidEmailsInput": "Wrong format detected. Please provide valid emails.",
-		"invalidFieldName": "The name of the field {{field}} is invalid: {{err}}",
-		"invalidGraphQLName": "The name can only consist of alphanumeric characters and underscores, and must start with a letter. Please choose a different name.",
-		"invalidGraphQLTypeName": "The name can only consist of alphanumeric characters. Please choose a different name.",
-		"invalidPublishNotificationArguments": "Action, content and channel arguments must all be provided.",
-		"invalidSeeNotificationArguments": "Notification ID must be provided.",
-		"invalidSeeNotificationsArguments": "Notifications IDs must be provided.",
-		"invalidUserUpload": "Please provide email and role for each user.",
-		"missingDataField": "Please add a value name to all questions, inside Data tab.",
-		"missingFile": "No file detected.",
-		"missingObjectParameters": "Missing {{object}} parameters",
-		"missingParameters": "Missing parameters",
-		"missingRelatedField": "Please add a related name to {{name}} question.",
-		"pageTypeError": "The page passed in argument is not a workflow type.",
-		"permissionNotGranted": "Permission not granted.",
-		"relatedNameDuplicated": "Related name duplicated : {{name}}. The target Resource already contains a field with that name. Please provide a different name.",
-		"resourceDuplicated": "An existing resource with that name already exists.",
-		"usageOfProtectedName": "This name is protected and cannot be used. Please choose a different name.",
-		"userNotLogged": "You must be connected.",
-		"wrongTemplateProvided": "Template must sharing the same resource as the parent form of the edited record."
+	"common":{
+        "errors":{
+            "authenticationTokenNotFound": "Missing bearer token.",
+			"userNotLogged": "You must be connected.",
+			"permissionNotGranted": "Permission not granted.",
+			"dataNotFound": "Data not found",
+			"invalidEmailsInput": "Wrong format detected. Please provide valid emails.",
+			"invalidGraphQLName": "The name can only consist of alphanumeric characters and underscores, and must start with a letter. Please choose a different name.",
+			"duplicatedGraphQLTypeName": "A form or a reference data with a similar name already exists. Please provide a different name.",
+			"fileExtensionNotAllowed": "File extension not allowed",
+			"fileSizeLimitReached": "File size exceed 5MB",
+			"invalidAPI": "API cannot be reached."
+        }
+    },
+	"mutations":{
+		"aggregation":{
+			"add":{
+				"errors":{
+					"invalidArguments": "Resource and aggregation must be provided when you are added new Aggregation"
+				}
+			},
+			"delete":{
+				"errors":{
+					"invalidArguments": "Resource and aggregation id must be provided when you are delete Aggregation"
+				}
+			},
+			"edit":{
+				"errors":{
+					"invalidEArguments": "Resource and aggregation and aggregation id must be provided when you are update Aggregation"
+				}
+			}
+		},
+		"apiConfiguration":{
+			"add":{
+				"errors":{
+					"invalidArguments": "API name must be provided."
+				}
+			},
+			"edit":{
+				"errors":{
+					"invalidArguments": "Either name, status, authType, endpoint, pingUrl, settings or permissions must be provided."
+				}
+			}
+		},
+		"dashboard":{
+			"add":{
+				"errors":{
+					"invalidArguments": "Dashboard name must be provided."
+				}
+			},
+			"edit":{
+				"errors":{
+					"invalidArguments": "Either name or structure must be provided."
+				}
+			}
+		},
+		"form":{
+			"add":{
+				"errors":{
+					"resourceDuplicated": "An existing resource with that name already exists."
+				}
+			},
+			"edit":{
+				"errors":{
+					"coreFieldMissing": "Core field missing : {{name}}. Please implement this field.",
+					"relatedNameDuplicated": "Related name duplicated : {{name}}. The target Resource already contains a field with that name. Please provide a different name."
+				}
+			}
+		},
+		"group":{
+			"add":{
+				"errors":{
+					"manualCreationDisabled": "Manual creation of groups is disabled."
+				}
+			},
+			"fetch":{
+				"errors":{
+					"groupsFromServiceDisabled": "Fetching groups from service not available."
+				}
+			}
+		},
+		"layout":{
+			"add":{
+				"errors":{
+					"invalidAddPageArguments": "Page type must be an available type and linked application ID must be provided."
+				}
+			},
+			"delete":{
+				"errors":{
+					"invalidArguments": "Resource and aggregation id must be provided when you are delete Aggregation"
+				}
+			},
+			"edit":{
+				"errors":{
+					"invalidAddPageArguments": "Page type must be an available type and linked application ID must be provided."
+				}
+			}
+		},
+		"page":{
+			"add":{
+				"errors":{
+					"invalidArguments": "Page type must be an available type and linked application ID must be provided."
+				}
+			},
+			"edit":{
+				"errors":{
+					"invalidArguments": "Either name or permissions must be provided."
+				}
+			}
+		},
+		"reference":{
+			"add":{
+				"errors":{
+					"invalidArguments": "Name must be provided."
+				}
+			},
+			"edit":{
+				"errors":{
+					"invalidArguments": "Either name, type, apiConfiguration, query, fields, valueField, path, data or permissions must be provided.",
+					"formResDuplicated": "A form or a resource with that name already exists."
+				}
+			}
+		},
+		"step":{
+			"add":{
+				"errors":{
+					"invalidArguments": "Name must be provided."
+				}
+			},
+			"edit":{
+				"errors":{
+					"invalidArguments": "Either name, type, content or permissions must be provided."
+				}
+			}
+		},
+		"workflow":{
+			"add":{
+				"errors":{
+					"invalidArguments": "Page id must be provided.",
+					"pageTypeError": "The page passed in argument is not a workflow type"
+				}
+			},
+			"edit":{
+				"errors":{
+					"invalidArguments": "Either name or steps must be provided."
+				}
+			}
+		},
+		"record":{
+			"convert":{
+				"errors":{
+					"invalidConversion": "Cannot convert this record to this target form type."
+				}
+			},
+			"edit":{
+				"errors":{
+					"wrongTemplateProvided": "Template must sharing the same resource as the parent form of the edited record."
+				}
+			}
+		},
+		"application":{
+			"duplicate":{
+				"errors":{
+					"invalidArguments": "Application name must be provided."
+				}
+			},
+			"edit":{
+				"errors":{
+					"invalidArguments": "Either name, status, pages, settings or permissions must be provided."
+				}
+			}
+		},
+		"user":{
+			"edit":{
+				"errors":{
+					"invalidArguments": "Either groups or roles must be provided."
+				}
+			}
+		},
+		"resource":{
+			"edit":{
+				"errors":{
+					"invalidArguments": "Either fields or permissions must be provided."
+				}
+			}
+		},
+		"notification":{
+			"publish":{
+				"errors":{
+					"invalidArguments": "Action, content and channel arguments must all be provided."
+				}
+			},
+			"see":{
+				"errors":{
+					"invalidArguments": "Notifications IDs must be provided."
+				}
+			}
+		}
+	},
+	"query":{
+		"records":{
+			"aggregation":{
+				"errors":{
+					"invalidAggregation": "Error with the aggregation format passed, missing a core parameter such as dataSource, pipeline, etc."
+				}
+			}
+		}
+	},
+	"utils":{
+		"form":{
+			"findDuplicateFields":{
+				"errors":{
+					"dataFieldDuplicated": "Data name duplicated : {{name}}. Please provide different value names for all questions."
+				}
+			},
+			"getNextId":{
+				"errors":{
+					"incrementalIdError": "Error with the incremental ID for records"
+				}
+			},
+			"extractFields":{
+				"errors":{
+					"missingDataField": "Please add a value name to all questions, inside Data tab.",
+					"missingRelatedField": "Please add a related name to {{name}} question."
+				}
+			}
+		},
+		"files":{
+			"uploadFile":{
+				"errors":{
+					"fileCannotBeUploaded": "File cannot be uploaded."
+				}
+			}
+		},
+		"aggregation":{
+			"buildPipeline":{
+				"errors":{
+					"invalidCustomStage": "Custom stage cannot be parsed correctly."
+				}
+			}
+		},
+		"validators":{
+			"validateName":{
+				"errors":{
+					"invalidFieldName": "The name of the field {{field}} is invalid: {{err}}",
+					"usageOfProtectedName": "This name is protected and cannot be used. Please choose a different name."
+				}
+			}
+		},
+		"user":{
+			"updateUserAttributes":{
+				"errors":{
+					"missingObjectParameters": "Missing {{object}} parameters"
+				}
+			}
+		}
+	},
+	"routes":{
+		"download":{
+			"errors":{
+				"internalServerError": "Internal Server Error",
+				"missingParameters": "Missing parameters"
+			}
+		},
+		"upload":{
+			"errors":{
+				"invalidUserUpload": "Please provide email and role for each user.",
+				"missingFile": "No file detected."
+			}
+		},
+		"email":{
+			"errors":{
+				"missingFile": "No file detected."
+			}
+		}
+	},
+	"server":{
+		"middlewares":{
+			"cors":{
+				"errors":{
+					"invalidCORS": "The CORS policy for this site does not allow access from the specified Origin."
+				}
+			}
+		}
 	},
 	"history": {
 		"allFields": "All fields",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -53,7 +53,7 @@
 			},
 			"edit": {
 				"errors": {
-					"invalidEArguments": "Resource and aggregation and aggregation id must be provided when you are update Aggregation"
+					"invalidArguments": "Resource and aggregation and aggregation id must be provided when you are update Aggregation"
 				}
 			}
 		},

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -53,7 +53,7 @@
 			},
 			"edit": {
 				"errors": {
-					"invalidEArguments": "******"
+					"invalidArguments": "******"
 				}
 			}
 		},

--- a/src/routes/download/index.ts
+++ b/src/routes/download/index.ts
@@ -306,7 +306,9 @@ router.post('/records', async (req, res) => {
 
   // Send res accordingly to parameters
   if (!params.fields || !params.query) {
-    return res.status(400).send(i18next.t('routes.download.errors.missingParameters'));
+    return res
+      .status(400)
+      .send(i18next.t('routes.download.errors.missingParameters'));
   }
 
   // Initialization

--- a/src/routes/download/index.ts
+++ b/src/routes/download/index.ts
@@ -129,7 +129,7 @@ router.get('/form/records/:id', async (req, res) => {
       return fileBuilder(res, filename, columns, rows, type);
     }
   } else {
-    res.status(404).send(i18next.t('errors.dataNotFound'));
+    res.status(404).send(i18next.t('common.errors.dataNotFound'));
   }
 });
 
@@ -240,11 +240,11 @@ router.get('/form/records/:id/history', async (req, res) => {
       };
       return await historyFileBuilder(res, history, meta, options);
     } else {
-      res.status(404).send(req.t('errors.dataNotFound'));
+      res.status(404).send(req.t('common.errors.dataNotFound'));
     }
   } catch (err) {
     logger.error(err.message, { stack: err.stack });
-    res.status(500).send(req.t('errors.internalServerError'));
+    res.status(500).send(req.t('routes.download.errors.internalServerError'));
   }
 });
 
@@ -280,7 +280,7 @@ router.get('/resource/records/:id', async (req, res) => {
       return fileBuilder(res, filename, columns, rows, type);
     }
   } else {
-    res.status(404).send(i18next.t('errors.dataNotFound'));
+    res.status(404).send(i18next.t('common.errors.dataNotFound'));
   }
 });
 
@@ -306,7 +306,7 @@ router.post('/records', async (req, res) => {
 
   // Send res accordingly to parameters
   if (!params.fields || !params.query) {
-    return res.status(400).send(i18next.t('errors.missingParameters'));
+    return res.status(400).send(i18next.t('routes.download.errors.missingParameters'));
   }
 
   // Initialization
@@ -408,7 +408,7 @@ router.get('/users', async (req, res) => {
     });
     return buildUserExport(req, res, users);
   }
-  res.status(404).send(i18next.t('errors.dataNotFound'));
+  res.status(404).send(i18next.t('common.errors.dataNotFound'));
 });
 
 /**
@@ -450,7 +450,7 @@ router.get('/application/:id/users', async (req, res) => {
     const users = await User.aggregate(aggregations);
     return buildUserExport(req, res, users);
   }
-  res.status(404).send(i18next.t('errors.dataNotFound'));
+  res.status(404).send(i18next.t('common.errors.dataNotFound'));
 });
 
 /**
@@ -460,10 +460,10 @@ router.get('/file/:form/:blob', async (req, res) => {
   const ability: AppAbility = req.context.user.ability;
   const form: Form = await Form.findById(req.params.form);
   if (!form) {
-    res.status(404).send(i18next.t('errors.dataNotFound'));
+    res.status(404).send(i18next.t('common.errors.dataNotFound'));
   }
   if (ability.cannot('read', form)) {
-    res.status(403).send(i18next.t('errors.permissionNotGranted'));
+    res.status(403).send(i18next.t('common.errors.permissionNotGranted'));
   }
   const blobName = `${req.params.form}/${req.params.blob}`;
   const path = `files/${sanitize(req.params.blob)}`;

--- a/src/routes/email/index.ts
+++ b/src/routes/email/index.ts
@@ -176,14 +176,18 @@ router.post('/files', async (req: any, res) => {
       return acc + x.size;
     }, 0) > FILE_SIZE_LIMIT
   ) {
-    return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
+    return res
+      .status(400)
+      .send(i18next.t('common.errors.fileSizeLimitReached'));
   }
 
   // Loop on files, to upload them
   for (const file of files) {
     // Check file size
     if (file.size > FILE_SIZE_LIMIT)
-      return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
+      return res
+        .status(400)
+        .send(i18next.t('common.errors.fileSizeLimitReached'));
     // eslint-disable-next-line @typescript-eslint/no-loop-func
     await new Promise((resolve, reject) => {
       fs.writeFile(

--- a/src/routes/email/index.ts
+++ b/src/routes/email/index.ts
@@ -150,7 +150,7 @@ router.post('/files', async (req: any, res) => {
   }
   // Check file
   if (!req.files || Object.keys(req.files.attachments).length === 0)
-    return res.status(400).send(i18next.t('errors.missingFile'));
+    return res.status(400).send(i18next.t('routes.email.errors.missingFile'));
 
   // Create folder to store files in
   const folderName = uuidv4();
@@ -176,14 +176,14 @@ router.post('/files', async (req: any, res) => {
       return acc + x.size;
     }, 0) > FILE_SIZE_LIMIT
   ) {
-    return res.status(400).send(i18next.t('errors.fileSizeLimitReached'));
+    return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
   }
 
   // Loop on files, to upload them
   for (const file of files) {
     // Check file size
     if (file.size > FILE_SIZE_LIMIT)
-      return res.status(400).send(i18next.t('errors.fileSizeLimitReached'));
+      return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
     // eslint-disable-next-line @typescript-eslint/no-loop-func
     await new Promise((resolve, reject) => {
       fs.writeFile(

--- a/src/routes/proxy/index.ts
+++ b/src/routes/proxy/index.ts
@@ -19,7 +19,7 @@ router.all('/:name/**', async (req, res) => {
     status: 'active',
   }).select('name authType endpoint settings id');
   if (!apiConfiguration) {
-    res.status(404).send(i18next.t('errors.dataNotFound'));
+    res.status(404).send(i18next.t('common.errors.dataNotFound'));
   }
   const token = await getToken(apiConfiguration);
   const headers = Object.assign(req.headers, {
@@ -119,7 +119,7 @@ router.all('/:name/**', async (req, res) => {
     try {
       res.status(503).send('Service currently unavailable');
     } catch (_e) {
-      res.status(500).send(i18next.t('errors.invalidAPI'));
+      res.status(500).send(i18next.t('common.errors.invalidAPI'));
     }
   }
 });

--- a/src/routes/roles/index.ts
+++ b/src/routes/roles/index.ts
@@ -28,13 +28,13 @@ router.get('/:id/summary', async (req, res) => {
           model: 'Permission',
         });
       if (!role) {
-        res.status(404).send(i18next.t('errors.dataNotFound'));
+        res.status(404).send(i18next.t('common.errors.dataNotFound'));
       }
     } catch {
-      res.status(404).send(i18next.t('errors.dataNotFound'));
+      res.status(404).send(i18next.t('common.errors.dataNotFound'));
     }
   } else {
-    res.status(403).send(i18next.t('errors.permissionNotGranted'));
+    res.status(403).send(i18next.t('common.errors.permissionNotGranted'));
   }
 
   const userRole = new User({ roles: [role] });

--- a/src/routes/upload/index.ts
+++ b/src/routes/upload/index.ts
@@ -125,15 +125,20 @@ router.post('/form/records/:id', async (req: any, res) => {
   const file = req.files.excelFile;
   // Check file size
   if (file.size > FILE_SIZE_LIMIT)
-    return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
+    return res
+      .status(400)
+      .send(i18next.t('common.errors.fileSizeLimitReached'));
   // Check file extension (only allowed .xlsx)
   if (file.name.match(/\.[0-9a-z]+$/i)[0] !== '.xlsx')
-    return res.status(400).send(i18next.t('common.errors.fileExtensionNotAllowed'));
+    return res
+      .status(400)
+      .send(i18next.t('common.errors.fileExtensionNotAllowed'));
 
   const form = await Form.findById(req.params.id);
 
   // Check if the form exist
-  if (!form) return res.status(404).send(i18next.t('common.errors.dataNotFound'));
+  if (!form)
+    return res.status(404).send(i18next.t('common.errors.dataNotFound'));
 
   // Insert records if authorized
   return insertRecords(res, file, form, form.fields, req.context);
@@ -150,10 +155,14 @@ router.post('/resource/records/:id', async (req: any, res) => {
   const file = req.files.excelFile;
   // Check file size
   if (file.size > FILE_SIZE_LIMIT)
-    return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
+    return res
+      .status(400)
+      .send(i18next.t('common.errors.fileSizeLimitReached'));
   // Check file extension (only allowed .xlsx)
   if (file.name.match(/\.[0-9a-z]+$/i)[0] !== '.xlsx')
-    return res.status(400).send(i18next.t('common.errors.fileExtensionNotAllowed'));
+    return res
+      .status(400)
+      .send(i18next.t('common.errors.fileExtensionNotAllowed'));
 
   const form = await Form.findOne({ resource: req.params.id, core: true });
   const resource = await Resource.findById(req.params.id);
@@ -176,10 +185,14 @@ router.post('/application/:id/invite', async (req: any, res) => {
   const file = req.files.excelFile;
   // Check file size
   if (file.size > FILE_SIZE_LIMIT)
-    return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
+    return res
+      .status(400)
+      .send(i18next.t('common.errors.fileSizeLimitReached'));
   // Check file extension (only allowed .xlsx)
   if (file.name.match(/\.[0-9a-z]+$/i)[0] !== '.xlsx')
-    return res.status(400).send(i18next.t('common.errors.fileExtensionNotAllowed'));
+    return res
+      .status(400)
+      .send(i18next.t('common.errors.fileExtensionNotAllowed'));
 
   const roles = await Role.find({ application: req.params.id }).select(
     'id title'
@@ -217,7 +230,9 @@ router.post('/application/:id/invite', async (req: any, res) => {
           });
         }
       } else {
-        return res.status(400).send(i18next.t('routes.upload.errors.invalidUserUpload'));
+        return res
+          .status(400)
+          .send(i18next.t('routes.upload.errors.invalidUserUpload'));
       }
       data.push(user);
     }
@@ -236,10 +251,14 @@ router.post('/invite', async (req: any, res) => {
   const file = req.files.excelFile;
   // Check file size
   if (file.size > FILE_SIZE_LIMIT)
-    return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
+    return res
+      .status(400)
+      .send(i18next.t('common.errors.fileSizeLimitReached'));
   // Check file extension (only allowed .xlsx)
   if (file.name.match(/\.[0-9a-z]+$/i)[0] !== '.xlsx')
-    return res.status(400).send(i18next.t('common.errors.fileExtensionNotAllowed'));
+    return res
+      .status(400)
+      .send(i18next.t('common.errors.fileExtensionNotAllowed'));
 
   const roles = await Role.find({ application: null }).select('id title');
   const workbook = new Workbook();
@@ -265,7 +284,9 @@ router.post('/invite', async (req: any, res) => {
         user.email = rawUser.email.text || rawUser.email;
         user.role = roles.find((x) => x.title === rawUser.role)._id || null;
       } else {
-        return res.status(400).send(i18next.t('routes.upload.errors.invalidUserUpload'));
+        return res
+          .status(400)
+          .send(i18next.t('routes.upload.errors.invalidUserUpload'));
       }
       data.push(user);
     }

--- a/src/routes/upload/index.ts
+++ b/src/routes/upload/index.ts
@@ -110,7 +110,7 @@ async function insertRecords(
       return res.status(200).send({ status: 'No record added.' });
     }
   } else {
-    return res.status(403).send(i18next.t('errors.dataNotFound'));
+    return res.status(403).send(i18next.t('common.errors.dataNotFound'));
   }
 }
 
@@ -120,20 +120,20 @@ async function insertRecords(
 router.post('/form/records/:id', async (req: any, res) => {
   // Check file
   if (!req.files || Object.keys(req.files).length === 0)
-    return res.status(400).send(i18next.t('errors.missingFile'));
+    return res.status(400).send(i18next.t('routes.upload.errors.missingFile'));
   // Get the file from request
   const file = req.files.excelFile;
   // Check file size
   if (file.size > FILE_SIZE_LIMIT)
-    return res.status(400).send(i18next.t('errors.fileSizeLimitReached'));
+    return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
   // Check file extension (only allowed .xlsx)
   if (file.name.match(/\.[0-9a-z]+$/i)[0] !== '.xlsx')
-    return res.status(400).send(i18next.t('errors.fileExtensionNotAllowed'));
+    return res.status(400).send(i18next.t('common.errors.fileExtensionNotAllowed'));
 
   const form = await Form.findById(req.params.id);
 
   // Check if the form exist
-  if (!form) return res.status(404).send(i18next.t('errors.dataNotFound'));
+  if (!form) return res.status(404).send(i18next.t('common.errors.dataNotFound'));
 
   // Insert records if authorized
   return insertRecords(res, file, form, form.fields, req.context);
@@ -145,21 +145,21 @@ router.post('/form/records/:id', async (req: any, res) => {
 router.post('/resource/records/:id', async (req: any, res) => {
   // Check file
   if (!req.files || Object.keys(req.files).length === 0)
-    return res.status(400).send(i18next.t('errors.missingFile'));
+    return res.status(400).send(i18next.t('routes.upload.errors.missingFile'));
   // Get the file from request
   const file = req.files.excelFile;
   // Check file size
   if (file.size > FILE_SIZE_LIMIT)
-    return res.status(400).send(i18next.t('errors.fileSizeLimitReached'));
+    return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
   // Check file extension (only allowed .xlsx)
   if (file.name.match(/\.[0-9a-z]+$/i)[0] !== '.xlsx')
-    return res.status(400).send(i18next.t('errors.fileExtensionNotAllowed'));
+    return res.status(400).send(i18next.t('common.errors.fileExtensionNotAllowed'));
 
   const form = await Form.findOne({ resource: req.params.id, core: true });
   const resource = await Resource.findById(req.params.id);
   // Check if the form and the resource exist
   if (!form || !resource)
-    return res.status(404).send(i18next.t('errors.dataNotFound'));
+    return res.status(404).send(i18next.t('common.errors.dataNotFound'));
 
   // Insert records if authorized
   return insertRecords(res, file, form, resource.fields, req.context);
@@ -171,15 +171,15 @@ router.post('/resource/records/:id', async (req: any, res) => {
 router.post('/application/:id/invite', async (req: any, res) => {
   // Check file
   if (!req.files || Object.keys(req.files).length === 0)
-    return res.status(400).send(i18next.t('errors.missingFile'));
+    return res.status(400).send(i18next.t('routes.upload.errors.missingFile'));
   // Get the file from request
   const file = req.files.excelFile;
   // Check file size
   if (file.size > FILE_SIZE_LIMIT)
-    return res.status(400).send(i18next.t('errors.fileSizeLimitReached'));
+    return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
   // Check file extension (only allowed .xlsx)
   if (file.name.match(/\.[0-9a-z]+$/i)[0] !== '.xlsx')
-    return res.status(400).send(i18next.t('errors.fileExtensionNotAllowed'));
+    return res.status(400).send(i18next.t('common.errors.fileExtensionNotAllowed'));
 
   const roles = await Role.find({ application: req.params.id }).select(
     'id title'
@@ -217,7 +217,7 @@ router.post('/application/:id/invite', async (req: any, res) => {
           });
         }
       } else {
-        return res.status(400).send(i18next.t('errors.invalidUserUpload'));
+        return res.status(400).send(i18next.t('routes.upload.errors.invalidUserUpload'));
       }
       data.push(user);
     }
@@ -231,15 +231,15 @@ router.post('/application/:id/invite', async (req: any, res) => {
 router.post('/invite', async (req: any, res) => {
   // Check file
   if (!req.files || Object.keys(req.files).length === 0)
-    return res.status(400).send(i18next.t('errors.missingFile'));
+    return res.status(400).send(i18next.t('routes.upload.errors.missingFile'));
   // Get the file from request
   const file = req.files.excelFile;
   // Check file size
   if (file.size > FILE_SIZE_LIMIT)
-    return res.status(400).send(i18next.t('errors.fileSizeLimitReached'));
+    return res.status(400).send(i18next.t('common.errors.fileSizeLimitReached'));
   // Check file extension (only allowed .xlsx)
   if (file.name.match(/\.[0-9a-z]+$/i)[0] !== '.xlsx')
-    return res.status(400).send(i18next.t('errors.fileExtensionNotAllowed'));
+    return res.status(400).send(i18next.t('common.errors.fileExtensionNotAllowed'));
 
   const roles = await Role.find({ application: null }).select('id title');
   const workbook = new Workbook();
@@ -265,7 +265,7 @@ router.post('/invite', async (req: any, res) => {
         user.email = rawUser.email.text || rawUser.email;
         user.role = roles.find((x) => x.title === rawUser.role)._id || null;
       } else {
-        return res.status(400).send(i18next.t('errors.invalidUserUpload'));
+        return res.status(400).send(i18next.t('routes.upload.errors.invalidUserUpload'));
       }
       data.push(user);
     }

--- a/src/schema/mutation/addAggregation.mutation.ts
+++ b/src/schema/mutation/addAggregation.mutation.ts
@@ -17,12 +17,12 @@ export default {
   async resolve(parent, args, context) {
     if (!args.resource || !args.aggregation) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddAggregationArguments')
+        context.i18next.t('mutations.aggregation.add.errors.invalidArguments')
       );
     }
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     // Edition of a resource
@@ -33,7 +33,7 @@ export default {
       const resource: Resource = await Resource.findOne(filters);
       if (!resource) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
       resource.aggregations.push(args.aggregation);

--- a/src/schema/mutation/addApiConfiguration.mutation.ts
+++ b/src/schema/mutation/addApiConfiguration.mutation.ts
@@ -17,7 +17,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     if (ability.can('create', 'ApiConfiguration')) {
@@ -36,10 +36,10 @@ export default {
         return apiConfiguration.save();
       }
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddApiConfigurationArguments')
+        context.i18next.t('mutations.apiConfiguration.add.errors.invalidArguments')
       );
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/addApiConfiguration.mutation.ts
+++ b/src/schema/mutation/addApiConfiguration.mutation.ts
@@ -36,10 +36,14 @@ export default {
         return apiConfiguration.save();
       }
       throw new GraphQLError(
-        context.i18next.t('mutations.apiConfiguration.add.errors.invalidArguments')
+        context.i18next.t(
+          'mutations.apiConfiguration.add.errors.invalidArguments'
+        )
       );
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/addApplication.mutation.ts
+++ b/src/schema/mutation/addApplication.mutation.ts
@@ -17,7 +17,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     if (ability.can('create', 'Application')) {
@@ -100,7 +100,7 @@ export default {
       }
       return application;
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/addApplication.mutation.ts
+++ b/src/schema/mutation/addApplication.mutation.ts
@@ -100,7 +100,9 @@ export default {
       }
       return application;
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/addChannel.mutation.ts
+++ b/src/schema/mutation/addChannel.mutation.ts
@@ -21,12 +21,12 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     const application = await Application.findById(args.application);
     if (!application)
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     if (ability.can('update', application)) {
       const channel = new Channel({
         title: args.title,
@@ -34,7 +34,7 @@ export default {
       });
       return channel.save();
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/addChannel.mutation.ts
+++ b/src/schema/mutation/addChannel.mutation.ts
@@ -34,7 +34,9 @@ export default {
       });
       return channel.save();
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/addDashboard.mutation.ts
+++ b/src/schema/mutation/addDashboard.mutation.ts
@@ -15,7 +15,7 @@ export default {
   resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     if (ability.can('create', 'Dashboard')) {
@@ -27,10 +27,10 @@ export default {
         return dashboard.save();
       }
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddDashboardArguments')
+        context.i18next.t('mutations.dashboard.add.errors.invalidArguments')
       );
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/addDashboard.mutation.ts
+++ b/src/schema/mutation/addDashboard.mutation.ts
@@ -30,7 +30,9 @@ export default {
         context.i18next.t('mutations.dashboard.add.errors.invalidArguments')
       );
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/addDistributionList.mutation.ts
+++ b/src/schema/mutation/addDistributionList.mutation.ts
@@ -25,13 +25,17 @@ export default {
       args.application
     );
     if (ability.cannot('update', 'DistributionList')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     // Prevent wrong emails to be saved
     if (
       args.distributionList.emails.filter((x) => !validateEmail(x)).length > 0
     ) {
-      throw new GraphQLError(context.i18next.t('common.errors.invalidEmailsInput'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.invalidEmailsInput')
+      );
     }
 
     const update = {

--- a/src/schema/mutation/addDistributionList.mutation.ts
+++ b/src/schema/mutation/addDistributionList.mutation.ts
@@ -18,20 +18,20 @@ export default {
   async resolve(_, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = extendAbilityForApplications(
       user,
       args.application
     );
     if (ability.cannot('update', 'DistributionList')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     // Prevent wrong emails to be saved
     if (
       args.distributionList.emails.filter((x) => !validateEmail(x)).length > 0
     ) {
-      throw new GraphQLError(context.i18next.t('errors.invalidEmailsInput'));
+      throw new GraphQLError(context.i18next.t('common.errors.invalidEmailsInput'));
     }
 
     const update = {

--- a/src/schema/mutation/addForm.mutation.ts
+++ b/src/schema/mutation/addForm.mutation.ts
@@ -26,12 +26,12 @@ export default {
     // Check authentication
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     // Check permission to create form
     if (ability.cannot('create', 'Form')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     // Check if another form with same name exists
     const graphQLTypeName = Form.getGraphQLTypeName(args.name);
@@ -41,7 +41,7 @@ export default {
       (await ReferenceData.hasDuplicate(graphQLTypeName))
     ) {
       throw new GraphQLError(
-        context.i18next.t('errors.duplicatedGraphQLTypeName')
+        context.i18next.t('common.errors.duplicatedGraphQLTypeName')
       );
     }
     // define default permission lists
@@ -66,7 +66,7 @@ export default {
         // Check permission to create resource
         if (ability.cannot('create', 'Resource')) {
           throw new GraphQLError(
-            context.i18next.t('errors.permissionNotGranted')
+            context.i18next.t('common.errors.permissionNotGranted')
           );
         }
         // create resource
@@ -120,7 +120,7 @@ export default {
         return form;
       }
     } catch (error) {
-      throw new GraphQLError(context.i18next.t('errors.resourceDuplicated'));
+      throw new GraphQLError(context.i18next.t('mutations.form.add.errors.resourceDuplicated'));
     }
   },
 };

--- a/src/schema/mutation/addForm.mutation.ts
+++ b/src/schema/mutation/addForm.mutation.ts
@@ -31,7 +31,9 @@ export default {
     const ability: AppAbility = user.ability;
     // Check permission to create form
     if (ability.cannot('create', 'Form')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     // Check if another form with same name exists
     const graphQLTypeName = Form.getGraphQLTypeName(args.name);
@@ -120,7 +122,9 @@ export default {
         return form;
       }
     } catch (error) {
-      throw new GraphQLError(context.i18next.t('mutations.form.add.errors.resourceDuplicated'));
+      throw new GraphQLError(
+        context.i18next.t('mutations.form.add.errors.resourceDuplicated')
+      );
     }
   },
 };

--- a/src/schema/mutation/addGroup.mutation.ts
+++ b/src/schema/mutation/addGroup.mutation.ts
@@ -33,6 +33,8 @@ export default {
     if (ability.can('create', group)) {
       return group.save();
     }
-    throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+    throw new GraphQLError(
+      context.i18next.t('common.errors.permissionNotGranted')
+    );
   },
 };

--- a/src/schema/mutation/addGroup.mutation.ts
+++ b/src/schema/mutation/addGroup.mutation.ts
@@ -16,12 +16,12 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     if (!config.get('user.groups.local')) {
       throw new GraphQLError(
-        context.i18next.t('errors.groupsManualCreationDisabled')
+        context.i18next.t('mutations.group.add.errors.manualCreationDisabled')
       );
     }
 
@@ -33,6 +33,6 @@ export default {
     if (ability.can('create', group)) {
       return group.save();
     }
-    throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+    throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
   },
 };

--- a/src/schema/mutation/addLayout.mutation.ts
+++ b/src/schema/mutation/addLayout.mutation.ts
@@ -18,12 +18,12 @@ export default {
   async resolve(parent, args, context) {
     if (args.form && args.resource) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddPageArguments')
+        context.i18next.t('mutations.layout.add.errors.invalidAddPageArguments')
       );
     }
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     // Edition of a resource
@@ -34,7 +34,7 @@ export default {
       const resource: Resource = await Resource.findOne(filters);
       if (!resource) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
       resource.layouts.push(args.layout);
@@ -48,7 +48,7 @@ export default {
       const form: Form = await Form.findOne(filters);
       if (!form) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
       form.layouts.push(args.layout);

--- a/src/schema/mutation/addPage.mutation.ts
+++ b/src/schema/mutation/addPage.mutation.ts
@@ -38,7 +38,9 @@ export default {
     // check permission
     const ability = await extendAbilityForPage(user, application);
     if (ability.cannot('create', 'Page')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     // Create the linked Workflow or Dashboard
     let pageName = '';
@@ -67,7 +69,9 @@ export default {
       case contentType.form: {
         const form = await Form.findById(content);
         if (!form) {
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         pageName = form.name;
         break;

--- a/src/schema/mutation/addPage.mutation.ts
+++ b/src/schema/mutation/addPage.mutation.ts
@@ -22,23 +22,23 @@ export default {
     // check user
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     // check inputs
     if (!args.application || !(args.type in contentType)) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddPageArguments')
+        context.i18next.t('mutations.page.add.errors.invalidArguments')
       );
     }
     // check data
     const application = await Application.findById(args.application);
     if (!application) {
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
     // check permission
     const ability = await extendAbilityForPage(user, application);
     if (ability.cannot('create', 'Page')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     // Create the linked Workflow or Dashboard
     let pageName = '';
@@ -67,7 +67,7 @@ export default {
       case contentType.form: {
         const form = await Form.findById(content);
         if (!form) {
-          throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
         }
         pageName = form.name;
         break;

--- a/src/schema/mutation/addPositionAttribute.mutation.ts
+++ b/src/schema/mutation/addPositionAttribute.mutation.ts
@@ -16,16 +16,16 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     const category = await PositionAttributeCategory.findById(
       args.positionAttribute.category
     ).populate('application');
     if (!category)
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     if (ability.cannot('update', category.application, 'users')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     let modifiedUser = await User.findById(args.user);
     if (modifiedUser) {
@@ -42,7 +42,7 @@ export default {
       });
       return modifiedUser;
     } else {
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
   },
 };

--- a/src/schema/mutation/addPositionAttribute.mutation.ts
+++ b/src/schema/mutation/addPositionAttribute.mutation.ts
@@ -25,7 +25,9 @@ export default {
     if (!category)
       throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     if (ability.cannot('update', category.application, 'users')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     let modifiedUser = await User.findById(args.user);
     if (modifiedUser) {

--- a/src/schema/mutation/addPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/addPositionAttributeCategory.mutation.ts
@@ -20,12 +20,12 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     const application = await Application.findById(args.application);
     if (!application)
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     if (ability.can('update', application)) {
       const category = new PositionAttributeCategory({
         title: args.title,
@@ -33,7 +33,7 @@ export default {
       });
       return category.save();
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/addPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/addPositionAttributeCategory.mutation.ts
@@ -33,7 +33,9 @@ export default {
       });
       return category.save();
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/addPullJob.mutation.ts
+++ b/src/schema/mutation/addPullJob.mutation.ts
@@ -35,7 +35,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = user.ability;
@@ -43,7 +43,7 @@ export default {
       if (args.convertTo) {
         const form = await Form.findById(args.convertTo);
         if (!form)
-          throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
 
       if (args.channel) {
@@ -52,7 +52,7 @@ export default {
         };
         const channel = await Channel.findOne(filters);
         if (!channel)
-          throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
 
       try {
@@ -87,7 +87,7 @@ export default {
         throw new GraphQLError(err.message);
       }
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/addPullJob.mutation.ts
+++ b/src/schema/mutation/addPullJob.mutation.ts
@@ -43,7 +43,9 @@ export default {
       if (args.convertTo) {
         const form = await Form.findById(args.convertTo);
         if (!form)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
       }
 
       if (args.channel) {
@@ -52,7 +54,9 @@ export default {
         };
         const channel = await Channel.findOne(filters);
         if (!channel)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
       }
 
       try {
@@ -87,7 +91,9 @@ export default {
         throw new GraphQLError(err.message);
       }
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/addRecord.mutation.ts
+++ b/src/schema/mutation/addRecord.mutation.ts
@@ -29,12 +29,15 @@ export default {
 
     // Get the form
     const form = await Form.findById(args.form);
-    if (!form) throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    if (!form)
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
 
     // Check the ability with permissions for this form
     const ability = await extendAbilityForRecords(user, form);
     if (ability.cannot('create', 'Record')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // Check unicity of record

--- a/src/schema/mutation/addRecord.mutation.ts
+++ b/src/schema/mutation/addRecord.mutation.ts
@@ -24,17 +24,17 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // Get the form
     const form = await Form.findById(args.form);
-    if (!form) throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+    if (!form) throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
 
     // Check the ability with permissions for this form
     const ability = await extendAbilityForRecords(user, form);
     if (ability.cannot('create', 'Record')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // Check unicity of record
@@ -57,7 +57,7 @@ export default {
         });
         if (uniqueRecordAlreadyExists) {
           throw new GraphQLError(
-            context.i18next.t('errors.permissionNotGranted')
+            context.i18next.t('common.errors.permissionNotGranted')
           );
         }
       }

--- a/src/schema/mutation/addReferenceData.mutation.ts
+++ b/src/schema/mutation/addReferenceData.mutation.ts
@@ -16,7 +16,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     if (ability.can('create', 'ReferenceData')) {
@@ -29,7 +29,7 @@ export default {
           (await ReferenceData.hasDuplicate(graphQLTypeName))
         ) {
           throw new GraphQLError(
-            context.i18next.t('errors.duplicatedGraphQLTypeName')
+            context.i18next.t('common.errors.duplicatedGraphQLTypeName')
           );
         }
 
@@ -54,10 +54,10 @@ export default {
         return referenceData.save();
       }
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddReferenceDataArguments')
+        context.i18next.t('mutations.reference.add.errors.invalidArguments')
       );
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/addReferenceData.mutation.ts
+++ b/src/schema/mutation/addReferenceData.mutation.ts
@@ -57,7 +57,9 @@ export default {
         context.i18next.t('mutations.reference.add.errors.invalidArguments')
       );
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/addRole.mutation.ts
+++ b/src/schema/mutation/addRole.mutation.ts
@@ -45,6 +45,8 @@ export default {
         return role.save();
       }
     }
-    throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+    throw new GraphQLError(
+      context.i18next.t('common.errors.permissionNotGranted')
+    );
   },
 };

--- a/src/schema/mutation/addRole.mutation.ts
+++ b/src/schema/mutation/addRole.mutation.ts
@@ -21,18 +21,18 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     if (args.application) {
       const application = await Application.findById(args.application);
       if (!application)
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       const role = new Role({
         title: args.title,
       });
       if (!application)
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       role.application = args.application;
       if (ability.can('create', role)) {
         return role.save();
@@ -45,6 +45,6 @@ export default {
         return role.save();
       }
     }
-    throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+    throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
   },
 };

--- a/src/schema/mutation/addRoleToUsers.mutation.ts
+++ b/src/schema/mutation/addRoleToUsers.mutation.ts
@@ -29,7 +29,8 @@ export default {
     }
     const ability: AppAbility = user.ability;
     const role = await Role.findById(args.role).populate('application');
-    if (!role) throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    if (!role)
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     // Check permissions depending if it's an application's user or a global user
     if (ability.cannot('update', 'User')) {
       if (role.application) {
@@ -52,7 +53,9 @@ export default {
     }
     // Prevent wrong emails to be invited.
     if (args.usernames.filter((x) => !validateEmail(x)).length > 0) {
-      throw new GraphQLError(context.i18next.t('common.errors.invalidEmailsInput'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.invalidEmailsInput')
+      );
     }
     // Perform the add role to users
     const invitedUsers: User[] = [];

--- a/src/schema/mutation/addRoleToUsers.mutation.ts
+++ b/src/schema/mutation/addRoleToUsers.mutation.ts
@@ -25,11 +25,11 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     const role = await Role.findById(args.role).populate('application');
-    if (!role) throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+    if (!role) throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     // Check permissions depending if it's an application's user or a global user
     if (ability.cannot('update', 'User')) {
       if (role.application) {
@@ -41,18 +41,18 @@ export default {
           .some((x) => x.type === permissions.canSeeUsers);
         if (!canUpdate) {
           throw new GraphQLError(
-            context.i18next.t('errors.permissionNotGranted')
+            context.i18next.t('common.errors.permissionNotGranted')
           );
         }
       } else {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     }
     // Prevent wrong emails to be invited.
     if (args.usernames.filter((x) => !validateEmail(x)).length > 0) {
-      throw new GraphQLError(context.i18next.t('errors.invalidEmailsInput'));
+      throw new GraphQLError(context.i18next.t('common.errors.invalidEmailsInput'));
     }
     // Perform the add role to users
     const invitedUsers: User[] = [];

--- a/src/schema/mutation/addStep.mutation.ts
+++ b/src/schema/mutation/addStep.mutation.ts
@@ -33,17 +33,17 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     if (!args.workflow || !(args.type in contentType)) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddStepArguments')
+        context.i18next.t('mutations.step.add.errors.invalidArguments')
       );
     }
     const page = await Page.findOne({ content: args.workflow });
     if (!page) {
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
     const application = await Application.findOne({
       pages: { $elemMatch: { $eq: mongoose.Types.ObjectId(page._id) } },
@@ -52,7 +52,7 @@ export default {
     if (ability.can('update', application)) {
       const workflow = await Workflow.findById(args.workflow);
       if (!workflow)
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       // Create a linked Dashboard if necessary
       if (args.type === contentType.dashboard) {
         stepName = 'Dashboard';
@@ -65,7 +65,7 @@ export default {
       } else {
         const form = await Form.findById(args.content);
         if (!form) {
-          throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
         }
         stepName = form.name;
       }
@@ -91,7 +91,7 @@ export default {
       await Workflow.findByIdAndUpdate(args.workflow, update);
       return step;
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/addStep.mutation.ts
+++ b/src/schema/mutation/addStep.mutation.ts
@@ -65,7 +65,9 @@ export default {
       } else {
         const form = await Form.findById(args.content);
         if (!form) {
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         stepName = form.name;
       }
@@ -91,7 +93,9 @@ export default {
       await Workflow.findByIdAndUpdate(args.workflow, update);
       return step;
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/addSubscription.mutation.ts
+++ b/src/schema/mutation/addSubscription.mutation.ts
@@ -26,17 +26,17 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     const application = await Application.findById(args.application);
     if (!application)
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
 
     if (args.convertTo) {
       const form = await Form.findById(args.convertTo);
       if (!form)
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 
     if (args.channel) {
@@ -46,7 +46,7 @@ export default {
       };
       const channel = await Channel.findOne(filters);
       if (!channel)
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 
     const subscription = {

--- a/src/schema/mutation/addTemplate.mutation.ts
+++ b/src/schema/mutation/addTemplate.mutation.ts
@@ -24,7 +24,9 @@ export default {
       args.application
     );
     if (ability.cannot('update', 'Template')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     const update = {

--- a/src/schema/mutation/addTemplate.mutation.ts
+++ b/src/schema/mutation/addTemplate.mutation.ts
@@ -17,14 +17,14 @@ export default {
   async resolve(_, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = extendAbilityForApplications(
       user,
       args.application
     );
     if (ability.cannot('update', 'Template')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     const update = {

--- a/src/schema/mutation/addUsers.mutation.ts
+++ b/src/schema/mutation/addUsers.mutation.ts
@@ -20,7 +20,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
 
@@ -35,17 +35,17 @@ export default {
           .some((x) => x.type === permissions.canSeeUsers);
         if (!canUpdate) {
           throw new GraphQLError(
-            context.i18next.t('errors.permissionNotGranted')
+            context.i18next.t('common.errors.permissionNotGranted')
           );
         }
       } else {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     }
     if (args.users.filter((x) => !validateEmail(x.email)).length > 0) {
-      throw new GraphQLError(context.i18next.t('errors.invalidEmailsInput'));
+      throw new GraphQLError(context.i18next.t('common.errors.invalidEmailsInput'));
     }
     // Separate registered users and new users
     const invitedUsers: User[] = [];

--- a/src/schema/mutation/addUsers.mutation.ts
+++ b/src/schema/mutation/addUsers.mutation.ts
@@ -45,7 +45,9 @@ export default {
       }
     }
     if (args.users.filter((x) => !validateEmail(x.email)).length > 0) {
-      throw new GraphQLError(context.i18next.t('common.errors.invalidEmailsInput'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.invalidEmailsInput')
+      );
     }
     // Separate registered users and new users
     const invitedUsers: User[] = [];

--- a/src/schema/mutation/addWorkflow.mutation.ts
+++ b/src/schema/mutation/addWorkflow.mutation.ts
@@ -23,20 +23,20 @@ export default {
   async resolve(parent, args, context) {
     if (!args.page) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddWorkflowArguments')
+        context.i18next.t('mutations.workflow.add.errors.invalidArguments')
       );
     } else {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
       const ability: AppAbility = user.ability;
       if (ability.can('create', 'Workflow')) {
         const page = await Page.findById(args.page);
         if (!page)
-          throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
         if (page.type !== contentType.workflow)
-          throw new GraphQLError(context.i18next.t('errors.pageTypeError'));
+          throw new GraphQLError(context.i18next.t('mutations.workflow.add.errors.pageTypeError'));
         // Create a workflow.
         const workflow = new Workflow({
           name: args.name,
@@ -52,7 +52,7 @@ export default {
         return workflow;
       } else {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     }

--- a/src/schema/mutation/addWorkflow.mutation.ts
+++ b/src/schema/mutation/addWorkflow.mutation.ts
@@ -28,15 +28,21 @@ export default {
     } else {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       if (ability.can('create', 'Workflow')) {
         const page = await Page.findById(args.page);
         if (!page)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         if (page.type !== contentType.workflow)
-          throw new GraphQLError(context.i18next.t('mutations.workflow.add.errors.pageTypeError'));
+          throw new GraphQLError(
+            context.i18next.t('mutations.workflow.add.errors.pageTypeError')
+          );
         // Create a workflow.
         const workflow = new Workflow({
           name: args.name,

--- a/src/schema/mutation/convertRecord.mutation.ts
+++ b/src/schema/mutation/convertRecord.mutation.ts
@@ -24,7 +24,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // Get the record and forms
@@ -32,7 +32,7 @@ export default {
     const oldForm = await Form.findById(oldRecord.form);
     const targetForm = await Form.findById(args.form);
     if (!oldForm.resource.equals(targetForm.resource))
-      throw new GraphQLError(context.i18next.t('errors.invalidConversion'));
+      throw new GraphQLError(context.i18next.t('mutations.record.convert.errors.invalidConversion'));
 
     // Check permissions
     const oldFormAbility = await extendAbilityForRecords(user, oldForm);
@@ -41,7 +41,7 @@ export default {
       oldFormAbility.cannot('update', oldRecord) ||
       targetFormAbility.cannot('create', 'Record')
     ) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // Convert the record

--- a/src/schema/mutation/convertRecord.mutation.ts
+++ b/src/schema/mutation/convertRecord.mutation.ts
@@ -32,7 +32,9 @@ export default {
     const oldForm = await Form.findById(oldRecord.form);
     const targetForm = await Form.findById(args.form);
     if (!oldForm.resource.equals(targetForm.resource))
-      throw new GraphQLError(context.i18next.t('mutations.record.convert.errors.invalidConversion'));
+      throw new GraphQLError(
+        context.i18next.t('mutations.record.convert.errors.invalidConversion')
+      );
 
     // Check permissions
     const oldFormAbility = await extendAbilityForRecords(user, oldForm);
@@ -41,7 +43,9 @@ export default {
       oldFormAbility.cannot('update', oldRecord) ||
       targetFormAbility.cannot('create', 'Record')
     ) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // Convert the record

--- a/src/schema/mutation/deleteAggregation.mutation.ts
+++ b/src/schema/mutation/deleteAggregation.mutation.ts
@@ -16,12 +16,12 @@ export default {
   async resolve(parent, args, context) {
     if (!args.resource) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidDeleteAggregationArguments')
+        context.i18next.t('mutations.aggregation.delete.errors.invalidArguments')
       );
     }
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     // Edition of a resource
@@ -32,7 +32,7 @@ export default {
       const resource: Resource = await Resource.findOne(filters);
       if (!resource) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
 

--- a/src/schema/mutation/deleteAggregation.mutation.ts
+++ b/src/schema/mutation/deleteAggregation.mutation.ts
@@ -16,7 +16,9 @@ export default {
   async resolve(parent, args, context) {
     if (!args.resource) {
       throw new GraphQLError(
-        context.i18next.t('mutations.aggregation.delete.errors.invalidArguments')
+        context.i18next.t(
+          'mutations.aggregation.delete.errors.invalidArguments'
+        )
       );
     }
     const user = context.user;

--- a/src/schema/mutation/deleteApiConfiguration.mutation.ts
+++ b/src/schema/mutation/deleteApiConfiguration.mutation.ts
@@ -17,7 +17,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     const filters = ApiConfiguration.accessibleBy(ability, 'delete')
@@ -25,7 +25,7 @@ export default {
       .getFilter();
     const apiConfiguration = await ApiConfiguration.findOneAndDelete(filters);
     if (!apiConfiguration)
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     if (apiConfiguration.status === status.active) {
       buildTypes();
     }

--- a/src/schema/mutation/deleteApiConfiguration.mutation.ts
+++ b/src/schema/mutation/deleteApiConfiguration.mutation.ts
@@ -25,7 +25,9 @@ export default {
       .getFilter();
     const apiConfiguration = await ApiConfiguration.findOneAndDelete(filters);
     if (!apiConfiguration)
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     if (apiConfiguration.status === status.active) {
       buildTypes();
     }

--- a/src/schema/mutation/deleteApplication.mutation.ts
+++ b/src/schema/mutation/deleteApplication.mutation.ts
@@ -19,7 +19,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     // Delete the application
     const ability: AppAbility = context.user.ability;
@@ -27,7 +27,7 @@ export default {
       .where({ _id: args.id })
       .getFilter();
     const application = await Application.findOneAndDelete(filters);
-    if (!application) throw new GraphQLError('errors.permissionNotGranted');
+    if (!application) throw new GraphQLError('common.errors.permissionNotGranted');
     // Send notification
     const channel = await Channel.findOne({ title: channels.applications });
     const notification = new Notification({

--- a/src/schema/mutation/deleteApplication.mutation.ts
+++ b/src/schema/mutation/deleteApplication.mutation.ts
@@ -27,7 +27,8 @@ export default {
       .where({ _id: args.id })
       .getFilter();
     const application = await Application.findOneAndDelete(filters);
-    if (!application) throw new GraphQLError('common.errors.permissionNotGranted');
+    if (!application)
+      throw new GraphQLError('common.errors.permissionNotGranted');
     // Send notification
     const channel = await Channel.findOne({ title: channels.applications });
     const notification = new Notification({

--- a/src/schema/mutation/deleteChannel.mutation.ts
+++ b/src/schema/mutation/deleteChannel.mutation.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -32,7 +32,7 @@ export default {
       }
       return Channel.findByIdAndDelete(args.id);
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/deleteChannel.mutation.ts
+++ b/src/schema/mutation/deleteChannel.mutation.ts
@@ -32,7 +32,9 @@ export default {
       }
       return Channel.findByIdAndDelete(args.id);
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/deleteDashboard.mutation.ts
+++ b/src/schema/mutation/deleteDashboard.mutation.ts
@@ -33,7 +33,9 @@ export default {
       if (page || step) {
         return Dashboard.findByIdAndDelete(args.id);
       }
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/deleteDashboard.mutation.ts
+++ b/src/schema/mutation/deleteDashboard.mutation.ts
@@ -17,7 +17,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -33,7 +33,7 @@ export default {
       if (page || step) {
         return Dashboard.findByIdAndDelete(args.id);
       }
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/deleteDistributionList.mutation.ts
+++ b/src/schema/mutation/deleteDistributionList.mutation.ts
@@ -23,7 +23,9 @@ export default {
       args.application
     );
     if (ability.cannot('update', 'DistributionList')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     const update = {

--- a/src/schema/mutation/deleteDistributionList.mutation.ts
+++ b/src/schema/mutation/deleteDistributionList.mutation.ts
@@ -16,14 +16,14 @@ export default {
   async resolve(_, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = extendAbilityForApplications(
       user,
       args.application
     );
     if (ability.cannot('update', 'DistributionList')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     const update = {

--- a/src/schema/mutation/deleteForm.mutation.ts
+++ b/src/schema/mutation/deleteForm.mutation.ts
@@ -28,7 +28,9 @@ export default {
       .getFilter();
     const form = await Form.findOne(filters);
     if (!form) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     // if is core form we have to delete the linked forms and resource
     if (form.core) {

--- a/src/schema/mutation/deleteForm.mutation.ts
+++ b/src/schema/mutation/deleteForm.mutation.ts
@@ -17,7 +17,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     // Get ability
     const ability: AppAbility = user.ability;
@@ -28,7 +28,7 @@ export default {
       .getFilter();
     const form = await Form.findOne(filters);
     if (!form) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     // if is core form we have to delete the linked forms and resource
     if (form.core) {

--- a/src/schema/mutation/deleteGroup.mutation.ts
+++ b/src/schema/mutation/deleteGroup.mutation.ts
@@ -27,7 +27,9 @@ export default {
     if (group) {
       return group;
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/deleteGroup.mutation.ts
+++ b/src/schema/mutation/deleteGroup.mutation.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -27,7 +27,7 @@ export default {
     if (group) {
       return group;
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/deleteLayout.mutation.ts
+++ b/src/schema/mutation/deleteLayout.mutation.ts
@@ -17,12 +17,12 @@ export default {
   async resolve(parent, args, context) {
     if (args.form && args.resource) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddPageArguments')
+        context.i18next.t('mutations.layout.delete.errors.invalidArguments')
       );
     }
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     // Edition of a resource
@@ -33,7 +33,7 @@ export default {
       const resource: Resource = await Resource.findOne(filters);
       if (!resource) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
       const layout = resource.layouts.id(args.id).remove();
@@ -47,7 +47,7 @@ export default {
       const form: Form = await Form.findOne(filters);
       if (!form) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
       const layout = form.layouts.id(args.id).remove();

--- a/src/schema/mutation/deletePage.mutation.ts
+++ b/src/schema/mutation/deletePage.mutation.ts
@@ -17,7 +17,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user)
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
 
     // get data
     const page = await Page.findById(args.id);
@@ -25,7 +25,7 @@ export default {
     // get permissions
     const ability = await extendAbilityForPage(user, page);
     if (ability.cannot('delete', page)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // delete page

--- a/src/schema/mutation/deletePage.mutation.ts
+++ b/src/schema/mutation/deletePage.mutation.ts
@@ -25,7 +25,9 @@ export default {
     // get permissions
     const ability = await extendAbilityForPage(user, page);
     if (ability.cannot('delete', page)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // delete page

--- a/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
@@ -17,16 +17,16 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = context.user.ability;
     const application = await Application.findById(args.application);
     if (!application)
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     if (ability.can('update', application)) {
       return PositionAttributeCategory.findByIdAndDelete(args.id);
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
@@ -26,7 +26,9 @@ export default {
     if (ability.can('update', application)) {
       return PositionAttributeCategory.findByIdAndDelete(args.id);
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/deletePullJob.mutation.ts
+++ b/src/schema/mutation/deletePullJob.mutation.ts
@@ -24,7 +24,9 @@ export default {
       .getFilter();
     const pullJob = await PullJob.findOneAndDelete(filters);
     if (!pullJob)
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
 
     unscheduleJob(pullJob);
     return pullJob;

--- a/src/schema/mutation/deletePullJob.mutation.ts
+++ b/src/schema/mutation/deletePullJob.mutation.ts
@@ -15,7 +15,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
 
@@ -24,7 +24,7 @@ export default {
       .getFilter();
     const pullJob = await PullJob.findOneAndDelete(filters);
     if (!pullJob)
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
 
     unscheduleJob(pullJob);
     return pullJob;

--- a/src/schema/mutation/deleteRecord.mutation.ts
+++ b/src/schema/mutation/deleteRecord.mutation.ts
@@ -22,7 +22,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // Get the record and form objects
@@ -32,7 +32,7 @@ export default {
     // Check the ability
     const ability = await extendAbilityForRecords(user, form);
     if (ability.cannot('delete', record)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // Delete the record

--- a/src/schema/mutation/deleteRecord.mutation.ts
+++ b/src/schema/mutation/deleteRecord.mutation.ts
@@ -32,7 +32,9 @@ export default {
     // Check the ability
     const ability = await extendAbilityForRecords(user, form);
     if (ability.cannot('delete', record)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // Delete the record

--- a/src/schema/mutation/deleteRecords.mutation.ts
+++ b/src/schema/mutation/deleteRecords.mutation.ts
@@ -23,7 +23,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // Get records and forms objects

--- a/src/schema/mutation/deleteReferenceData.mutation.ts
+++ b/src/schema/mutation/deleteReferenceData.mutation.ts
@@ -24,7 +24,9 @@ export default {
       .getFilter();
     const referenceData = await ReferenceData.findOneAndDelete(filters);
     if (!referenceData) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // Rebuild schema

--- a/src/schema/mutation/deleteReferenceData.mutation.ts
+++ b/src/schema/mutation/deleteReferenceData.mutation.ts
@@ -16,7 +16,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     const filters = ReferenceData.accessibleBy(ability, 'delete')
@@ -24,7 +24,7 @@ export default {
       .getFilter();
     const referenceData = await ReferenceData.findOneAndDelete(filters);
     if (!referenceData) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // Rebuild schema

--- a/src/schema/mutation/deleteResource.mutation.ts
+++ b/src/schema/mutation/deleteResource.mutation.ts
@@ -17,7 +17,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = user.ability;
@@ -28,7 +28,7 @@ export default {
 
     /// Resource is not deleted, user does not have permission to do the deletion
     if (!deletedResource) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     buildTypes();

--- a/src/schema/mutation/deleteResource.mutation.ts
+++ b/src/schema/mutation/deleteResource.mutation.ts
@@ -28,7 +28,9 @@ export default {
 
     /// Resource is not deleted, user does not have permission to do the deletion
     if (!deletedResource) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     buildTypes();

--- a/src/schema/mutation/deleteRole.mutation.ts
+++ b/src/schema/mutation/deleteRole.mutation.ts
@@ -27,7 +27,9 @@ export default {
     if (role) {
       return role;
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/deleteRole.mutation.ts
+++ b/src/schema/mutation/deleteRole.mutation.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -27,7 +27,7 @@ export default {
     if (role) {
       return role;
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/deleteStep.mutation.ts
+++ b/src/schema/mutation/deleteStep.mutation.ts
@@ -17,13 +17,13 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const step = await Step.findById(args.id);
     const ability = await extendAbilityForStep(user, step);
     if (ability.cannot('delete', step)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     await step.deleteOne();

--- a/src/schema/mutation/deleteStep.mutation.ts
+++ b/src/schema/mutation/deleteStep.mutation.ts
@@ -23,7 +23,9 @@ export default {
     const step = await Step.findById(args.id);
     const ability = await extendAbilityForStep(user, step);
     if (ability.cannot('delete', step)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     await step.deleteOne();

--- a/src/schema/mutation/deleteSubscription.mutation.ts
+++ b/src/schema/mutation/deleteSubscription.mutation.ts
@@ -23,7 +23,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -32,7 +32,7 @@ export default {
       .getFilter();
     const application = await Application.findOne(filters);
     if (!application)
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     application.subscriptions = await application.subscriptions.filter(
       (sub) => sub.routingKey !== args.routingKey
     );

--- a/src/schema/mutation/deleteTemplate.mutation.ts
+++ b/src/schema/mutation/deleteTemplate.mutation.ts
@@ -23,7 +23,9 @@ export default {
       args.application
     );
     if (ability.cannot('update', 'Template')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     const update = {

--- a/src/schema/mutation/deleteTemplate.mutation.ts
+++ b/src/schema/mutation/deleteTemplate.mutation.ts
@@ -16,14 +16,14 @@ export default {
   async resolve(_, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = extendAbilityForApplications(
       user,
       args.application
     );
     if (ability.cannot('update', 'Template')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     const update = {

--- a/src/schema/mutation/deleteUsers.mutation.ts
+++ b/src/schema/mutation/deleteUsers.mutation.ts
@@ -21,14 +21,14 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     if (ability.can('delete', 'User')) {
       const result = await User.deleteMany({ _id: { $in: args.ids } });
       return result.deletedCount;
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/deleteUsers.mutation.ts
+++ b/src/schema/mutation/deleteUsers.mutation.ts
@@ -28,7 +28,9 @@ export default {
       const result = await User.deleteMany({ _id: { $in: args.ids } });
       return result.deletedCount;
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/deleteUsersFromApplication.mutation.ts
+++ b/src/schema/mutation/deleteUsersFromApplication.mutation.ts
@@ -18,7 +18,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     // Test global permissions and application permission
@@ -33,7 +33,7 @@ export default {
       );
       if (!canDelete) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     }

--- a/src/schema/mutation/deleteWorkflow.mutation.ts
+++ b/src/schema/mutation/deleteWorkflow.mutation.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -35,7 +35,7 @@ export default {
       }
     }
     if (!workflow)
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     return workflow;
   },
 };

--- a/src/schema/mutation/deleteWorkflow.mutation.ts
+++ b/src/schema/mutation/deleteWorkflow.mutation.ts
@@ -35,7 +35,9 @@ export default {
       }
     }
     if (!workflow)
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     return workflow;
   },
 };

--- a/src/schema/mutation/duplicateApplication.mutation.ts
+++ b/src/schema/mutation/duplicateApplication.mutation.ts
@@ -24,7 +24,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -32,7 +32,7 @@ export default {
       const baseApplication = await Application.findById(args.application);
       const copiedPages = await duplicatePages(baseApplication);
       if (!baseApplication)
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       if (args.name !== '') {
         const application = new Application({
           name: args.name,
@@ -76,10 +76,10 @@ export default {
         return application;
       }
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddApplicationArguments')
+        context.i18next.t('mutations.application.duplicate.errors.invalidArguments')
       );
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/duplicateApplication.mutation.ts
+++ b/src/schema/mutation/duplicateApplication.mutation.ts
@@ -76,10 +76,14 @@ export default {
         return application;
       }
       throw new GraphQLError(
-        context.i18next.t('mutations.application.duplicate.errors.invalidArguments')
+        context.i18next.t(
+          'mutations.application.duplicate.errors.invalidArguments'
+        )
       );
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/duplicatePage.mutation.ts
+++ b/src/schema/mutation/duplicatePage.mutation.ts
@@ -53,7 +53,9 @@ export default {
         return newPage;
       }
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/duplicatePage.mutation.ts
+++ b/src/schema/mutation/duplicatePage.mutation.ts
@@ -18,12 +18,12 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     const application = await Application.findById(args.application);
     if (!application)
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
 
     // Check access to the application
     if (ability.can('update', application)) {
@@ -53,7 +53,7 @@ export default {
         return newPage;
       }
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/editAggregation.mutation.ts
+++ b/src/schema/mutation/editAggregation.mutation.ts
@@ -18,12 +18,12 @@ export default {
   async resolve(parent, args, context) {
     if (!args.resource || !args.aggregation) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditAggregationArguments')
+        context.i18next.t('mutations.aggregation.edit.errors.invalidEArguments')
       );
     }
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     // Edition of a resource
@@ -34,7 +34,7 @@ export default {
       const resource: Resource = await Resource.findOne(filters);
       if (!resource) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
 

--- a/src/schema/mutation/editAggregation.mutation.ts
+++ b/src/schema/mutation/editAggregation.mutation.ts
@@ -18,7 +18,7 @@ export default {
   async resolve(parent, args, context) {
     if (!args.resource || !args.aggregation) {
       throw new GraphQLError(
-        context.i18next.t('mutations.aggregation.edit.errors.invalidEArguments')
+        context.i18next.t('mutations.aggregation.edit.errors.invalidArguments')
       );
     }
     const user = context.user;

--- a/src/schema/mutation/editApiConfiguration.mutation.ts
+++ b/src/schema/mutation/editApiConfiguration.mutation.ts
@@ -48,7 +48,9 @@ export default {
       !args.permissions
     ) {
       throw new GraphQLError(
-        context.i18next.t('mutations.apiConfiguration.edit.errors.invalidArguments')
+        context.i18next.t(
+          'mutations.apiConfiguration.edit.errors.invalidArguments'
+        )
       );
     }
     const update = {};
@@ -85,7 +87,9 @@ export default {
       }
       return apiConfiguration;
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/editApiConfiguration.mutation.ts
+++ b/src/schema/mutation/editApiConfiguration.mutation.ts
@@ -34,7 +34,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     if (
@@ -48,7 +48,7 @@ export default {
       !args.permissions
     ) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditApiConfigurationArguments')
+        context.i18next.t('mutations.apiConfiguration.edit.errors.invalidArguments')
       );
     }
     const update = {};
@@ -85,7 +85,7 @@ export default {
       }
       return apiConfiguration;
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/editApplication.mutation.ts
+++ b/src/schema/mutation/editApplication.mutation.ts
@@ -31,7 +31,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = context.user.ability;
     if (
@@ -43,7 +43,7 @@ export default {
         !args.permissions)
     ) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditApplicationArguments')
+        context.i18next.t('mutations.application.duplicate.errors.invalidArguments')
       );
     }
     const filters = Application.accessibleBy(ability, 'update')
@@ -51,7 +51,7 @@ export default {
       .getFilter();
     let application = await Application.findOne(filters);
     if (!application) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     if (
       application.lockedBy &&

--- a/src/schema/mutation/editApplication.mutation.ts
+++ b/src/schema/mutation/editApplication.mutation.ts
@@ -43,7 +43,9 @@ export default {
         !args.permissions)
     ) {
       throw new GraphQLError(
-        context.i18next.t('mutations.application.duplicate.errors.invalidArguments')
+        context.i18next.t(
+          'mutations.application.duplicate.errors.invalidArguments'
+        )
       );
     }
     const filters = Application.accessibleBy(ability, 'update')
@@ -51,7 +53,9 @@ export default {
       .getFilter();
     let application = await Application.findOne(filters);
     if (!application) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     if (
       application.lockedBy &&

--- a/src/schema/mutation/editChannel.mutation.ts
+++ b/src/schema/mutation/editChannel.mutation.ts
@@ -22,12 +22,12 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = context.user.ability;
     const channel = await Channel.findById(args.id);
     if (!channel)
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     if (ability.can('update', channel)) {
       return Channel.findByIdAndUpdate(
         args.id,
@@ -37,7 +37,7 @@ export default {
         { new: true }
       );
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/editChannel.mutation.ts
+++ b/src/schema/mutation/editChannel.mutation.ts
@@ -37,7 +37,9 @@ export default {
         { new: true }
       );
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/editDashboard.mutation.ts
+++ b/src/schema/mutation/editDashboard.mutation.ts
@@ -24,12 +24,12 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     // check inputs
     if (!args || (!args.name && !args.structure)) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditDashboardArguments')
+        context.i18next.t('mutations.dashboard.edit.errors.invalidArguments')
       );
     }
     // get data
@@ -37,7 +37,7 @@ export default {
     // check permissions
     const ability = await extendAbilityForContent(user, dashboard);
     if (ability.cannot('update', dashboard)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     // do the update on dashboard
     const updateDashboard: {

--- a/src/schema/mutation/editDashboard.mutation.ts
+++ b/src/schema/mutation/editDashboard.mutation.ts
@@ -37,7 +37,9 @@ export default {
     // check permissions
     const ability = await extendAbilityForContent(user, dashboard);
     if (ability.cannot('update', dashboard)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     // do the update on dashboard
     const updateDashboard: {

--- a/src/schema/mutation/editDistributionList.mutation.ts
+++ b/src/schema/mutation/editDistributionList.mutation.ts
@@ -19,20 +19,20 @@ export default {
   async resolve(_, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = extendAbilityForApplications(
       user,
       args.application
     );
     if (ability.cannot('update', 'DistributionList')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     // Prevent wrong emails to be saved
     if (
       args.distributionList.emails.filter((x) => !validateEmail(x)).length > 0
     ) {
-      throw new GraphQLError(context.i18next.t('errors.invalidEmailsInput'));
+      throw new GraphQLError(context.i18next.t('common.errors.invalidEmailsInput'));
     }
 
     const update = {

--- a/src/schema/mutation/editDistributionList.mutation.ts
+++ b/src/schema/mutation/editDistributionList.mutation.ts
@@ -26,13 +26,17 @@ export default {
       args.application
     );
     if (ability.cannot('update', 'DistributionList')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     // Prevent wrong emails to be saved
     if (
       args.distributionList.emails.filter((x) => !validateEmail(x)).length > 0
     ) {
-      throw new GraphQLError(context.i18next.t('common.errors.invalidEmailsInput'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.invalidEmailsInput')
+      );
     }
 
     const update = {

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -81,14 +81,14 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // Permission check
     const ability: AppAbility = user.ability;
     const form = await Form.findById(args.id);
     if (ability.cannot('update', form)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // Initialize the update object --- TODO = put interface
@@ -109,7 +109,7 @@ export default {
         (await ReferenceData.hasDuplicate(graphQLTypeName))
       ) {
         throw new GraphQLError(
-          context.i18next.t('errors.duplicatedGraphQLTypeName')
+          context.i18next.t('common.errors.duplicatedGraphQLTypeName')
         );
       }
       update.name = args.name;
@@ -222,7 +222,7 @@ export default {
             })
           ) {
             throw new GraphQLError(
-              i18next.t('errors.relatedNameDuplicated', {
+              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
                 name: field.relatedName,
               })
             );
@@ -235,7 +235,7 @@ export default {
             })
           ) {
             throw new GraphQLError(
-              i18next.t('errors.relatedNameDuplicated', {
+              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
                 name: field.relatedName,
               })
             );
@@ -330,7 +330,7 @@ export default {
             }
             if (!fieldExists) {
               throw new GraphQLError(
-                i18next.t('errors.coreFieldMissing', { name: field.name })
+                i18next.t('mutations.form.edit.errors.coreFieldMissing', { name: field.name })
               );
             }
             fieldExists = false;

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -88,7 +88,9 @@ export default {
     const ability: AppAbility = user.ability;
     const form = await Form.findById(args.id);
     if (ability.cannot('update', form)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // Initialize the update object --- TODO = put interface
@@ -330,7 +332,9 @@ export default {
             }
             if (!fieldExists) {
               throw new GraphQLError(
-                i18next.t('mutations.form.edit.errors.coreFieldMissing', { name: field.name })
+                i18next.t('mutations.form.edit.errors.coreFieldMissing', {
+                  name: field.name,
+                })
               );
             }
             fieldExists = false;

--- a/src/schema/mutation/editLayout.mutation.ts
+++ b/src/schema/mutation/editLayout.mutation.ts
@@ -18,7 +18,9 @@ export default {
   async resolve(parent, args, context) {
     if (args.form && args.resource) {
       throw new GraphQLError(
-        context.i18next.t('mutations.layout.edit.errors.invalidAddPageArguments')
+        context.i18next.t(
+          'mutations.layout.edit.errors.invalidAddPageArguments'
+        )
       );
     }
     const user = context.user;

--- a/src/schema/mutation/editLayout.mutation.ts
+++ b/src/schema/mutation/editLayout.mutation.ts
@@ -18,12 +18,12 @@ export default {
   async resolve(parent, args, context) {
     if (args.form && args.resource) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidAddPageArguments')
+        context.i18next.t('mutations.layout.edit.errors.invalidAddPageArguments')
       );
     }
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     // Edition of a resource
@@ -34,7 +34,7 @@ export default {
       const resource: Resource = await Resource.findOne(filters);
       if (!resource) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
       resource.layouts.id(args.id).name = args.layout.name;
@@ -50,7 +50,7 @@ export default {
       const form: Form = await Form.findOne(filters);
       if (!form) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
       form.layouts.id(args.id).name = args.layout.name;

--- a/src/schema/mutation/editPage.mutation.ts
+++ b/src/schema/mutation/editPage.mutation.ts
@@ -42,22 +42,22 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     // check inputs
     if (!args || (!args.name && !args.permissions))
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditPageArguments')
+        context.i18next.t('mutations.page.edit.errors.invalidArguments')
       );
     // get data
     let page = await Page.findById(args.id);
     if (!page) {
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
     // check permission
     const ability = await extendAbilityForPage(user, page);
     if (ability.cannot('update', page)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // update name

--- a/src/schema/mutation/editPage.mutation.ts
+++ b/src/schema/mutation/editPage.mutation.ts
@@ -57,7 +57,9 @@ export default {
     // check permission
     const ability = await extendAbilityForPage(user, page);
     if (ability.cannot('update', page)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // update name

--- a/src/schema/mutation/editPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/editPositionAttributeCategory.mutation.ts
@@ -23,12 +23,12 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = context.user.ability;
     const application = await Application.findById(args.application);
     if (!application)
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     if (ability.can('update', application)) {
       return PositionAttributeCategory.findByIdAndUpdate(
         args.id,
@@ -38,7 +38,7 @@ export default {
         { new: true }
       );
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/editPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/editPositionAttributeCategory.mutation.ts
@@ -38,7 +38,9 @@ export default {
         { new: true }
       );
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/editPullJob.mutation.ts
+++ b/src/schema/mutation/editPullJob.mutation.ts
@@ -35,14 +35,14 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
 
     if (args.convertTo) {
       const form = await Form.findById(args.convertTo);
       if (!form)
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 
     if (args.channel) {
@@ -51,7 +51,7 @@ export default {
       };
       const channel = await Channel.findOne(filters);
       if (!channel)
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 
     const update = {};
@@ -80,7 +80,7 @@ export default {
         model: 'ApiConfiguration',
       });
       if (!pullJob)
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       if (pullJob.status === status.active) {
         scheduleJob(pullJob);
       } else {

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -83,7 +83,9 @@ export default {
       ability.cannot('update', oldRecord) ||
       hasInaccessibleFields(oldRecord, args.data, ability)
     ) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // Update record
@@ -109,7 +111,9 @@ export default {
         template = await Form.findById(args.template, 'fields resource');
         if (!template.resource.equals(parentForm.resource)) {
           throw new GraphQLError(
-            context.i18next.t('mutations.record.edit.errors.wrongTemplateProvided')
+            context.i18next.t(
+              'mutations.record.edit.errors.wrongTemplateProvided'
+            )
           );
         }
       } else {

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -57,14 +57,14 @@ export default {
   async resolve(parent, args, context) {
     if (!args.data && !args.version) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditRecordArguments')
+        context.i18next.t('mutations.record.edit.errors.invalidArguments')
       );
     }
 
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // Get record and form
@@ -74,7 +74,7 @@ export default {
       'fields permissions resource structure'
     );
     if (!oldRecord || !parentForm) {
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 
     // Check permissions with two layers
@@ -83,7 +83,7 @@ export default {
       ability.cannot('update', oldRecord) ||
       hasInaccessibleFields(oldRecord, args.data, ability)
     ) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // Update record
@@ -109,7 +109,7 @@ export default {
         template = await Form.findById(args.template, 'fields resource');
         if (!template.resource.equals(parentForm.resource)) {
           throw new GraphQLError(
-            context.i18next.t('errors.wrongTemplateProvided')
+            context.i18next.t('mutations.record.edit.errors.wrongTemplateProvided')
           );
         }
       } else {

--- a/src/schema/mutation/editRecords.mutation.ts
+++ b/src/schema/mutation/editRecords.mutation.ts
@@ -82,7 +82,9 @@ export default {
             );
             if (!template.resource.equals(record.form.resource)) {
               throw new GraphQLError(
-                context.i18next.t('mutations.record.edit.errors.wrongTemplateProvided')
+                context.i18next.t(
+                  'mutations.record.edit.errors.wrongTemplateProvided'
+                )
               );
             }
             fields = template.fields;

--- a/src/schema/mutation/editRecords.mutation.ts
+++ b/src/schema/mutation/editRecords.mutation.ts
@@ -39,13 +39,13 @@ export default {
   async resolve(parent, args, context) {
     if (!args.data) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditRecordArguments')
+        context.i18next.t('mutations.record.edit.errors.invalidArguments')
       );
     }
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // Get records and forms
@@ -82,7 +82,7 @@ export default {
             );
             if (!template.resource.equals(record.form.resource)) {
               throw new GraphQLError(
-                context.i18next.t('errors.wrongTemplateProvided')
+                context.i18next.t('mutations.record.edit.errors.wrongTemplateProvided')
               );
             }
             fields = template.fields;

--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -38,7 +38,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
     // Build update
@@ -56,7 +56,7 @@ export default {
         (await Form.hasDuplicate(graphQLTypeName)) ||
         (await ReferenceData.hasDuplicate(graphQLTypeName, args.id))
       ) {
-        throw new GraphQLError(context.i18next.t('errors.formResDuplicated'));
+        throw new GraphQLError(context.i18next.t('mutations.reference.edit.errors.formResDuplicated'));
       }
       update.graphQLTypeName = ReferenceData.getGraphQLTypeName(args.name);
     }
@@ -68,7 +68,7 @@ export default {
     }
     if (Object.keys(update).length <= 1) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditReferenceDataArguments')
+        context.i18next.t('mutations.reference.edit.errors.invalidArguments')
       );
     }
     const filters = ReferenceData.accessibleBy(ability, 'update')
@@ -83,7 +83,7 @@ export default {
       buildTypes();
       return referenceData;
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -56,7 +56,9 @@ export default {
         (await Form.hasDuplicate(graphQLTypeName)) ||
         (await ReferenceData.hasDuplicate(graphQLTypeName, args.id))
       ) {
-        throw new GraphQLError(context.i18next.t('mutations.reference.edit.errors.formResDuplicated'));
+        throw new GraphQLError(
+          context.i18next.t('mutations.reference.edit.errors.formResDuplicated')
+        );
       }
       update.graphQLTypeName = ReferenceData.getGraphQLTypeName(args.name);
     }
@@ -83,7 +85,9 @@ export default {
       buildTypes();
       return referenceData;
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -117,14 +117,14 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     if (
       !args ||
       (!args.fields && !args.permissions && !args.fieldsPermissions)
     ) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditResourceArguments')
+        context.i18next.t('mutations.resource.edit.errors.invalidArguments')
       );
     }
 
@@ -132,7 +132,7 @@ export default {
     const ability: AppAbility = user.ability;
     const resource = await Resource.findById(args.id);
     if (ability.cannot('update', resource)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // Create the update object

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -132,7 +132,9 @@ export default {
     const ability: AppAbility = user.ability;
     const resource = await Resource.findById(args.id);
     if (ability.cannot('update', resource)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // Create the update object

--- a/src/schema/mutation/editRole.mutation.ts
+++ b/src/schema/mutation/editRole.mutation.ts
@@ -31,7 +31,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const autoAssignmentUpdate: any = {};
@@ -82,7 +82,7 @@ export default {
       { new: true }
     );
     if (!role) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     return role;
   },

--- a/src/schema/mutation/editRole.mutation.ts
+++ b/src/schema/mutation/editRole.mutation.ts
@@ -82,7 +82,9 @@ export default {
       { new: true }
     );
     if (!role) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     return role;
   },

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -43,7 +43,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     // check inputs
     if (
@@ -51,14 +51,14 @@ export default {
       (!args.name && !args.type && !args.content && !args.permissions)
     ) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditStepArguments')
+        context.i18next.t('mutations.step.edit.errors.invalidArguments')
       );
     }
     // get data and check permissions
     let step = await Step.findById(args.id);
     const ability = await extendAbilityForStep(user, step);
     if (ability.cannot('update', step)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     // check the new content exists
     if (args.content) {
@@ -74,7 +74,7 @@ export default {
           break;
       }
       if (!content)
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 
     // defining what to update

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -58,7 +58,9 @@ export default {
     let step = await Step.findById(args.id);
     const ability = await extendAbilityForStep(user, step);
     if (ability.cannot('update', step)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     // check the new content exists
     if (args.content) {

--- a/src/schema/mutation/editSubscription.mutation.ts
+++ b/src/schema/mutation/editSubscription.mutation.ts
@@ -39,7 +39,9 @@ export default {
       .getFilter();
     const application = await Application.findOne(filters);
     if (!application) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     const subscription = {
       routingKey: args.routingKey,

--- a/src/schema/mutation/editSubscription.mutation.ts
+++ b/src/schema/mutation/editSubscription.mutation.ts
@@ -30,7 +30,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -39,7 +39,7 @@ export default {
       .getFilter();
     const application = await Application.findOne(filters);
     if (!application) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     const subscription = {
       routingKey: args.routingKey,

--- a/src/schema/mutation/editTemplate.mutation.ts
+++ b/src/schema/mutation/editTemplate.mutation.ts
@@ -25,7 +25,9 @@ export default {
       args.application
     );
     if (ability.cannot('update', 'Template')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     const update = {

--- a/src/schema/mutation/editTemplate.mutation.ts
+++ b/src/schema/mutation/editTemplate.mutation.ts
@@ -18,14 +18,14 @@ export default {
   async resolve(_, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = extendAbilityForApplications(
       user,
       args.application
     );
     if (ability.cannot('update', 'Template')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     const update = {

--- a/src/schema/mutation/editUser.mutation.ts
+++ b/src/schema/mutation/editUser.mutation.ts
@@ -22,7 +22,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -40,7 +40,7 @@ export default {
         );
         if (!canUpdate) {
           throw new GraphQLError(
-            context.i18next.t('errors.permissionNotGranted')
+            context.i18next.t('common.errors.permissionNotGranted')
           );
         }
       }
@@ -62,7 +62,7 @@ export default {
       }
       if (Object.keys(update).length < 1) {
         throw new GraphQLError(
-          context.i18next.t('errors.invalidEditUserArguments')
+          context.i18next.t('mutations.user.edit.errors.invalidArguments')
         );
       }
       return User.findByIdAndUpdate(args.id, update, { new: true }).populate({
@@ -72,7 +72,7 @@ export default {
     } else {
       if (ability.cannot('update', 'User')) {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
       const update = {};
@@ -89,7 +89,7 @@ export default {
       }
       if (Object.keys(update).length < 1) {
         throw new GraphQLError(
-          context.i18next.t('errors.invalidEditUserArguments')
+          context.i18next.t('mutations.user.edit.errors.invalidArguments')
         );
       }
       return User.findByIdAndUpdate(args.id, update, { new: true });

--- a/src/schema/mutation/editUserProfile.mutation.ts
+++ b/src/schema/mutation/editUserProfile.mutation.ts
@@ -21,7 +21,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const availableAttributes: { value: string; text: string }[] =
@@ -59,11 +59,11 @@ export default {
         try {
           return await User.findByIdAndUpdate(args.id, update, { new: true });
         } catch {
-          throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
         }
       } else {
         throw new GraphQLError(
-          context.i18next.t('errors.permissionNotGranted')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } else {

--- a/src/schema/mutation/editUserProfile.mutation.ts
+++ b/src/schema/mutation/editUserProfile.mutation.ts
@@ -59,7 +59,9 @@ export default {
         try {
           return await User.findByIdAndUpdate(args.id, update, { new: true });
         } catch {
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
       } else {
         throw new GraphQLError(

--- a/src/schema/mutation/editWorkflow.mutation.ts
+++ b/src/schema/mutation/editWorkflow.mutation.ts
@@ -39,7 +39,9 @@ export default {
     let workflow = await Workflow.findById(args.id);
     const ability = await extendAbilityForContent(user, workflow);
     if (ability.cannot('update', workflow)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // do the update

--- a/src/schema/mutation/editWorkflow.mutation.ts
+++ b/src/schema/mutation/editWorkflow.mutation.ts
@@ -25,13 +25,13 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // check inputs
     if (!args || (!args.name && !args.steps)) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidEditWorkflowArguments')
+        context.i18next.t('mutations.workflow.edit.errors.invalidArguments')
       );
     }
 
@@ -39,7 +39,7 @@ export default {
     let workflow = await Workflow.findById(args.id);
     const ability = await extendAbilityForContent(user, workflow);
     if (ability.cannot('update', workflow)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // do the update

--- a/src/schema/mutation/fetchGroups.mutation.ts
+++ b/src/schema/mutation/fetchGroups.mutation.ts
@@ -15,7 +15,9 @@ export default {
     const canFetch = !config.get('user.groups.local');
     if (!canFetch) {
       throw new GraphQLError(
-        context.i18next.t('mutations.group.fetch.errors.groupsFromServiceDisabled')
+        context.i18next.t(
+          'mutations.group.fetch.errors.groupsFromServiceDisabled'
+        )
       );
     }
 
@@ -26,7 +28,9 @@ export default {
     }
     const ability: AppAbility = context.user.ability;
     if (!ability.can('create', 'Group')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     const groups = await fetchGroups();

--- a/src/schema/mutation/fetchGroups.mutation.ts
+++ b/src/schema/mutation/fetchGroups.mutation.ts
@@ -15,18 +15,18 @@ export default {
     const canFetch = !config.get('user.groups.local');
     if (!canFetch) {
       throw new GraphQLError(
-        context.i18next.t('errors.groupsFromServiceDisabled')
+        context.i18next.t('mutations.group.fetch.errors.groupsFromServiceDisabled')
       );
     }
 
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = context.user.ability;
     if (!ability.can('create', 'Group')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     const groups = await fetchGroups();

--- a/src/schema/mutation/publish.mutation.ts
+++ b/src/schema/mutation/publish.mutation.ts
@@ -23,7 +23,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -31,10 +31,10 @@ export default {
       'application'
     );
     if (!channel || !channel.application) {
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
     if (ability.cannot('read', channel.application)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     const records = await Record.find({})

--- a/src/schema/mutation/publish.mutation.ts
+++ b/src/schema/mutation/publish.mutation.ts
@@ -34,7 +34,9 @@ export default {
       throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
     if (ability.cannot('read', channel.application)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     const records = await Record.find({})

--- a/src/schema/mutation/publishNotification.mutation.ts
+++ b/src/schema/mutation/publishNotification.mutation.ts
@@ -24,11 +24,11 @@ export default {
   async resolve(parent, args, context) {
     if (!args || !args.action || !args.content || !args.channel)
       throw new GraphQLError(
-        context.i18next.t('errors.invalidPublishNotificationArguments')
+        context.i18next.t('mutations.notification.publish.errors.invalidArguments')
       );
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const notification = new Notification({
       action: args.action,

--- a/src/schema/mutation/publishNotification.mutation.ts
+++ b/src/schema/mutation/publishNotification.mutation.ts
@@ -24,7 +24,9 @@ export default {
   async resolve(parent, args, context) {
     if (!args || !args.action || !args.content || !args.channel)
       throw new GraphQLError(
-        context.i18next.t('mutations.notification.publish.errors.invalidArguments')
+        context.i18next.t(
+          'mutations.notification.publish.errors.invalidArguments'
+        )
       );
     const user = context.user;
     if (!user) {

--- a/src/schema/mutation/restoreRecord.mutation.ts
+++ b/src/schema/mutation/restoreRecord.mutation.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     // Get the record
     const record = await Record.findById(args.id).populate({
@@ -26,7 +26,7 @@ export default {
     // Check ability
     const ability = await extendAbilityForRecords(user, record.form);
     if (ability.cannot('update', record)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     // Update the record
     return Record.findByIdAndUpdate(

--- a/src/schema/mutation/restoreRecord.mutation.ts
+++ b/src/schema/mutation/restoreRecord.mutation.ts
@@ -26,7 +26,9 @@ export default {
     // Check ability
     const ability = await extendAbilityForRecords(user, record.form);
     if (ability.cannot('update', record)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     // Update the record
     return Record.findByIdAndUpdate(

--- a/src/schema/mutation/seeNotification.mutation.ts
+++ b/src/schema/mutation/seeNotification.mutation.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;

--- a/src/schema/mutation/seeNotifications.mutation.ts
+++ b/src/schema/mutation/seeNotifications.mutation.ts
@@ -21,13 +21,13 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
     if (!args) {
       throw new GraphQLError(
-        context.i18next.t('errors.invalidSeeNotificationsArguments')
+        context.i18next.t('mutations.notification.see.errors.invalidArguments')
       );
     }
     const filters = Notification.accessibleBy(ability, 'update')

--- a/src/schema/mutation/toggleApplicationLock.mutation.ts
+++ b/src/schema/mutation/toggleApplicationLock.mutation.ts
@@ -21,7 +21,7 @@ export default {
   async resolve(parent, args, context) {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = context.user.ability;
     const filters = Application.accessibleBy(ability, 'update')
@@ -29,7 +29,7 @@ export default {
       .getFilter();
     let application = await Application.findOne(filters);
     if (!application) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     const update = {
       lockedBy: args.lock ? user._id : null,

--- a/src/schema/mutation/toggleApplicationLock.mutation.ts
+++ b/src/schema/mutation/toggleApplicationLock.mutation.ts
@@ -29,7 +29,9 @@ export default {
       .getFilter();
     let application = await Application.findOne(filters);
     if (!application) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     const update = {
       lockedBy: args.lock ? user._id : null,

--- a/src/schema/mutation/uploadFile.mutation.ts
+++ b/src/schema/mutation/uploadFile.mutation.ts
@@ -22,7 +22,7 @@ export default {
     const file = await args.file;
     const form = await Form.findById(args.form);
     if (!form) {
-      throw new GraphQLError(i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(i18next.t('common.errors.dataNotFound'));
     }
     const path = await uploadFile(file.file, args.form);
     return path;

--- a/src/schema/query/apiConfiguration.query.ts
+++ b/src/schema/query/apiConfiguration.query.ts
@@ -22,7 +22,9 @@ export default {
     if (ability.can('read', 'ApiConfiguration')) {
       return ApiConfiguration.findById(args.id);
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/query/apiConfiguration.query.ts
+++ b/src/schema/query/apiConfiguration.query.ts
@@ -15,14 +15,14 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability = context.user.ability;
     if (ability.can('read', 'ApiConfiguration')) {
       return ApiConfiguration.findById(args.id);
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/query/apiConfigurations.query.ts
+++ b/src/schema/query/apiConfigurations.query.ts
@@ -24,7 +24,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;

--- a/src/schema/query/application.query.ts
+++ b/src/schema/query/application.query.ts
@@ -18,7 +18,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability = context.user.ability;
@@ -46,7 +46,7 @@ export default {
       application.pages = pages.map((x) => x._id);
     }
     if (!application) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     return application;
   },

--- a/src/schema/query/application.query.ts
+++ b/src/schema/query/application.query.ts
@@ -46,7 +46,9 @@ export default {
       application.pages = pages.map((x) => x._id);
     }
     if (!application) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     return application;
   },

--- a/src/schema/query/applications.query.ts
+++ b/src/schema/query/applications.query.ts
@@ -103,7 +103,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     // Inputs check
     if (args.sortField) {

--- a/src/schema/query/channels.query.ts
+++ b/src/schema/query/channels.query.ts
@@ -15,7 +15,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability = context.user.ability;

--- a/src/schema/query/dashboard.query.ts
+++ b/src/schema/query/dashboard.query.ts
@@ -23,7 +23,9 @@ export default {
     const dashboard = await Dashboard.findById(args.id);
     const ability = await extendAbilityForContent(user, dashboard);
     if (ability.cannot('read', dashboard)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     return dashboard;

--- a/src/schema/query/dashboard.query.ts
+++ b/src/schema/query/dashboard.query.ts
@@ -16,14 +16,14 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // get data and check permissions
     const dashboard = await Dashboard.findById(args.id);
     const ability = await extendAbilityForContent(user, dashboard);
     if (ability.cannot('read', dashboard)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     return dashboard;

--- a/src/schema/query/dashboards.query.ts
+++ b/src/schema/query/dashboards.query.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability = context.user.ability;

--- a/src/schema/query/form.query.ts
+++ b/src/schema/query/form.query.ts
@@ -17,7 +17,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // get data and permissions
@@ -26,12 +26,12 @@ export default {
       model: 'Resource',
     });
     if (!form) {
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 
     const ability = await extendAbilityForRecords(user, form);
     if (ability.cannot('read', form)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     return form;

--- a/src/schema/query/form.query.ts
+++ b/src/schema/query/form.query.ts
@@ -31,7 +31,9 @@ export default {
 
     const ability = await extendAbilityForRecords(user, form);
     if (ability.cannot('read', form)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     return form;

--- a/src/schema/query/forms.query.ts
+++ b/src/schema/query/forms.query.ts
@@ -103,7 +103,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     // Inputs check
     if (args.sortField) {

--- a/src/schema/query/group.query.ts
+++ b/src/schema/query/group.query.ts
@@ -26,14 +26,18 @@ export default {
           _id: args.id,
         });
         if (!group) {
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return group;
       } catch {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/query/group.query.ts
+++ b/src/schema/query/group.query.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -26,14 +26,14 @@ export default {
           _id: args.id,
         });
         if (!group) {
-          throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
         }
         return group;
       } catch {
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/query/groups.query.ts
+++ b/src/schema/query/groups.query.ts
@@ -17,7 +17,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;

--- a/src/schema/query/me.query.ts
+++ b/src/schema/query/me.query.ts
@@ -12,7 +12,7 @@ export default {
     if (user) {
       return user;
     } else {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
   },
 };

--- a/src/schema/query/notifications.query.ts
+++ b/src/schema/query/notifications.query.ts
@@ -24,7 +24,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;

--- a/src/schema/query/page.query.ts
+++ b/src/schema/query/page.query.ts
@@ -25,7 +25,9 @@ export default {
     // check ability
     const ability = await extendAbilityForPage(user, page);
     if (ability.cannot('read', page)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     return page;

--- a/src/schema/query/page.query.ts
+++ b/src/schema/query/page.query.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // get data
@@ -25,7 +25,7 @@ export default {
     // check ability
     const ability = await extendAbilityForPage(user, page);
     if (ability.cannot('read', page)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     return page;

--- a/src/schema/query/pages.query.ts
+++ b/src/schema/query/pages.query.ts
@@ -14,7 +14,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // create ability object for all pages

--- a/src/schema/query/permissions.query.ts
+++ b/src/schema/query/permissions.query.ts
@@ -19,7 +19,7 @@ export default {
       }
       return Permission.find({ global: true });
     } else {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
   },
 };

--- a/src/schema/query/positionAttributes.query.ts
+++ b/src/schema/query/positionAttributes.query.ts
@@ -20,7 +20,9 @@ export default {
     }
     const ability: AppAbility = context.user.ability;
     if (ability.cannot('read', 'User')) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     const positionAttributes = [];
     const lastAttributeValue = [];

--- a/src/schema/query/positionAttributes.query.ts
+++ b/src/schema/query/positionAttributes.query.ts
@@ -16,11 +16,11 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = context.user.ability;
     if (ability.cannot('read', 'User')) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     const positionAttributes = [];
     const lastAttributeValue = [];

--- a/src/schema/query/pullJobs.query.ts
+++ b/src/schema/query/pullJobs.query.ts
@@ -20,7 +20,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;

--- a/src/schema/query/record.query.ts
+++ b/src/schema/query/record.query.ts
@@ -27,7 +27,9 @@ export default {
     // Check ability
     const ability = await extendAbilityForRecords(user, form);
     if (ability.cannot('read', record)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     // Return the record

--- a/src/schema/query/record.query.ts
+++ b/src/schema/query/record.query.ts
@@ -17,7 +17,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // Get the form and the record
@@ -27,7 +27,7 @@ export default {
     // Check ability
     const ability = await extendAbilityForRecords(user, form);
     if (ability.cannot('read', record)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     // Return the record

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -29,7 +29,9 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.i18n.t('common.errors.userNotLogged'));
+      throw new GraphQLError(
+        context.i18next.i18n.t('common.errors.userNotLogged')
+      );
     }
 
     // Get data

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -29,7 +29,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.i18n.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.i18n.t('common.errors.userNotLogged'));
     }
 
     // Get data
@@ -58,7 +58,7 @@ export default {
     const ability = await extendAbilityForRecords(user, record.form);
     if (ability.cannot('read', record) || ability.cannot('read', record.form)) {
       throw new GraphQLError(
-        context.i18next.i18n.t('errors.permissionNotGranted')
+        context.i18next.i18n.t('common.errors.permissionNotGranted')
       );
     }
 

--- a/src/schema/query/records.query.ts
+++ b/src/schema/query/records.query.ts
@@ -14,7 +14,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability = await extendAbilityForRecords(user);

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -354,7 +354,9 @@ export default {
         },
       });
     } else {
-      throw new GraphQLError(context.i18next.t('query.records.aggregation.errors.invalidAggregation'));
+      throw new GraphQLError(
+        context.i18next.t('query.records.aggregation.errors.invalidAggregation')
+      );
     }
     // Build pipeline stages
     if (aggregation.pipeline && aggregation.pipeline.length) {

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -49,7 +49,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // global variables
@@ -80,7 +80,7 @@ export default {
         { archived: { $ne: true } }
       );
     } else {
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 
     pipeline.push({
@@ -354,7 +354,7 @@ export default {
         },
       });
     } else {
-      throw new GraphQLError(context.i18next.t('errors.invalidAggregation'));
+      throw new GraphQLError(context.i18next.t('query.records.aggregation.errors.invalidAggregation'));
     }
     // Build pipeline stages
     if (aggregation.pipeline && aggregation.pipeline.length) {

--- a/src/schema/query/referenceData.query.ts
+++ b/src/schema/query/referenceData.query.ts
@@ -15,7 +15,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     return ReferenceData.findById(args.id);
   },

--- a/src/schema/query/referenceDatas.query.ts
+++ b/src/schema/query/referenceDatas.query.ts
@@ -24,7 +24,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;

--- a/src/schema/query/resource.query.ts
+++ b/src/schema/query/resource.query.ts
@@ -16,14 +16,14 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = user.ability;
     const resource = await Resource.findOne({ _id: args.id });
 
     if (ability.cannot('read', resource)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
     return resource;
   },

--- a/src/schema/query/resource.query.ts
+++ b/src/schema/query/resource.query.ts
@@ -23,7 +23,9 @@ export default {
     const resource = await Resource.findOne({ _id: args.id });
 
     if (ability.cannot('read', resource)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
     return resource;
   },

--- a/src/schema/query/resources.query.ts
+++ b/src/schema/query/resources.query.ts
@@ -76,7 +76,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = user.ability;

--- a/src/schema/query/role.query.ts
+++ b/src/schema/query/role.query.ts
@@ -26,14 +26,18 @@ export default {
           _id: args.id,
         });
         if (!role) {
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return role;
       } catch {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/query/role.query.ts
+++ b/src/schema/query/role.query.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -26,14 +26,14 @@ export default {
           _id: args.id,
         });
         if (!role) {
-          throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
         }
         return role;
       } catch {
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/query/roles.query.ts
+++ b/src/schema/query/roles.query.ts
@@ -36,7 +36,9 @@ export default {
         }
       }
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/query/roles.query.ts
+++ b/src/schema/query/roles.query.ts
@@ -17,7 +17,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -36,7 +36,7 @@ export default {
         }
       }
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/query/rolesFromApplications.query.ts
+++ b/src/schema/query/rolesFromApplications.query.ts
@@ -15,7 +15,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     return Role.find({ application: { $in: args.applications } }).select(

--- a/src/schema/query/step.query.ts
+++ b/src/schema/query/step.query.ts
@@ -23,7 +23,9 @@ export default {
     const step = await Step.findById(args.id);
     const ability = await extendAbilityForStep(user, step);
     if (ability.cannot('read', step)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     return step;

--- a/src/schema/query/step.query.ts
+++ b/src/schema/query/step.query.ts
@@ -16,14 +16,14 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // get data and check permissions
     const step = await Step.findById(args.id);
     const ability = await extendAbilityForStep(user, step);
     if (ability.cannot('read', step)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     return step;

--- a/src/schema/query/steps.query.ts
+++ b/src/schema/query/steps.query.ts
@@ -13,7 +13,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;

--- a/src/schema/query/user.query.ts
+++ b/src/schema/query/user.query.ts
@@ -28,7 +28,9 @@ export default {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/query/user.query.ts
+++ b/src/schema/query/user.query.ts
@@ -16,7 +16,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -25,10 +25,10 @@ export default {
       try {
         return User.findById(args.id).populate('roles').populate('groups');
       } catch {
-        throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/query/users.query.ts
+++ b/src/schema/query/users.query.ts
@@ -62,7 +62,9 @@ export default {
         return User.aggregate(aggregations);
       }
     } else {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
   },
 };

--- a/src/schema/query/users.query.ts
+++ b/src/schema/query/users.query.ts
@@ -17,7 +17,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;
@@ -62,7 +62,7 @@ export default {
         return User.aggregate(aggregations);
       }
     } else {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
   },
 };

--- a/src/schema/query/workflow.query.ts
+++ b/src/schema/query/workflow.query.ts
@@ -25,7 +25,9 @@ export default {
     const workflow = await Workflow.findById(args.id);
     const ability = await extendAbilityForContent(user, workflow);
     if (ability.cannot('read', workflow)) {
-      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
     }
 
     if (args.asRole) {

--- a/src/schema/query/workflow.query.ts
+++ b/src/schema/query/workflow.query.ts
@@ -18,14 +18,14 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     // get data and check permissions
     const workflow = await Workflow.findById(args.id);
     const ability = await extendAbilityForContent(user, workflow);
     if (ability.cannot('read', workflow)) {
-      throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
+      throw new GraphQLError(context.i18next.t('common.errors.permissionNotGranted'));
     }
 
     if (args.asRole) {

--- a/src/schema/query/workflows.query.ts
+++ b/src/schema/query/workflows.query.ts
@@ -13,7 +13,7 @@ export default {
     // Authentication check
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
 
     const ability: AppAbility = context.user.ability;

--- a/src/schema/subscription/applicationEdited.subscription.ts
+++ b/src/schema/subscription/applicationEdited.subscription.ts
@@ -16,7 +16,7 @@ export default {
     const subscriber: AMQPPubSub = await pubsub();
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     return withFilter(
       () => subscriber.asyncIterator('app_edited'),

--- a/src/schema/subscription/applicationUnlocked.subscription.ts
+++ b/src/schema/subscription/applicationUnlocked.subscription.ts
@@ -16,7 +16,7 @@ export default {
     const subscriber: AMQPPubSub = await pubsub();
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     return withFilter(
       () => subscriber.asyncIterator('app_lock'),

--- a/src/server/apollo/onConnect.ts
+++ b/src/server/apollo/onConnect.ts
@@ -19,7 +19,7 @@ export default (connectionParams, ws: any) => {
     });
   } else {
     throw new AuthenticationError(
-      i18next.t('errors.authenticationTokenNotFound')
+      i18next.t('common.errors.authenticationTokenNotFound')
     );
   }
 };

--- a/src/server/middlewares/cors.ts
+++ b/src/server/middlewares/cors.ts
@@ -12,7 +12,7 @@ export const corsMiddleware = cors({
   origin: (origin, callback) => {
     if (!origin) return callback(null, true);
     if (allowedOrigins.indexOf(origin) === -1) {
-      const msg = i18next.t('errors.invalidCORS');
+      const msg = i18next.t('server.middlewares.cors.errors.invalidCORS');
       return callback(new Error(`${msg}: ${origin}`), false);
     }
     return callback(null, true);

--- a/src/server/middlewares/rest.ts
+++ b/src/server/middlewares/rest.ts
@@ -26,7 +26,7 @@ export const restMiddleware = (req, res, next) => {
       req.context.user.ability = defineUserAbility(user);
       next();
     } else {
-      res.status(401).send(i18next.t('errors.userNotLogged'));
+      res.status(401).send(i18next.t('common.errors.userNotLogged'));
     }
   })(req, res, next);
 };

--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -146,14 +146,18 @@ const buildPipeline = (
         const custom: string = stage.form.raw;
         if (forbiddenKeywords.some((x: string) => custom.includes(x))) {
           throw new GraphQLError(
-            context.i18next.t('utils.aggregation.buildPipeline.errors.invalidCustomStage')
+            context.i18next.t(
+              'utils.aggregation.buildPipeline.errors.invalidCustomStage'
+            )
           );
         }
         try {
           pipeline.push(JSON.parse(custom));
         } catch {
           throw new GraphQLError(
-            context.i18next.t('utils.aggregation.buildPipeline.errors.invalidCustomStage')
+            context.i18next.t(
+              'utils.aggregation.buildPipeline.errors.invalidCustomStage'
+            )
           );
         }
         break;

--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -146,14 +146,14 @@ const buildPipeline = (
         const custom: string = stage.form.raw;
         if (forbiddenKeywords.some((x: string) => custom.includes(x))) {
           throw new GraphQLError(
-            context.i18next.t('errors.invalidCustomStage')
+            context.i18next.t('utils.aggregation.buildPipeline.errors.invalidCustomStage')
           );
         }
         try {
           pipeline.push(JSON.parse(custom));
         } catch {
           throw new GraphQLError(
-            context.i18next.t('errors.invalidCustomStage')
+            context.i18next.t('utils.aggregation.buildPipeline.errors.invalidCustomStage')
           );
         }
         break;

--- a/src/utils/files/uploadFile.ts
+++ b/src/utils/files/uploadFile.ts
@@ -76,6 +76,8 @@ export const uploadFile = async (file: any, form: string): Promise<string> => {
     await blockBlobClient.uploadStream(fileStream);
     return filename;
   } catch {
-    throw new GraphQLError(i18next.t('utils.files.uploadFile.errors.fileCannotBeUploaded'));
+    throw new GraphQLError(
+      i18next.t('utils.files.uploadFile.errors.fileCannotBeUploaded')
+    );
   }
 };

--- a/src/utils/files/uploadFile.ts
+++ b/src/utils/files/uploadFile.ts
@@ -58,7 +58,7 @@ export const uploadFile = async (file: any, form: string): Promise<string> => {
     !contentType ||
     !ALLOWED_EXTENSIONS.includes(mime.extension(contentType) || '')
   ) {
-    throw new GraphQLError(i18next.t('errors.fileExtensionNotAllowed'));
+    throw new GraphQLError(i18next.t('common.errors.fileExtensionNotAllowed'));
   }
   try {
     const blobServiceClient = BlobServiceClient.fromConnectionString(
@@ -76,6 +76,6 @@ export const uploadFile = async (file: any, form: string): Promise<string> => {
     await blockBlobClient.uploadStream(fileStream);
     return filename;
   } catch {
-    throw new GraphQLError(i18next.t('errors.fileCannotBeUploaded'));
+    throw new GraphQLError(i18next.t('utils.files.uploadFile.errors.fileCannotBeUploaded'));
   }
 };

--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -18,7 +18,7 @@ export const extractFields = async (object, fields, core): Promise<void> => {
         await extractFields(element, fields, core);
       } else {
         if (!element.valueName) {
-          throw new GraphQLError(i18next.t('errors.missingDataField'));
+          throw new GraphQLError(i18next.t('utils.form.extractFields.errors.missingDataField'));
         }
         validateGraphQLFieldName(element.valueName, i18next);
         const type = await getFieldType(element);
@@ -52,7 +52,7 @@ export const extractFields = async (object, fields, core): Promise<void> => {
             );
           } else {
             throw new GraphQLError(
-              i18next.t('errors.missingRelatedField', {
+              i18next.t('utils.form.extractFields.errors.missingRelatedField', {
                 name: element.valueName,
               })
             );

--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -18,7 +18,9 @@ export const extractFields = async (object, fields, core): Promise<void> => {
         await extractFields(element, fields, core);
       } else {
         if (!element.valueName) {
-          throw new GraphQLError(i18next.t('utils.form.extractFields.errors.missingDataField'));
+          throw new GraphQLError(
+            i18next.t('utils.form.extractFields.errors.missingDataField')
+          );
         }
         validateGraphQLFieldName(element.valueName, i18next);
         const type = await getFieldType(element);

--- a/src/utils/form/findDuplicateFields.ts
+++ b/src/utils/form/findDuplicateFields.ts
@@ -14,7 +14,9 @@ export const findDuplicateFields = (fields): void => {
   );
   if (duplication.length > 0) {
     throw new GraphQLError(
-      i18next.t('utils.form.findDuplicateFields.errors.dataFieldDuplicated', { name: duplication[0] })
+      i18next.t('utils.form.findDuplicateFields.errors.dataFieldDuplicated', {
+        name: duplication[0],
+      })
     );
   }
 };

--- a/src/utils/form/findDuplicateFields.ts
+++ b/src/utils/form/findDuplicateFields.ts
@@ -14,7 +14,7 @@ export const findDuplicateFields = (fields): void => {
   );
   if (duplication.length > 0) {
     throw new GraphQLError(
-      i18next.t('errors.dataFieldDuplicated', { name: duplication[0] })
+      i18next.t('utils.form.findDuplicateFields.errors.dataFieldDuplicated', { name: duplication[0] })
     );
   }
 };

--- a/src/utils/form/getNextId.ts
+++ b/src/utils/form/getNextId.ts
@@ -80,7 +80,9 @@ export const getNextId = async (structureId: string): Promise<string> => {
     }
     cache.set(structureId, nextId);
   } else {
-    throw new Error(i18next.t('utils.form.getNextId.errors.incrementalIdError'));
+    throw new Error(
+      i18next.t('utils.form.getNextId.errors.incrementalIdError')
+    );
   }
   return nextId;
 };

--- a/src/utils/form/getNextId.ts
+++ b/src/utils/form/getNextId.ts
@@ -80,7 +80,7 @@ export const getNextId = async (structureId: string): Promise<string> => {
     }
     cache.set(structureId, nextId);
   } else {
-    throw new Error(i18next.t('errors.incrementalIdError'));
+    throw new Error(i18next.t('utils.form.getNextId.errors.incrementalIdError'));
   }
   return nextId;
 };

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -233,7 +233,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
   ) => {
     const user: User = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     // Id of the form / resource
     const id = idsByName[entityName];

--- a/src/utils/schema/resolvers/Query/meta.ts
+++ b/src/utils/schema/resolvers/Query/meta.ts
@@ -12,14 +12,14 @@ import { Form, Resource } from '@models';
 export default (id) => async (parent, args, context) => {
   const user = context.user;
   if (!user) {
-    throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+    throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
   }
 
   const form = await Form.findById(id);
   if (!form) {
     const resource = await Resource.findById(id);
     if (!resource) {
-      throw new GraphQLError(context.i18next.t('errors.dataNotFound'));
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     } else {
       const ability = await extendAbilityForRecords(user, resource);
       return resource.fields.reduce((fields, field) => {

--- a/src/utils/schema/resolvers/Query/single.ts
+++ b/src/utils/schema/resolvers/Query/single.ts
@@ -11,7 +11,7 @@ export default () =>
   (_, { id }, context) => {
     const user = context.user;
     if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     return Record.findOne({ _id: id, archived: { $ne: true } });
   };

--- a/src/utils/schema/resolvers/index.ts
+++ b/src/utils/schema/resolvers/index.ts
@@ -72,7 +72,7 @@ export const getResolvers = (
                 const user = context.user;
                 if (!user) {
                   throw new GraphQLError(
-                    context.i18next.t('errors.userNotLogged')
+                    context.i18next.t('common.errors.userNotLogged')
                   );
                 }
                 const apiConfiguration = await ApiConfiguration.findOne(

--- a/src/utils/user/updateUserAttributes.ts
+++ b/src/utils/user/updateUserAttributes.ts
@@ -31,9 +31,12 @@ export const updateUserAttributes = async (
     isEmpty(settings.mapping)
   ) {
     logger.error(
-      i18next.t('utils.user.updateUserAttributes.errors.missingObjectParameters', {
-        object: 'user attributes settings',
-      })
+      i18next.t(
+        'utils.user.updateUserAttributes.errors.missingObjectParameters',
+        {
+          object: 'user attributes settings',
+        }
+      )
     );
     return false;
   }

--- a/src/utils/user/updateUserAttributes.ts
+++ b/src/utils/user/updateUserAttributes.ts
@@ -31,7 +31,7 @@ export const updateUserAttributes = async (
     isEmpty(settings.mapping)
   ) {
     logger.error(
-      i18next.t('errors.missingObjectParameters', {
+      i18next.t('utils.user.updateUserAttributes.errors.missingObjectParameters', {
         object: 'user attributes settings',
       })
     );
@@ -60,14 +60,14 @@ export const updateUserAttributes = async (
       headers,
     });
   } catch (err) {
-    logger.error(i18next.t('errors.invalidAPI'), { stack: err.stack });
+    logger.error(i18next.t('common.errors.invalidAPI'), { stack: err.stack });
     return false;
   }
   let data: any;
   try {
     data = await res.json();
   } catch (err) {
-    logger.error(i18next.t('errors.authenticationTokenNotFound'), {
+    logger.error(i18next.t('common.errors.authenticationTokenNotFound'), {
       stack: err.stack,
     });
     return false;

--- a/src/utils/user/updateUserGroups.ts
+++ b/src/utils/user/updateUserGroups.ts
@@ -33,7 +33,7 @@ export const updateUserGroups = async (
     !settings.id
   ) {
     logger.error(
-      i18next.t('errors.missingObjectParameters', {
+      i18next.t('common.errors.missingObjectParameters', {
         object: 'user groups settings',
       })
     );
@@ -62,14 +62,14 @@ export const updateUserGroups = async (
       headers,
     });
   } catch (err) {
-    logger.error(i18next.t('errors.invalidAPI'), { stack: err.stack });
+    logger.error(i18next.t('common.errors.invalidAPI'), { stack: err.stack });
     return false;
   }
   let data: any;
   try {
     data = await res.json();
   } catch (err) {
-    logger.error(i18next.t('errors.authenticationTokenNotFound'), {
+    logger.error(i18next.t('common.errors.authenticationTokenNotFound'), {
       stack: err.stack,
     });
     return false;

--- a/src/utils/validators/validateApi.ts
+++ b/src/utils/validators/validateApi.ts
@@ -8,6 +8,6 @@ import i18next from 'i18next';
  */
 export const validateApi = (name: string): void => {
   if (!/^[A-Za-z-_]+$/i.test(name)) {
-    throw new GraphQLError(i18next.t('errors.invalidGraphQLName'));
+    throw new GraphQLError(i18next.t('common.errors.invalidGraphQLName'));
   }
 };

--- a/src/utils/validators/validateName.ts
+++ b/src/utils/validators/validateName.ts
@@ -27,10 +27,10 @@ export const validateGraphQLTypeName = (
   i18next = i18nextModule
 ): void => {
   if (!GRAPHQL_TYPE_NAME_REGEX.test(name)) {
-    throw new GraphQLError(i18next.t('errors.invalidGraphQLName'));
+    throw new GraphQLError(i18next.t('common.errors.invalidGraphQLName'));
   }
   if (protectedNames.indexOf(name.toLowerCase()) >= 0) {
-    throw new GraphQLError(i18next.t('errors.usageOfProtectedName'));
+    throw new GraphQLError(i18next.t('utils.validators.validateName.errors.usageOfProtectedName'));
   }
 };
 
@@ -46,9 +46,9 @@ export const validateGraphQLFieldName = (
 ): void => {
   if (!GRAPHQL_TYPE_NAME_REGEX.test(name)) {
     throw new GraphQLError(
-      i18next.t('errors.invalidFieldName', {
+      i18next.t('utils.validators.validateName.errors.invalidFieldName', {
         field: name,
-        err: i18next.t('errors.invalidGraphQLName'),
+        err: i18next.t('common.errors.invalidGraphQLName'),
       })
     );
   }

--- a/src/utils/validators/validateName.ts
+++ b/src/utils/validators/validateName.ts
@@ -30,7 +30,9 @@ export const validateGraphQLTypeName = (
     throw new GraphQLError(i18next.t('common.errors.invalidGraphQLName'));
   }
   if (protectedNames.indexOf(name.toLowerCase()) >= 0) {
-    throw new GraphQLError(i18next.t('utils.validators.validateName.errors.usageOfProtectedName'));
+    throw new GraphQLError(
+      i18next.t('utils.validators.validateName.errors.usageOfProtectedName')
+    );
   }
 };
 


### PR DESCRIPTION
# Description
We use [i18n](https://www.i18next.com/) in order to translate messages sent by the API in the back-end ( you can find many examples in the back-end mutations / queries resolvers )

At the moment, i18n messages of the back-end are stored in a file called src/i18n/en.json

Nevertheless, we are storing almost everything under the “errors” key

It would be better to organize the messages, following the structure of the code

To start with, create a key called: “mutations”, then, have one sub-key for type of object, and finally, one sub-key for type of mutation


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please test all error messages in project


# Checklist:
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

