### PR TITLE
AB#52075 Files in a Grid - Support file type in history

### DIFF
--- a/src/utils/form/transformRecord.ts
+++ b/src/utils/form/transformRecord.ts
@@ -44,7 +44,7 @@ export const formatValue = (field: any, value: any): any => {
       break;
     case 'file':
       if (value != null) {
-        return value.map((x) => ({ name: x.name }));
+        return value.map((x) => ({ name: x.name, content: x.content }));
       }
       break;
     default:

--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -282,7 +282,7 @@ export class RecordHistory {
               (!after[key] && current[key]) ||
               (current[key] &&
                 after[key] &&
-                after[key].toString() !== current[key].toString())
+                JSON.stringify(after[key]) !== JSON.stringify(current[key]))
             ) {
               changes.push(this.modifyField(key, after, current));
             } else if (!after[key] && current[key]) {


### PR DESCRIPTION
# Description
Currently an update on only a file input will not trigger a new version of the record.
We should design how we want to reflect those changes.
The history of a file attachment and the changing/updating of a file attachment in a grid is currently not recorded.  If a file is removed or changed there is no history of this.
Also issue resolved of file not change/update

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please create one form with File type field
then, add some records from this form, edit them ( changing the file of the file question ), and in the grid, clicking on the '...' button on the records row, show the history.

## Sreenshots
![image](https://user-images.githubusercontent.com/111883188/210060773-d2c56b1a-0b51-4684-b22b-7485302bcfbd.png)

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

