### PR TITLE
AB#57872 bug issue of not filter not working

### DIFF
--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -258,15 +258,15 @@ const buildMongoFilter = (
                     return {
                       $or: [
                         { [fieldName]: { $ne: value } },
-                        { [fieldName]: { $ne: intValue } },
-                        { [fieldName]: { $exists: false } },
+                        // { [fieldName]: { $ne: intValue } },
+                        { [fieldName]: { $exists: true } },
                       ],
                     };
                   } else {
                     return {
                       $or: [
                         { [fieldName]: { $ne: value } },
-                        { [fieldName]: { $ne: intValue } },
+                        // { [fieldName]: { $ne: intValue } },
                       ],
                     };
                   }
@@ -274,7 +274,7 @@ const buildMongoFilter = (
                   return {
                     $or: [
                       { [fieldName]: { $ne: value } },
-                      { [fieldName]: { $ne: intValue } },
+                      // { [fieldName]: { $ne: intValue } },
                     ],
                   };
                 }

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -213,12 +213,31 @@ const buildMongoFilter = (
               if (isNaN(intValue)) {
                 return { [fieldName]: { $eq: value } };
               } else {
-                return {
-                  $or: [
-                    { [fieldName]: { $eq: value } },
-                    { [fieldName]: { $eq: intValue } },
-                  ],
-                };
+                if (type == 'boolean') {
+                  if (value == null) {
+                    return {
+                      $or: [
+                        { [fieldName]: { $eq: value } },
+                        { [fieldName]: { $eq: intValue } },
+                        { [fieldName]: { $exists: false } },
+                      ],
+                    };
+                  } else {
+                    return {
+                      $or: [
+                        { [fieldName]: { $eq: value } },
+                        { [fieldName]: { $eq: intValue } },
+                      ],
+                    };
+                  }
+                } else {
+                  return {
+                    $or: [
+                      { [fieldName]: { $eq: value } },
+                      { [fieldName]: { $eq: intValue } },
+                    ],
+                  };
+                }
               }
             }
           }
@@ -234,12 +253,31 @@ const buildMongoFilter = (
               if (isNaN(intValue)) {
                 return { [fieldName]: { $ne: value } };
               } else {
-                return {
-                  $or: [
-                    { [fieldName]: { $ne: value } },
-                    { [fieldName]: { $ne: intValue } },
-                  ],
-                };
+                if (type == 'boolean') {
+                  if (value == null) {
+                    return {
+                      $or: [
+                        { [fieldName]: { $ne: value } },
+                        { [fieldName]: { $ne: intValue } },
+                        { [fieldName]: { $exists: false } },
+                      ],
+                    };
+                  } else {
+                    return {
+                      $or: [
+                        { [fieldName]: { $ne: value } },
+                        { [fieldName]: { $ne: intValue } },
+                      ],
+                    };
+                  }
+                } else {
+                  return {
+                    $or: [
+                      { [fieldName]: { $ne: value } },
+                      { [fieldName]: { $ne: intValue } },
+                    ],
+                  };
+                }
               }
             }
           }


### PR DESCRIPTION
# Description
Have a resource with a boolean field called confidential
Have some records with true, false or null set up for this field
Have two roles:
First which can access all records from this resource
Second which can access only non confidential records. Try it twice:
Filter on confidential not equal true -> gives access to all records
Filter on confidential equal false or confidential equal null -> gives access to correct records but we cannot see any fields from the ones with confidential = null.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
please create permission filter from application=>role=>resource and singup and login in the front office and also add application role to user

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

