### PR TITLE
AB#44839 Created app field issue in the export

### DIFF
--- a/__tests__/schema/query/form.test.ts
+++ b/__tests__/schema/query/form.test.ts
@@ -142,7 +142,7 @@ describe('Form query tests', () => {
     const response = await request
       .post('/graphql')
       .send({ query, variables })
-      .set('Authorization', token)
+      .set('Authorization', `Bearer ${await acquireToken()}`)
       .set('Accept', 'application/json');
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('data');

--- a/src/utils/form/getAccessibleFields.ts
+++ b/src/utils/form/getAccessibleFields.ts
@@ -1,4 +1,5 @@
 import { Record } from '@models';
+import { subject } from '@casl/ability';
 import { AppAbility } from '@security/defineUserAbility';
 
 /**
@@ -12,7 +13,8 @@ import { AppAbility } from '@security/defineUserAbility';
 const getAccessibleFieldsFromRecord = (record: Record, ability: AppAbility) => {
   const fields = Object.keys(record.data);
   const data = fields.reduce((acc, field) => {
-    if (ability.can('read', record, `data.${field}`))
+    //if (ability.can('read', record, `data.${field}`))
+    if (ability.can('read', subject('Record', record)))
       Object.assign(acc, { [field]: record.data[field] });
     return acc;
   }, {});

--- a/src/utils/form/getAccessibleFields.ts
+++ b/src/utils/form/getAccessibleFields.ts
@@ -13,6 +13,7 @@ import { AppAbility } from '@security/defineUserAbility';
 const getAccessibleFieldsFromRecord = (record: Record, ability: AppAbility) => {
   const fields = Object.keys(record.data);
   const data = fields.reduce((acc, field) => {
+    // subject allows to use any object as 'Record', so we don't need to transform object to record, and break some other functionalities
     if (ability.can('read', subject('Record', record), `data.${field}`))
       Object.assign(acc, { [field]: record.data[field] });
     return acc;

--- a/src/utils/form/getAccessibleFields.ts
+++ b/src/utils/form/getAccessibleFields.ts
@@ -13,8 +13,7 @@ import { AppAbility } from '@security/defineUserAbility';
 const getAccessibleFieldsFromRecord = (record: Record, ability: AppAbility) => {
   const fields = Object.keys(record.data);
   const data = fields.reduce((acc, field) => {
-    //if (ability.can('read', record, `data.${field}`))
-    if (ability.can('read', subject('Record', record)))
+    if (ability.can('read', subject('Record', record), `data.${field}`))
       Object.assign(acc, { [field]: record.data[field] });
     return acc;
   }, {});

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -309,9 +309,9 @@ export const getEntityResolver = (
   const formResolver = {
     form: (entity, args, context) => {
       if (context.display && (args.display === undefined || args.display)) {
-        return entity.form.name;
+        return entity.form && entity.form.name ? entity.form?.name : '';
       } else {
-        return entity.form._id;
+        return entity.form && entity.form._id ? entity.form._id : '';
       }
     },
   };

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -12,6 +12,7 @@ import { NameExtension } from '../../introspection/getFieldName';
 import getReferenceDataResolver from './getReferenceDataResolver';
 import get from 'lodash/get';
 import { logger } from '@services/logger.service';
+import { subject } from '@casl/ability';
 
 /**
  * Gets the resolvers for each field of the document for a given resource
@@ -203,10 +204,10 @@ export const getEntityResolver = (
     canUpdate: async (entity, args, context) => {
       const user = context.user;
       const form =
-        new Form(entity._form) ||
+        (entity._form && new Form(entity._form)) ||
         (await Form.findById(entity.form, 'permissions fields resource'));
       const ability = await extendAbilityForRecords(user, form);
-      return ability.can('update', new Record(entity));
+      return ability.can('update', subject('Record', entity));
     },
   };
 
@@ -214,10 +215,10 @@ export const getEntityResolver = (
     canDelete: async (entity, args, context) => {
       const user = context.user;
       const form =
-        new Form(entity._form) ||
+        (entity._form && new Form(entity._form)) ||
         (await Form.findById(entity.form, 'permissions fields resource'));
       const ability = await extendAbilityForRecords(user, form);
-      return ability.can('delete', new Record(entity));
+      return ability.can('delete', subject('Record', entity));
     },
   };
 
@@ -308,18 +309,11 @@ export const getEntityResolver = (
   /** Resolver of form field. */
   const formResolver = {
     form: (entity, args, context) => {
+      const form = entity._form || entity.form;
       if (context.display && (args.display === undefined || args.display)) {
-        return entity.form && entity.form.name
-          ? entity.form?.name
-          : entity._form && entity._form.name
-          ? entity._form.name
-          : '';
+        return get(form, 'name', '');
       } else {
-        return entity.form && entity.form._id
-          ? entity.form._id
-          : entity._form && entity._form._id
-          ? entity._form._id
-          : '';
+        return get(form, '_id', '');
       }
     },
   };

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -203,7 +203,7 @@ export const getEntityResolver = (
     canUpdate: async (entity, args, context) => {
       const user = context.user;
       const form =
-        entity._form ||
+        new Form(entity._form) ||
         (await Form.findById(entity.form, 'permissions fields resource'));
       const ability = await extendAbilityForRecords(user, form);
       return ability.can('update', new Record(entity));
@@ -214,7 +214,7 @@ export const getEntityResolver = (
     canDelete: async (entity, args, context) => {
       const user = context.user;
       const form =
-        entity._form ||
+        new Form(entity._form) ||
         (await Form.findById(entity.form, 'permissions fields resource'));
       const ability = await extendAbilityForRecords(user, form);
       return ability.can('delete', new Record(entity));
@@ -309,9 +309,17 @@ export const getEntityResolver = (
   const formResolver = {
     form: (entity, args, context) => {
       if (context.display && (args.display === undefined || args.display)) {
-        return entity.form && entity.form.name ? entity.form?.name : '';
+        return entity.form && entity.form.name
+          ? entity.form?.name
+          : entity._form && entity._form.name
+          ? entity._form.name
+          : '';
       } else {
-        return entity.form && entity.form._id ? entity.form._id : '';
+        return entity.form && entity.form._id
+          ? entity.form._id
+          : entity._form && entity._form._id
+          ? entity._form._id
+          : '';
       }
     },
   };

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -26,11 +26,11 @@ const defaultRecordAggregation = [
       from: 'forms',
       localField: 'form',
       foreignField: '_id',
-      as: '_form',
+      as: 'form',
     },
   },
   {
-    $unwind: '$_form',
+    $unwind: '$form',
   },
   {
     $lookup: {
@@ -386,7 +386,8 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
           },
         },
       ]);
-      items = aggregation[0].items.map((x) => new Record(x)); // needed for accessible fields check
+      //items = aggregation[0].items.map((x) => new Record(x)); // needed for accessible fields check
+      items = aggregation[0].items;
       totalCount = aggregation[0]?.totalCount[0]?.count || 0;
     } else {
       // If we're using cursors, get pagination filters  <---- DEPRECATED ??
@@ -611,7 +612,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
 
     // === CONSTRUCT OUTPUT + RETURN ===
     const edges = items.map((r) => {
-      const record = getAccessibleFields(r, ability).toObject();
+      const record = getAccessibleFields(r, ability);
       Object.assign(record, { id: record._id });
 
       return {

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -386,7 +386,6 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
           },
         },
       ]);
-      //items = aggregation[0].items.map((x) => new Record(x)); // needed for accessible fields check
       items = aggregation[0].items;
       totalCount = aggregation[0]?.totalCount[0]?.count || 0;
     } else {
@@ -415,7 +414,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
           },
         },
       ]);
-      items = aggregation[0].items.map((x) => new Record(x)); // needed for accessible fields check
+      items = aggregation[0].items;
       totalCount = aggregation[0]?.totalCount[0]?.count || 0;
     }
 

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -26,11 +26,11 @@ const defaultRecordAggregation = [
       from: 'forms',
       localField: 'form',
       foreignField: '_id',
-      as: 'form',
+      as: '_form',
     },
   },
   {
-    $unwind: '$form',
+    $unwind: '$_form',
   },
   {
     $lookup: {


### PR DESCRIPTION
# Description
I want to reach out regarding an issue with the export of the signal app. Below column of "Created app"  was recently added to the AEMM and monthly report view so that the business can filter 
However, when they export the data, this column is completely empty. Using the filter function in the app doesn’t work either which suggests that the values are being displayed but are not being considered.
Can you help with this?

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
please export records with form fields and check form name is export or not

## Sreenshots
![image](https://user-images.githubusercontent.com/111883188/213689479-3852f54b-f01f-4c4c-984d-faa9f4c69793.png)

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

