### PR TITLE
Fix 1.3.x/ab#35599 let not supported 2

### DIFF
--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -292,6 +292,18 @@ export default {
                 },
               },
               {
+                $addFields: {
+                  [`data.${fieldName}`]: {
+                    $filter: {
+                      input: `$data.${fieldName}`,
+                      cond: {
+                        $eq: ['$$this.form', relatedField.form],
+                      },
+                    },
+                  },
+                },
+              },
+              {
                 $addFields: selectableDefaultRecordFieldsFlat.reduce(
                   (fields, selectableField) => {
                     if (!selectableField.includes('By')) {

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -342,11 +342,10 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
     const afterLookupsFilters = getAfterLookupsFilter(filter, fields, context);
 
     // Add the basic records filter
-    Object.assign(
-      mongooseFilter,
-      { $or: [{ resource: id }, { form: id }] },
-      { archived: { $ne: true } }
-    );
+    const basicFilters = {
+      $or: [{ resource: id }, { form: id }],
+      archived: { $ne: true },
+    };
 
     // Additional filter from the user permissions
     const form = await Form.findOne({
@@ -369,6 +368,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
     // If we're using skip parameter, include them into the aggregation
     if (skip || skip === 0) {
       const aggregation = await Record.aggregate([
+        { $match: basicFilters},
         ...linkedRecordsAggregation,
         ...linkedReferenceDataAggregation,
         ...defaultRecordAggregation,
@@ -397,6 +397,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
           }
         : {};
       const aggregation = await Record.aggregate([
+        { $match: basicFilters},
         ...linkedRecordsAggregation,
         ...linkedReferenceDataAggregation,
         ...defaultRecordAggregation,


### PR DESCRIPTION
# Description

Aggregation was not working because we did not filter on relatedForm (spme fields could be named the same across resources).
Query all was not working because again some LIST fields could be named the same way.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with aggregation on related records for the first issue and a filter on a resource field for the second one.

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

