### PR TITLE
Feat/ab#51567 permissions see users assigned with automatic assignement

### DIFF
--- a/src/schema/types/role.type.ts
+++ b/src/schema/types/role.type.ts
@@ -177,7 +177,7 @@ export const RoleType = new GraphQLObjectType({
           ? sortField.cursorFilter(args.afterCursor, 'asc')
           : {};
 
-        let users = await User.find({
+        const users = await User.find({
           $and: [cursorFilters],
         }).sort(sortField.sort('asc'));
 

--- a/src/utils/user/getAutoAssignedRoles.ts
+++ b/src/utils/user/getAutoAssignedRoles.ts
@@ -117,7 +117,7 @@ export const getAutoAssignedRoles = async (user: User): Promise<Role[]> => {
 export const getAutoAssignedUsers = async (
   user: User,
   role: Role
-): Promise<Boolean> => {
+): Promise<boolean> => {
   return role.autoAssignment.some((x) =>
     checkIfRoleIsAssigned(x, get(user, 'groups', []), user.attributes ?? {})
   );

--- a/src/utils/user/getAutoAssignedRoles.ts
+++ b/src/utils/user/getAutoAssignedRoles.ts
@@ -106,3 +106,19 @@ export const getAutoAssignedRoles = async (user: User): Promise<Role[]> => {
     return arr;
   }, []);
 };
+
+/**
+ * Get list of auto assigned user
+ *
+ * @param user user to check
+ * @param role role to check
+ * @returns list of auto assigned roles
+ */
+export const getAutoAssignedUsers = async (
+  user: User,
+  role: Role
+): Promise<Boolean> => {
+  return role.autoAssignment.some((x) =>
+    checkIfRoleIsAssigned(x, get(user, 'groups', []), user.attributes ?? {})
+  );
+};


### PR DESCRIPTION
# Description
Need some design because we don't want to mix them with users manually assigned. But we would like to see:
List of users auto-assigned to a role
List of users auto-assigned to an application

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I have added new field for getting auto assing role to users

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

