### PR TITLE
Fix 1.3.x/AB#53528 create graphql type for metadata

### DIFF
--- a/src/schema/types/form.type.ts
+++ b/src/schema/types/form.type.ts
@@ -14,6 +14,7 @@ import {
   VersionType,
   RecordConnectionType,
   LayoutConnectionType,
+  MetadataType,
 } from '.';
 import { Resource, Record, Version, Form } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
@@ -244,7 +245,7 @@ export const FormType = new GraphQLObjectType({
       },
     },
     metadata: {
-      type: new GraphQLList(GraphQLJSON),
+      type: new GraphQLList(MetadataType),
       resolve(parent, _, context) {
         return getMetaData(parent, context);
       },

--- a/src/schema/types/index.ts
+++ b/src/schema/types/index.ts
@@ -25,3 +25,4 @@ export * from './group.type';
 export * from './aggregation.type';
 export * from './template.type';
 export * from './distributionList.type';
+export * from './metadata.type';

--- a/src/schema/types/metadata.type.ts
+++ b/src/schema/types/metadata.type.ts
@@ -1,0 +1,138 @@
+import { Form, Resource } from '@models';
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLList,
+  GraphQLBoolean,
+} from 'graphql';
+import GraphQLJSON from 'graphql-type-json';
+import { AppAbility } from 'security/defineUserAbility';
+import { Connection } from './pagination.type';
+import { selectableDefaultRecordFieldsFlat } from '@const/defaultRecordFields';
+import { get, sortBy } from 'lodash';
+import { getFullChoices } from '@utils/form';
+import {
+  getMetaData,
+  getOwnerOptions,
+  getReferenceDataFields,
+  getUsersOptions,
+} from '@utils/form/metadata.helper';
+import { referenceDataType } from '@const/enumTypes';
+import { CustomAPI } from '@server/apollo/dataSources';
+
+/** GraphQL metadata type definition */
+export const MetadataType = new GraphQLObjectType({
+  name: 'Metadata',
+  fields: () => ({
+    automated: { type: GraphQLBoolean },
+    name: { type: GraphQLString },
+    type: { type: GraphQLString },
+    editor: { type: GraphQLString },
+    filter: { type: GraphQLJSON },
+    filterable: { type: GraphQLBoolean },
+    multiSelect: { type: GraphQLBoolean },
+    canSee: {
+      type: GraphQLBoolean,
+      resolve: (parent, _, context) => {
+        const ability: AppAbility = context.user._abilityForRecords;
+        const ogParent: Form | Resource = context._parent;
+        return ability.can('read', ogParent, `data.${parent.name}`);
+      },
+    },
+    canUpdate: {
+      type: GraphQLBoolean,
+      resolve: (parent, _, context) => {
+        const ability: AppAbility = context.user._abilityForRecords;
+        const ogParent: Form | Resource = context._parent;
+        if (selectableDefaultRecordFieldsFlat.includes(parent.name)) {
+          return false;
+        } else {
+          return ability.can('update', ogParent, `data.${parent.name}`);
+        }
+      },
+    },
+    options: {
+      type: GraphQLJSON,
+      resolve: async (parent, _, context) => {
+        const ogParent: Form | Resource = context._parent;
+        if (parent.name === 'from') {
+          const relatedForms = await Form.find({
+            resource: get(ogParent, 'resource', ogParent.id),
+          }).select('id name');
+          return relatedForms.map((x) => {
+            return {
+              text: x.name,
+              value: x.id,
+            };
+          });
+        }
+        if (
+          ['radiogroup', 'dropdown', 'checkbox', 'tagbox'].includes(parent.type)
+        ) {
+          if (parent._field?.choicesByUrl) {
+            return getFullChoices(parent._field, context);
+          } else if (parent._referenceData) {
+            // For ReferenceData children use object stored in field to create choices.
+            const referenceData = parent._referenceData;
+            let items: any[];
+            // If it's coming from an API Configuration, uses a dataSource.
+            if (referenceData.type !== referenceDataType.static) {
+              const dataSource: CustomAPI =
+                context.dataSources[referenceData.apiConfiguration.name];
+              items = await dataSource.getReferenceDataItems(
+                referenceData,
+                referenceData.apiConfiguration
+              );
+            } else {
+              items = referenceData.data;
+            }
+            return sortBy(
+              items.map((x) => ({
+                value: String(x[parent.name]),
+                text: String(x[parent.name]),
+              })),
+              (x) => x.text
+            );
+          } else {
+            return get(parent._field, 'choices', []).map((x) => {
+              return {
+                text: get(x, 'text', x),
+                value: get(x, 'value', x),
+              };
+            });
+          }
+        }
+        if (['users', 'owner'].includes(parent.type)) {
+          const ability: AppAbility = context.user._abilityForRecords;
+          const canSee = ability.can('read', ogParent, `data.${parent.name}`);
+          if (canSee) {
+            if (parent.type === 'users') {
+              return getUsersOptions(parent._field.applications);
+            } else {
+              return getOwnerOptions(parent._field.applications);
+            }
+          }
+        }
+      },
+    },
+    fields: {
+      type: new GraphQLList(MetadataType),
+      resolve: async (parent, _, context) => {
+        if (['resource', 'resources'].includes(parent.type)) {
+          return getMetaData(
+            await Resource.findById(parent._field.resource),
+            context,
+            false
+          );
+        }
+        if (parent._field?.referenceData) {
+          return getReferenceDataFields(parent._field);
+        }
+        return parent.fields;
+      },
+    },
+  }),
+});
+
+/** GraphQL metadata connection type definition */
+export const MetadataConnectionType = Connection(MetadataType);

--- a/src/schema/types/resource.type.ts
+++ b/src/schema/types/resource.type.ts
@@ -14,6 +14,7 @@ import {
   RecordConnectionType,
   LayoutConnectionType,
   AggregationConnectionType,
+  MetadataType,
 } from '.';
 import { Form, Record } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
@@ -325,7 +326,7 @@ export const ResourceType = new GraphQLObjectType({
       },
     },
     metadata: {
-      type: new GraphQLList(GraphQLJSON),
+      type: new GraphQLList(MetadataType),
       resolve(parent, _, context) {
         return getMetaData(parent, context);
       },

--- a/src/server/apollo/dataSources.ts
+++ b/src/server/apollo/dataSources.ts
@@ -101,7 +101,7 @@ export class CustomAPI extends RESTDataSource {
     value: string,
     text: string,
     hasOther: boolean
-  ): Promise<{ value: any; text: string }[]> {
+  ): Promise<{ value: string; text: string }[]> {
     try {
       const res = await this.get(endpoint);
       const choices = path ? [...get(res, path)] : [...res];
@@ -110,8 +110,8 @@ export class CustomAPI extends RESTDataSource {
       }
       return choices
         ? choices.map((x: any) => ({
-            value: value ? get(x, value) : x,
-            text: text ? get(x, text) : value ? get(x, value) : x,
+            value: String(value ? get(x, value) : x),
+            text: String(text ? get(x, text) : value ? get(x, value) : x),
           }))
         : [];
     } catch (err) {

--- a/src/utils/form/metadata.helper.ts
+++ b/src/utils/form/metadata.helper.ts
@@ -1,71 +1,69 @@
-import get from 'lodash/get';
-import { Form, Resource, User, Role } from '@models';
+import { Form, Resource, User, Role, ReferenceData } from '@models';
 import mongoose from 'mongoose';
 import { sortBy } from 'lodash';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
-import { AppAbility } from '@security/defineUserAbility';
-import { getFullChoices } from './getDisplayText';
+
+export type Metadata = {
+  automated?: boolean;
+  name: string;
+  type?: string;
+  editor?: string;
+  filter?: { defaultOperator?: string; operators: string[] };
+  canSee?: boolean;
+  canUpdate?: boolean;
+  multiSelect?: boolean;
+  filterable?: boolean;
+  options?: { text: string; value: any }[];
+  fields?: Metadata[];
+  _field?: any;
+  _referenceData?: ReferenceData;
+};
 
 /**
- * Build meta data for users fields.
+ * Build options for users metadata fields.
  *
- * @param parent form or resource object
- * @param ability user ability
- * @param field field to get metadata of
- * @returns metadata
+ * @param applications list of applications from which users should come.
+ * @returns options for users metadata field.
  */
-export const getUsersMetaData = async (
-  parent: Form | Resource,
-  ability: AppAbility,
-  field: any
-) => {
+export const getUsersOptions = async (applications: undefined | string[]) => {
   let users: User[] = [];
-  const metaData = {
-    name: field.name,
-    editor: 'select',
-    multiSelect: true,
-    canSee: ability.can('read', parent, `data.${field.name}`),
-    canUpdate: ability.can('update', parent, `data.${field.name}`),
-  };
-  if (metaData.canSee) {
-    if (field.applications && field.applications.length > 0) {
-      const aggregations = [
-        // Left join
-        {
-          $lookup: {
-            from: 'roles',
-            localField: 'roles',
-            foreignField: '_id',
-            as: 'roles',
-          },
+  if (applications && applications.length > 0) {
+    const aggregations = [
+      // Left join
+      {
+        $lookup: {
+          from: 'roles',
+          localField: 'roles',
+          foreignField: '_id',
+          as: 'roles',
         },
-        // Replace the roles field with a filtered array, containing only roles that are part of the application(s).
-        {
-          $addFields: {
-            roles: {
-              $filter: {
-                input: '$roles',
-                as: 'role',
-                cond: {
-                  $in: [
-                    '$$role.application',
-                    field.applications.map((x) => mongoose.Types.ObjectId(x)),
-                  ],
-                },
+      },
+      // Replace the roles field with a filtered array, containing only roles that are part of the application(s).
+      {
+        $addFields: {
+          roles: {
+            $filter: {
+              input: '$roles',
+              as: 'role',
+              cond: {
+                $in: [
+                  '$$role.application',
+                  applications.map((x) => mongoose.Types.ObjectId(x)),
+                ],
               },
             },
           },
         },
-        // Filter users that have at least one role in the application(s).
-        { $match: { 'roles.0': { $exists: true } } },
-      ];
-      users = await User.aggregate(aggregations);
-    } else {
-      users = await User.find();
-    }
+      },
+      // Filter users that have at least one role in the application(s).
+      { $match: { 'roles.0': { $exists: true } } },
+    ];
+    users = await User.aggregate(aggregations);
+  } else {
+    users = await User.find();
   }
-  return Object.assign(metaData, {
-    options: (users
+  return (
+    users
       ? users.map((x) => {
           return {
             text: x.username,
@@ -73,56 +71,62 @@ export const getUsersMetaData = async (
           };
         })
       : []
-    ).concat({
-      text: 'Current user',
-      value: 'me',
-    }),
+  ).concat({
+    text: 'Current user',
+    value: 'me',
   });
 };
 
 /**
- * Get metadata of roles field (owner)
+ * Build options for owner metadata fields.
  *
- * @param parent form or resource object
- * @param ability user ability
- * @param field field to get metadata of
- * @returns metadata
+ * @param applications list of applications from which roles should come.
+ * @returns options for owner metadata field.
  */
-export const getRolesMetaData = async (
-  parent: Form | Resource,
-  ability: AppAbility,
-  field: any
-) => {
+export const getOwnerOptions = async (applications: string[]) => {
   let roles: Role[] = [];
-  const metaData = {
-    name: field.name,
-    editor: 'select',
-    multiSelect: true,
-    canSee: ability.can('read', parent, `data.${field.name}`),
-    canUpdate: ability.can('update', parent, `data.${field.name}`),
-  };
+  roles = await Role.find({
+    application: {
+      $in: applications.map((x) => mongoose.Types.ObjectId(x)),
+    },
+  })
+    .select('id title application')
+    .populate({
+      path: 'application',
+      model: 'Application',
+    });
 
-  if (metaData.canSee) {
-    roles = await Role.find({
-      application: {
-        $in: field.applications.map((x) => mongoose.Types.ObjectId(x)),
-      },
-    })
-      .select('id title application')
-      .populate({
-        path: 'application',
-        model: 'Application',
-      });
-  }
-
-  return Object.assign(metaData, {
-    options: roles.map((x) => {
-      return {
-        text: `${x.application.name} - ${x.title}`,
-        value: x.id,
-      };
-    }),
+  return roles.map((x) => {
+    return {
+      text: `${x.application.name} - ${x.title}`,
+      value: x.id,
+    };
   });
+};
+
+/**
+ * Build fields for reference data metadata.
+ *
+ * @param field Parent field.
+ * @returns Reference data sub fields.
+ */
+export const getReferenceDataFields = async (
+  field: any
+): Promise<Metadata[]> => {
+  const referenceData = await ReferenceData.findById(
+    field.referenceData.id
+  ).populate({
+    path: 'apiConfiguration',
+    model: 'ApiConfiguration',
+    select: { name: 1, endpoint: 1, graphQLEndpoint: 1 },
+  });
+  return referenceData.fields.map((fieldName) => ({
+    name: fieldName,
+    type: field.type,
+    editor: 'select',
+    multiSelect: ['checkbox', 'tagbox'].includes(field.type),
+    _referenceData: referenceData,
+  }));
 };
 
 /**
@@ -130,19 +134,20 @@ export const getRolesMetaData = async (
  *
  * @param parent form or resource
  * @param context request context
- * @param level indicate nested level of metadata. We stop adding fields to resources at 1
+ * @param root indicate if this is the root metadata call. For nested ones this should be set to false.
  * @returns Promise of fields metadata
  */
 export const getMetaData = async (
   parent: Form | Resource,
   context: any,
-  level = 0
+  root = true
 ): Promise<any[]> => {
-  const metaData = [];
-  const ability = await extendAbilityForRecords(context.user, parent);
-
-  // In order to handle parallel execution
-  const promises: Promise<any>[] = [];
+  const metaData: Metadata[] = [];
+  context._parent = parent;
+  context.user._abilityForRecords = await extendAbilityForRecords(
+    context.user,
+    parent
+  );
 
   // ID, Incremental ID
   for (const fieldName of ['id', 'incrementalId']) {
@@ -154,43 +159,28 @@ export const getMetaData = async (
       filter: {
         operators: ['eq', 'neq', 'contains', 'doesnotcontain', 'startswith'],
       },
-      canSee: ability.can('read', parent, `data.${fieldName}`),
       canUpdate: false,
     });
   }
 
   // Form
-  const getFormMetaData = async () => {
-    const relatedForms = await Form.find({
-      resource: get(parent, 'resource', parent.id),
-    }).select('id name');
-    metaData.push({
-      automated: true,
-      name: 'form',
-      editor: 'select',
-      filter: {
-        defaultOperator: 'eq',
-        operators: ['eq', 'neq'],
-      },
-      canSee: ability.can('read', parent, 'data.form'),
-      canUpdate: false,
-      options: relatedForms.map((x) => {
-        return {
-          text: x.name,
-          value: x.id,
-        };
-      }),
-    });
-  };
-  promises.push(getFormMetaData());
+  metaData.push({
+    automated: true,
+    name: 'form',
+    editor: 'select',
+    filter: {
+      defaultOperator: 'eq',
+      operators: ['eq', 'neq'],
+    },
+    canUpdate: false,
+  });
 
-  // CreatedBy, ModifiedBy
-  for (const fieldName of ['createdBy', 'modifiedBy']) {
+  // CreatedBy, LastUpdatedBy
+  for (const fieldName of ['createdBy', 'lastUpdatedBy']) {
     metaData.push({
       automated: true,
       name: fieldName,
       editor: null,
-      canSee: ability.can('read', parent, `data.${fieldName}`),
       canUpdate: false,
       fields: [
         {
@@ -228,7 +218,6 @@ export const getMetaData = async (
       name: fieldName,
       type: 'datetime',
       editor: 'datetime',
-      canSee: ability.can('read', parent, `data.${fieldName}`),
       canUpdate: false,
     });
   }
@@ -238,197 +227,101 @@ export const getMetaData = async (
    *
    * @param field resource field
    */
-  const getFieldMetaData = async (field: any) => {
+  const getFieldMetaData = (field: any) => {
+    const fieldMeta: Metadata = {
+      name: field.name,
+      type: field.type,
+      editor: null,
+    };
     switch (field.type) {
       case 'radiogroup':
       case 'dropdown': {
-        let options = [];
-        if (field.choicesByUrl) {
-          options = await getFullChoices(field, context);
-        } else {
-          options = get(field, 'choices', []).map((x) => {
-            return {
-              text: get(x, 'text', x),
-              value: get(x, 'value', x),
-            };
-          });
-        }
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: 'select',
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-          options,
-        });
+        fieldMeta.editor = 'select';
+        fieldMeta._field = field;
         break;
       }
       case 'checkbox':
       case 'tagbox': {
-        let options = [];
-        if (field.choicesByUrl) {
-          options = await getFullChoices(field, context);
-        } else {
-          options = get(field, 'choices', []).map((x) => {
-            return {
-              text: get(x, 'text', x),
-              value: get(x, 'value', x),
-            };
-          });
-        }
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: 'select',
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-          multiSelect: true,
-          options,
-        });
+        fieldMeta.editor = 'select';
+        fieldMeta.multiSelect = true;
+        fieldMeta._field = field;
         break;
       }
       case 'time': {
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: 'time',
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-        });
+        fieldMeta.editor = 'time';
         break;
       }
       case 'date': {
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: 'date',
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-        });
+        fieldMeta.editor = 'date';
         break;
       }
       case 'datetime':
       case 'datetime-local': {
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: 'datetime',
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-        });
+        fieldMeta.editor = 'datetime';
         break;
       }
       case 'email':
       case 'url':
       case 'comment':
       case 'text': {
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: 'text',
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-        });
+        fieldMeta.editor = 'text';
         break;
       }
       case 'boolean': {
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: 'boolean',
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-        });
+        fieldMeta.editor = 'boolean';
         break;
       }
       case 'numeric': {
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: 'numeric',
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-        });
+        fieldMeta.editor = 'numeric';
         break;
       }
       case 'multipletext': {
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: null,
-          filterable: false,
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-        });
+        fieldMeta.editor = 'datetime';
         break;
       }
       case 'matrix':
       case 'matrixdropdown':
       case 'matrixdynamic':
       case 'multipletext': {
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: null,
-          filterable: false,
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-        });
+        fieldMeta.filterable = false;
         break;
       }
       case 'resource':
       case 'resources': {
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: null,
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-          filterable: level === 0,
-          ...(level === 0 && {
-            fields: await getMetaData(
-              await Resource.findById(field.resource),
-              context,
-              level + 1
-            ),
-          }),
-        });
+        fieldMeta.filterable = root;
+        fieldMeta._field = field;
         break;
       }
       case 'file': {
-        metaData.push({
-          name: field.name,
-          type: field.type,
-          editor: null,
-          filter: {
-            defaultOperator: 'isnotnull',
-            operators: ['isnull', 'isnotnull'],
-          },
-          canSee: ability.can('read', parent, `data.${field.name}`),
-          canUpdate: ability.can('update', parent, `data.${field.name}`),
-        });
+        fieldMeta.filter = {
+          defaultOperator: 'isnotnull',
+          operators: ['isnull', 'isnotnull'],
+        };
         break;
       }
       case 'users': {
-        metaData.push(await getUsersMetaData(parent, ability, field));
+        fieldMeta.editor = 'select';
+        fieldMeta.multiSelect = true;
+        fieldMeta._field = field;
         break;
       }
       case 'owner': {
-        metaData.push(await getRolesMetaData(parent, ability, field));
+        fieldMeta.editor = 'select';
+        fieldMeta.multiSelect = true;
+        fieldMeta._field = field;
         break;
       }
       default: {
         break;
       }
     }
+    metaData.push(fieldMeta);
   };
 
   // Classic fields
   for (const field of parent.fields) {
-    promises.push(getFieldMetaData(field));
+    getFieldMetaData(field);
   }
-
-  await Promise.all(promises);
 
   return sortBy(metaData, (x) => x.name);
 };


### PR DESCRIPTION
# Description

- Create a graphQL type to handle new metadata. This way we can fetch only needed metadata (especially options which can be heavy).
- Support reference data in metadata (not supported before).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on a several form with following type of question:
- Single/multi select choicesByUrl
- Single/multi select ref data
- Single/multi select resource
- User
- Owner

# Checklist:

( * == Mandatory ) 

- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

