### PR TITLE
fix/OORT-559_application-locking

### DIFF
--- a/src/schema/mutation/editApplication.mutation.ts
+++ b/src/schema/mutation/editApplication.mutation.ts
@@ -64,7 +64,7 @@ export default {
       throw new GraphQLError('Please unlock application for edition.');
     }
     const update = {
-      lockedBy: user._id,
+      // lockedBy: user._id,
     };
     Object.assign(
       update,

--- a/src/schema/types/application.type.ts
+++ b/src/schema/types/application.type.ts
@@ -98,7 +98,7 @@ export const ApplicationType = new GraphQLObjectType({
       type: GraphQLBoolean,
       resolve(parent, args, context) {
         return parent.lockedBy
-          ? parent.lockedBy.toString() === context.user._id
+          ? parent.lockedBy.equals(context.user._id)
           : false;
       },
     },

--- a/src/services/form.service.ts
+++ b/src/services/form.service.ts
@@ -1,5 +1,4 @@
 import * as Survey from 'survey-knockout';
-import { ICustomQuestionTypeConfiguration } from 'survey-knockout';
 
 /**
  * Form service, for SurveyJS validation.
@@ -27,7 +26,7 @@ export class FormService {
    * Init resource component.
    */
   private initResourceComponent() {
-    const component: ICustomQuestionTypeConfiguration = {
+    const component = {
       name: 'resource',
       title: 'Resource',
       questionJSON: {
@@ -52,7 +51,7 @@ export class FormService {
    * Init resources component.
    */
   private initResourcesComponent() {
-    const component: ICustomQuestionTypeConfiguration = {
+    const component = {
       name: 'resources',
       title: 'Resources',
       questionJSON: {
@@ -77,7 +76,7 @@ export class FormService {
    * Init owner component.
    */
   private initOwnerComponent() {
-    const component: ICustomQuestionTypeConfiguration = {
+    const component = {
       name: 'owner',
       title: 'Owner',
       questionJSON: {
@@ -102,7 +101,7 @@ export class FormService {
    * Init users component.
    */
   private initUsersComponent() {
-    const component: ICustomQuestionTypeConfiguration = {
+    const component = {
       name: 'users',
       title: 'Users',
       questionJSON: {


### PR DESCRIPTION
# Description

This PR fixes a few issues:
* For some reason, `ICustomQuestionTypeConfiguration` seems to no longer be exported survey-knockout, so I removed the typing
* Properly checking if app was locked by the current user
* Turns out what was locking "randomly" the application was the editApplication mutilation, I don't know if that was intended or not (doesn't make much sense to me), so I just commented it out.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By checking the lockedByUser field in the frontend and editing an application (which is no longer being locked)

# Checklist:

( * == Mandatory ) 

- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

