### PR TITLE
Fix/ab#54743 cannot update permissions filter

### DIFF
--- a/__tests__/schema/query/form.test.ts
+++ b/__tests__/schema/query/form.test.ts
@@ -142,7 +142,7 @@ describe('Form query tests', () => {
     const response = await request
       .post('/graphql')
       .send({ query, variables })
-      .set('Authorization', `Bearer ${await acquireToken()}`)
+      .set('Authorization', token)
       .set('Accept', 'application/json');
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('data');

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -656,6 +656,7 @@ export default {
         }
       }
     }
+    // Split the request in two parts, to avoid conflict
     if (!!update.$pull) {
       await Resource.findByIdAndUpdate(
         args.id,
@@ -669,11 +670,5 @@ export default {
       { new: true },
       () => args.fields && buildTypes()
     );
-    /* return Resource.findByIdAndUpdate(
-      args.id,
-      update,
-      { new: true },
-      () => args.fields && buildTypes()
-    ); */
   },
 };

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -658,17 +658,16 @@ export default {
         }
       }
     }
-    if (!!update['$pull']) {
+    if (!!update.$pull) {
       await Resource.findByIdAndUpdate(
         args.id,
-        { modifiedAt: update.modifiedAt, $pull: update['$pull'] },
+        { modifiedAt: update.modifiedAt, $pull: update.$pull },
         () => args.fields && buildTypes()
       );
     }
-
     return Resource.findByIdAndUpdate(
       args.id,
-      { modifiedAt: update.modifiedAt, $addToSet: update['$addToSet'] },
+      { modifiedAt: update.modifiedAt, $addToSet: update.$addToSet },
       { new: true },
       () => args.fields && buildTypes()
     );

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -661,13 +661,13 @@ export default {
     if (!!update.$pull) {
       await Resource.findByIdAndUpdate(
         args.id,
-        { modifiedAt: update.modifiedAt, $pull: update.$pull },
+        { $pull: update.$pull },
         () => args.fields && buildTypes()
       );
     }
     return Resource.findByIdAndUpdate(
       args.id,
-      { modifiedAt: update.modifiedAt, $addToSet: update.$addToSet },
+      { $addToSet: update.$addToSet },
       { new: true },
       () => args.fields && buildTypes()
     );

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -557,9 +557,7 @@ export default {
     }
 
     // Create the update object
-    const update: any = {
-      modifiedAt: new Date(),
-    };
+    const update: any = {};
     Object.assign(update, args.fields && { fields: args.fields });
 
     const allResourceFields = (await Resource.findById(args.id)).fields;

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -658,12 +658,25 @@ export default {
         }
       }
     }
+    if (!!update['$pull']) {
+      await Resource.findByIdAndUpdate(
+        args.id,
+        { modifiedAt: update.modifiedAt, $pull: update['$pull'] },
+        () => args.fields && buildTypes()
+      );
+    }
 
     return Resource.findByIdAndUpdate(
+      args.id,
+      { modifiedAt: update.modifiedAt, $addToSet: update['$addToSet'] },
+      { new: true },
+      () => args.fields && buildTypes()
+    );
+    /* return Resource.findByIdAndUpdate(
       args.id,
       update,
       { new: true },
       () => args.fields && buildTypes()
-    );
+    ); */
   },
 };


### PR DESCRIPTION
# Description
Currently to update a filter, we're pulling it from the array and pushing the new one after. It looks like mongo cannot pull and push objects in the same field in one update operation. Maybe try to use another compatible operator instead. Otherwise, we should separate those in two updates.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
 - Go to a role page
 - Go to the Resource tab
 - Open a resource
 - Create a filter permission on any access
 - Save it
 - Update the filter
 - Save it

## Sreenshots
![image](https://user-images.githubusercontent.com/111883188/214005784-33ba88ad-bf55-4168-becc-d87772b9bdf0.png)

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

