### PR TITLE
Feat/oort 574 add simple tests on singular queries in back end

### DIFF
--- a/__tests__/models/record.test.ts
+++ b/__tests__/models/record.test.ts
@@ -14,7 +14,6 @@ beforeAll(async () => {
     name: faker.name.fullName(),
   }).save();
 
-  //create Form
   const formName = faker.random.alpha(10);
 
   //create Resource
@@ -22,6 +21,7 @@ beforeAll(async () => {
     name: formName,
   }).save();
 
+  //create Form
   await new Form({
     name: formName,
     graphQLTypeName: formName,

--- a/__tests__/schema/query/apiConfigurations.test.ts
+++ b/__tests__/schema/query/apiConfigurations.test.ts
@@ -1,0 +1,44 @@
+import { ApolloServer } from 'apollo-server-express';
+import schema from '../../../src/schema';
+import { SafeTestServer } from '../../server.setup';
+import { ApiConfiguration, Role } from '@models';
+
+let server: ApolloServer;
+
+/**
+ * Test ApiConfigurations query.
+ */
+describe('ApiConfigurations query tests', () => {
+  const query = '{ apiConfigurations { totalCount, edges { node { id } } } }';
+
+  test('query with wrong user returns error', async () => {
+    server = await SafeTestServer.createApolloTestServer(schema, {
+      name: 'Wrong user',
+      roles: [],
+    });
+    const result = await server.executeOperation({ query });
+    expect(result.errors).toBeUndefined();
+    expect(result).toHaveProperty(['data', 'apiConfigurations', 'totalCount']);
+    expect(result.data?.apiConfigurations.edges).toEqual([]);
+    expect(result.data?.apiConfigurations.totalCount).toEqual(0);
+  });
+  test('query with admin user returns expected number of apiConfigurations', async () => {
+    const count = await ApiConfiguration.countDocuments();
+    console.log('ApiConfiguration count ==>> ', count);
+    const admin = await Role.findOne(
+      { title: 'admin' },
+      'id permissions'
+    ).populate({
+      path: 'permissions',
+      model: 'Permission',
+    });
+    server = await SafeTestServer.createApolloTestServer(schema, {
+      name: 'Admin user',
+      roles: [admin],
+    });
+    const result = await server.executeOperation({ query });
+    expect(result.errors).toBeUndefined();
+    expect(result).toHaveProperty(['data', 'apiConfigurations', 'totalCount']);
+    expect(result.data?.apiConfigurations.totalCount).toEqual(count);
+  });
+});

--- a/__tests__/schema/query/record.test.ts
+++ b/__tests__/schema/query/record.test.ts
@@ -1,0 +1,93 @@
+import schema from '../../../src/schema';
+import { SafeTestServer } from '../../server.setup';
+import { acquireToken } from '../../authentication.setup';
+import { Form, Resource, Record } from '@models';
+import { faker } from '@faker-js/faker';
+import supertest from 'supertest';
+
+let server: SafeTestServer;
+let record;
+let request: supertest.SuperTest<supertest.Test>;
+let token: string;
+
+beforeAll(async () => {
+  server = new SafeTestServer();
+  await server.start(schema);
+  request = supertest(server.app);
+  token = `Bearer ${await acquireToken()}`;
+
+  //create Form
+  const formName = faker.random.alpha(10);
+
+  //create Resource
+  const resource = await new Resource({
+    name: formName,
+  }).save();
+
+  const form = await new Form({
+    name: formName,
+    graphQLTypeName: formName,
+    resource: resource._id,
+  }).save();
+
+  const records = [];
+  for (let j = 0; j < 10; j++) {
+    records.push({
+      field_1: faker.vehicle.vehicle(),
+      field_2: [faker.word.adjective(), faker.word.adjective()],
+      field_3: faker.word.adjective(),
+    });
+  }
+
+  const inputData = {
+    incrementalId:
+      new Date().getFullYear() +
+      '-D0000000' +
+      faker.datatype.number({ min: 1000000 }),
+    form: form._id,
+    resource: resource._id,
+    archived: 'false',
+    data: records,
+  };
+  record = await new Record(inputData).save();
+});
+afterAll(async () => {
+  await Record.deleteOne({ _id: record._id });
+});
+
+/**
+ * Test Record query.
+ */
+describe('Record query tests', () => {
+  const query =
+    'query getRecord($id: ID!) {\
+      record(id: $id) { id, incrementalId }\
+    }';
+
+  test('query without user returns error', async () => {
+    const variables = {
+      id: record._id,
+    };
+    const response = await request
+      .post('/graphql')
+      .send({ query, variables })
+      .set('Accept', 'application/json');
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('data');
+    expect(response.body.data.record).toBeNull();
+  });
+
+  test('query with admin user returns expected record', async () => {
+    const variables = {
+      id: record._id,
+    };
+    const response = await request
+      .post('/graphql')
+      .send({ query, variables })
+      .set('Authorization', token)
+      .set('Accept', 'application/json');
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('data');
+    expect(response.body.data.record).toHaveProperty('id');
+  });
+});

--- a/__tests__/schema/query/recordHistory.test.ts
+++ b/__tests__/schema/query/recordHistory.test.ts
@@ -1,0 +1,95 @@
+import schema from '../../../src/schema';
+import { SafeTestServer } from '../../server.setup';
+import { acquireToken } from '../../authentication.setup';
+import { Form, Resource, Record } from '@models';
+import { faker } from '@faker-js/faker';
+import supertest from 'supertest';
+
+let server: SafeTestServer;
+let record;
+let request: supertest.SuperTest<supertest.Test>;
+let token: string;
+
+beforeAll(async () => {
+  server = new SafeTestServer();
+  await server.start(schema);
+  request = supertest(server.app);
+  token = `Bearer ${await acquireToken()}`;
+
+  const formName = faker.random.alpha(10);
+
+  //create Resource
+  const resource = await new Resource({
+    name: formName,
+  }).save();
+
+  //create Form
+  const form = await new Form({
+    name: formName,
+    graphQLTypeName: formName,
+    resource: resource._id,
+  }).save();
+
+  const records = [];
+  for (let j = 0; j < 10; j++) {
+    records.push({
+      field_1: faker.vehicle.vehicle(),
+      field_2: [faker.word.adjective(), faker.word.adjective()],
+      field_3: faker.word.adjective(),
+    });
+  }
+
+  const inputData = {
+    incrementalId:
+      new Date().getFullYear() +
+      '-D0000000' +
+      faker.datatype.number({ min: 1000000 }),
+    form: form._id,
+    resource: resource._id,
+    archived: 'false',
+    data: records,
+  };
+  record = await new Record(inputData).save();
+});
+afterAll(async () => {
+  await Record.deleteOne({ _id: record._id });
+});
+
+/**
+ * Test RecordHistory query.
+ */
+describe('RecordHistory query tests', () => {
+  const query =
+    'query getRecordHistory($id: ID!) {\
+      recordHistory(id: $id) { createdAt }\
+    }';
+
+  test('query without user returns error', async () => {
+    const variables = {
+      id: record._id,
+    };
+    const response = await request
+      .post('/graphql')
+      .send({ query, variables })
+      .set('Accept', 'application/json');
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('data');
+    console.log('1 recordHistory ==>> ', response.body.data.recordHistory);
+    expect(response.body.data.recordHistory).toBeNull();
+  });
+
+  test('query with admin user returns expected recordHistory', async () => {
+    const variables = {
+      id: record._id,
+    };
+    const response = await request
+      .post('/graphql')
+      .send({ query, variables })
+      .set('Authorization', token)
+      .set('Accept', 'application/json');
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('data');
+    console.log('2 recordHistory ==>> ', response.body.data.recordHistory);
+    expect(response.body.data.recordHistory.length).toEqual(1);
+  });
+});

--- a/__tests__/schema/query/referenceData.test.ts
+++ b/__tests__/schema/query/referenceData.test.ts
@@ -24,7 +24,7 @@ beforeAll(async () => {
       value: faker.address.countryCode(),
     });
   }
-  let name = faker.random.alpha(10);
+  const name = faker.random.alpha(10);
   const inputData = {
     name: name,
     graphQLTypeName: name,

--- a/__tests__/schema/query/resource.test.ts
+++ b/__tests__/schema/query/resource.test.ts
@@ -1,0 +1,185 @@
+import schema from '../../../src/schema';
+import { SafeTestServer } from '../../server.setup';
+import { acquireToken } from '../../authentication.setup';
+import { Resource } from '@models';
+import { faker } from '@faker-js/faker';
+import supertest from 'supertest';
+
+let server: SafeTestServer;
+let resource;
+let request: supertest.SuperTest<supertest.Test>;
+let token: string;
+
+beforeAll(async () => {
+  server = new SafeTestServer();
+  await server.start(schema);
+  request = supertest(server.app);
+  token = `Bearer ${await acquireToken()}`;
+
+  const field1 = faker.word.adjective();
+  const field2 = faker.word.adjective();
+  const field3 = faker.word.adjective();
+  const field4 = faker.word.adjective();
+
+  const choice1 = faker.word.adjective();
+  const formName = faker.random.alpha(10);
+
+  const layoutLists = [];
+  for (let j = 0; j < 1; j++) {
+    const layoutData = {
+      name: formName,
+      query: {
+        name: formName,
+        template: '',
+        filter: {
+          logic: 'and',
+          filters: [
+            {
+              field: field1,
+              operator: 'eq',
+              value: 'test',
+            },
+            {
+              field: field2,
+              operator: 'contains',
+              value: [choice1],
+            },
+          ],
+        },
+        pageSize: 10,
+        fields: [
+          {
+            name: field1,
+            type: 'String',
+            kind: 'SCALAR',
+            label: field1,
+            format: null,
+          },
+          {
+            name: field2,
+            type: 'JSON',
+            kind: 'SCALAR',
+            label: field2,
+            format: null,
+          },
+        ],
+        sort: {
+          field: field1,
+          order: 'asc',
+        },
+        style: [],
+      },
+    };
+    layoutLists.push(layoutData);
+  }
+  resource = await new Resource({
+    name: formName,
+    layouts: layoutLists,
+    aggregations: {
+      name: faker.word.adjective(),
+      sourceFields: [field1, field2, field3, field4],
+      pipeline: [
+        {
+          type: 'filter',
+          form: {
+            logic: 'and',
+            filters: [
+              {
+                field: field2,
+                value: faker.word.adjective(),
+              },
+            ],
+          },
+        },
+        {
+          type: 'sort',
+          form: {
+            field: field1,
+            order: 'asc',
+          },
+        },
+        {
+          type: 'group',
+          form: {
+            groupBy: [
+              {
+                field: field2,
+                expression: {
+                  operator: null,
+                  field: '',
+                },
+              },
+            ],
+            addFields: [
+              {
+                name: '',
+                expression: {
+                  operator: 'sum',
+                  field: field3,
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: 'addFields',
+          form: [
+            {
+              name: 'fieldnew',
+              expression: {
+                operator: 'add',
+                field: field1,
+              },
+            },
+          ],
+        },
+        {
+          type: 'unwind',
+          form: {
+            field: field1,
+          },
+        },
+      ],
+    },
+  }).save();
+});
+afterAll(async () => {
+  await Resource.deleteOne({ _id: resource._id });
+});
+
+/**
+ * Test Resource query.
+ */
+describe('Resource query tests', () => {
+  const query =
+    'query getResource($id: ID!) {\
+      resource(id: $id) { id, name }\
+    }';
+
+  test('query without user returns error', async () => {
+    const variables = {
+      id: resource._id,
+    };
+    const response = await request
+      .post('/graphql')
+      .send({ query, variables })
+      .set('Accept', 'application/json');
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('data');
+    expect(response.body.data.resource).toBeNull();
+  });
+
+  test('query with admin user returns expected resource', async () => {
+    const variables = {
+      id: resource._id,
+    };
+    const response = await request
+      .post('/graphql')
+      .send({ query, variables })
+      .set('Authorization', token)
+      .set('Accept', 'application/json');
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('data');
+    expect(response.body.data.resource).toHaveProperty('id');
+  });
+});

--- a/__tests__/schema/query/role.test.ts
+++ b/__tests__/schema/query/role.test.ts
@@ -1,12 +1,13 @@
 import schema from '../../../src/schema';
 import { SafeTestServer } from '../../server.setup';
 import { acquireToken } from '../../authentication.setup';
-import { Group } from '@models';
+import { Application, Channel, Role } from '@models';
 import { faker } from '@faker-js/faker';
 import supertest from 'supertest';
+import { status } from '@const/enumTypes';
 
 let server: SafeTestServer;
-let group;
+let role;
 let request: supertest.SuperTest<supertest.Test>;
 let token: string;
 
@@ -16,28 +17,46 @@ beforeAll(async () => {
   request = supertest(server.app);
   token = `Bearer ${await acquireToken()}`;
 
-  group = await new Group({
+  const application = await new Application({
+    name: faker.internet.userName(),
+    status: status.pending,
+  }).save();
+  const channelsInput = [];
+  for (let i = 0; i < 10; i++) {
+    channelsInput.push({
+      title: faker.internet.userName(),
+    });
+  }
+  const channelList: any = await Channel.insertMany(channelsInput);
+  const channels = channelList.map((channel) => {
+    return channel._id;
+  });
+
+  const inputData = {
     title: faker.random.alpha(10),
     description: faker.commerce.productDescription(),
-    oid: faker.datatype.uuid(),
-  }).save();
+    application: application._id,
+    channels: channels,
+  };
+
+  role = await new Role(inputData).save();
 });
 afterAll(async () => {
-  await Group.deleteOne({ _id: group._id });
+  await Role.deleteOne({ _id: role._id });
 });
 
 /**
- * Test Group query.
+ * Test Role query.
  */
-describe('Group query tests', () => {
+describe('Role query tests', () => {
   const query =
-    'query getGroup($id: ID!) {\
-      group(id: $id) { id, title }\
+    'query getRole($id: ID!) {\
+      role(id: $id) { id, title }\
     }';
 
   test('query without user returns error', async () => {
     const variables = {
-      id: group._id,
+      id: role._id,
     };
     const response = await request
       .post('/graphql')
@@ -45,12 +64,12 @@ describe('Group query tests', () => {
       .set('Accept', 'application/json');
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('data');
-    expect(response.body.data.group).toBeNull();
+    expect(response.body.data.role).toBeNull();
   });
 
-  test('query with admin user returns expected group', async () => {
+  test('query with admin user returns expected role', async () => {
     const variables = {
-      id: group._id,
+      id: role._id,
     };
     const response = await request
       .post('/graphql')
@@ -59,6 +78,6 @@ describe('Group query tests', () => {
       .set('Accept', 'application/json');
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('data');
-    expect(response.body.data.group).toHaveProperty('id');
+    expect(response.body.data.role).toHaveProperty('id');
   });
 });

--- a/__tests__/schema/query/step.test.ts
+++ b/__tests__/schema/query/step.test.ts
@@ -1,12 +1,13 @@
 import schema from '../../../src/schema';
 import { SafeTestServer } from '../../server.setup';
 import { acquireToken } from '../../authentication.setup';
-import { Group } from '@models';
+import { Dashboard, Step } from '@models';
 import { faker } from '@faker-js/faker';
 import supertest from 'supertest';
+import { contentType } from '@const/enumTypes';
 
 let server: SafeTestServer;
-let group;
+let step;
 let request: supertest.SuperTest<supertest.Test>;
 let token: string;
 
@@ -16,28 +17,32 @@ beforeAll(async () => {
   request = supertest(server.app);
   token = `Bearer ${await acquireToken()}`;
 
-  group = await new Group({
-    title: faker.random.alpha(10),
-    description: faker.commerce.productDescription(),
-    oid: faker.datatype.uuid(),
+  const dashboard = await new Dashboard({
+    name: faker.word.adjective(),
+  }).save();
+
+  step = await new Step({
+    name: faker.random.alpha(10),
+    type: contentType.dashboard,
+    content: dashboard._id,
   }).save();
 });
 afterAll(async () => {
-  await Group.deleteOne({ _id: group._id });
+  await Step.deleteOne({ _id: step._id });
 });
 
 /**
- * Test Group query.
+ * Test Step query.
  */
-describe('Group query tests', () => {
+describe('Step query tests', () => {
   const query =
-    'query getGroup($id: ID!) {\
-      group(id: $id) { id, title }\
+    'query getStep($id: ID!) {\
+      step(id: $id) { id, name }\
     }';
 
   test('query without user returns error', async () => {
     const variables = {
-      id: group._id,
+      id: step._id,
     };
     const response = await request
       .post('/graphql')
@@ -45,12 +50,12 @@ describe('Group query tests', () => {
       .set('Accept', 'application/json');
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('data');
-    expect(response.body.data.group).toBeNull();
+    expect(response.body.data.step).toBeNull();
   });
 
-  test('query with admin user returns expected group', async () => {
+  test('query with admin user returns expected step', async () => {
     const variables = {
-      id: group._id,
+      id: step._id,
     };
     const response = await request
       .post('/graphql')
@@ -59,6 +64,6 @@ describe('Group query tests', () => {
       .set('Accept', 'application/json');
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('data');
-    expect(response.body.data.group).toHaveProperty('id');
+    expect(response.body.data.step).toHaveProperty('id');
   });
 });

--- a/__tests__/schema/query/user.test.ts
+++ b/__tests__/schema/query/user.test.ts
@@ -1,12 +1,13 @@
 import schema from '../../../src/schema';
 import { SafeTestServer } from '../../server.setup';
 import { acquireToken } from '../../authentication.setup';
-import { Group } from '@models';
+import { Group, Application, User } from '@models';
 import { faker } from '@faker-js/faker';
 import supertest from 'supertest';
+import { status } from '@const/enumTypes';
 
 let server: SafeTestServer;
-let group;
+let user;
 let request: supertest.SuperTest<supertest.Test>;
 let token: string;
 
@@ -16,28 +17,50 @@ beforeAll(async () => {
   request = supertest(server.app);
   token = `Bearer ${await acquireToken()}`;
 
-  group = await new Group({
-    title: faker.random.alpha(10),
-    description: faker.commerce.productDescription(),
+  const groupsData = [];
+  for (let i = 0; i < 10; i++) {
+    groupsData.push({
+      name: faker.word.adjective(),
+    });
+  }
+  const groupList: any = await Group.insertMany(groupsData);
+
+  const groups = groupList.map((group) => {
+    return group._id;
+  });
+
+  //create Application
+  const application = await new Application({
+    name: faker.internet.userName(),
+    status: status.pending,
+  }).save();
+
+  user = await new User({
+    username: faker.internet.email(),
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    name: faker.name.fullName(),
     oid: faker.datatype.uuid(),
+    groups: groups,
+    favoriteApp: application._id,
   }).save();
 });
 afterAll(async () => {
-  await Group.deleteOne({ _id: group._id });
+  await User.deleteOne({ _id: user._id });
 });
 
 /**
- * Test Group query.
+ * Test User query.
  */
-describe('Group query tests', () => {
+describe('User query tests', () => {
   const query =
-    'query getGroup($id: ID!) {\
-      group(id: $id) { id, title }\
+    'query getUser($id: ID!) {\
+      user(id: $id) { id, name }\
     }';
 
   test('query without user returns error', async () => {
     const variables = {
-      id: group._id,
+      id: user._id,
     };
     const response = await request
       .post('/graphql')
@@ -45,12 +68,12 @@ describe('Group query tests', () => {
       .set('Accept', 'application/json');
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('data');
-    expect(response.body.data.group).toBeNull();
+    expect(response.body.data.user).toBeNull();
   });
 
-  test('query with admin user returns expected group', async () => {
+  test('query with admin user returns expected user', async () => {
     const variables = {
-      id: group._id,
+      id: user._id,
     };
     const response = await request
       .post('/graphql')
@@ -59,6 +82,6 @@ describe('Group query tests', () => {
       .set('Accept', 'application/json');
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('data');
-    expect(response.body.data.group).toHaveProperty('id');
+    expect(response.body.data.user).toHaveProperty('id');
   });
 });


### PR DESCRIPTION
# Description
Each ‘singular’ query, meaning that it is on a single object, should have a dedicated test file


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
please run test cases


# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

