### PR TITLE
Feat/ab#56114 sa hq ro provide a field and column with filter for modified app

### DIFF
--- a/src/const/defaultRecordFields.ts
+++ b/src/const/defaultRecordFields.ts
@@ -115,6 +115,15 @@ export const defaultRecordFields: {
     filterType: GraphQLBoolean,
     selectable: false,
   },
+  {
+    field: 'lastUsedForm',
+    type: GraphQLID,
+    filterType: GraphQLString,
+    selectable: true,
+    args: {
+      display: { type: GraphQLBoolean },
+    },
+  },
 ];
 
 /**
@@ -148,6 +157,7 @@ export const defaultMetaFields: { field: string; type: GraphQLType }[] = [
   { field: 'canUpdate', type: GraphQLJSON },
   { field: 'canDelete', type: GraphQLJSON },
   { field: '_source', type: GraphQLID },
+  { field: 'lastUsedForm', type: GraphQLJSON },
 ];
 
 /** The names of the deafult meta fields */

--- a/src/models/record.model.ts
+++ b/src/models/record.model.ts
@@ -30,6 +30,7 @@ export interface Record extends AccessibleFieldsDocument {
     canDelete?: any[];
   };
   createdBy?: any;
+  lastUsedForm?: any;
 }
 
 /** Mongoose record schema declaration */
@@ -79,6 +80,10 @@ const recordSchema = new Schema<Record>(
     versions: {
       type: [mongoose.Schema.Types.ObjectId],
       ref: 'Version',
+    },
+    lastUsedForm: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Form'
     },
   },
   {

--- a/src/models/record.model.ts
+++ b/src/models/record.model.ts
@@ -83,7 +83,7 @@ const recordSchema = new Schema<Record>(
     },
     lastUsedForm: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'Form'
+      ref: 'Form',
     },
   },
   {

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -134,6 +134,7 @@ export default {
       transformRecord(args.data, template.fields);
       const update: any = {
         data: { ...oldRecord.data, ...args.data },
+        lastUsedForm: args.template,
         //modifiedAt: new Date(),
         $push: { versions: version._id },
       };
@@ -158,6 +159,7 @@ export default {
       });
       const update: any = {
         data: oldVersion.data,
+        lastUsedForm: args.template,
         //modifiedAt: new Date(),
         $push: { versions: version._id },
       };

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -318,6 +318,18 @@ export const getEntityResolver = (
     },
   };
 
+  /** Resolver of lastUsedForm field. */
+  const lastUsedFormResolver = {
+    lastUsedForm: (entity, args, context) => {
+      const lastUsedForm = entity._lastUsedForm || entity.lastUsedForm;
+      if (context.display && (args.display === undefined || args.display)) {
+        return get(lastUsedForm, 'name', '');
+      } else {
+        return get(lastUsedForm, '_id', '');
+      }
+    },
+  };
+
   return Object.assign(
     {},
     classicResolvers,
@@ -328,6 +340,7 @@ export const getEntityResolver = (
     manyToManyResolvers,
     oneToManyResolvers,
     referenceDataResolvers,
-    formResolver
+    formResolver,
+    lastUsedFormResolver
   );
 };

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -162,7 +162,7 @@ const defaultRecordAggregation = [
   },
   {
     $addFields: {
-      '_lastUsedForm': {
+      _lastUsedForm: {
         $ifNull: ['$_lastUsedForm', '$_form'],
       },
     },

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -146,6 +146,27 @@ const defaultRecordAggregation = [
     },
   },
   { $unset: 'lastVersion' },
+  {
+    $lookup: {
+      from: 'forms',
+      localField: 'lastUsedForm',
+      foreignField: '_id',
+      as: '_lastUsedForm',
+    },
+  },
+  {
+    $unwind: {
+      path: '$_lastUsedForm',
+      preserveNullAndEmptyArrays: true,
+    },
+  },
+  {
+    $addFields: {
+      '_lastUsedForm': {
+        $ifNull: ['$_lastUsedForm', '$_form'],
+      },
+    },
+  },
 ];
 
 /**


### PR DESCRIPTION
# Description
Currently the business has a 'Created App' column where they can filter the signals according to the HQ or RO that created them.  However this field does not take into account the signals that have been modified by another region or HQ.  
The users need a field to set up a column so they can see all signals that have been modified by HQ or a certain RO - 'Modified App'.  
Comment from Pacome - Currently the Created app field is not really returning the app where the Signal was created but the template used for its creation.
My proposition would be to add a new default field to all records where we are storing the last template used to edit the record. It could be called lastUsedForm or anything similar and then we will be able to label it "Modified App" (even if it's not strictly correct).

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
here you will need to create two form, one is core and scond is child form and then add/update records from dashboard, but currently you can't see Modified App field because Frontend work is pending

## Fronted Issue
when we are updating record from resource(check below screenshot), that time I am not getting template in the editRecord(check below screenshot).
![image](https://user-images.githubusercontent.com/111883188/223443927-b9d095b7-034a-4a39-bec3-8e0d034d4c28.png)

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

