### PR TITLE
fix/AB#55074_copy-dashboard-from-workflow

### DIFF
--- a/src/services/page.service.ts
+++ b/src/services/page.service.ts
@@ -1,6 +1,7 @@
 import { GraphQLError } from 'graphql';
 import { Page, Application, Workflow, Dashboard, Form, Step } from '@models';
 import i18next from 'i18next';
+import mongoose from 'mongoose';
 
 /**
  * Creates new pages from a given application and returns them in an array.
@@ -45,7 +46,7 @@ export const duplicatePages = async (application: Application) => {
  * @returns copy of the page
  */
 export const duplicatePage = async (
-  page: Page,
+  page: Page | { content: mongoose.Types.ObjectId; type: string; name: string },
   name?: string,
   permissions?: any
 ) => {


### PR DESCRIPTION
# Description

Updated the duplicatePage mutation to also duplicate Dashboards that are Steps, and not only duplicate Pages.
Changed need due to the impossibility of making a copy of a Dashboard inside a Workflow, when It's possible to make a copy of a Dashboard that's a Page.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Copying Dashboards from inside and outside Workflows.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

