### PR TITLE
AB#58694 Add GeoJSON generation in new API endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@azure/storage-blob": "^12.5.0",
     "@casl/ability": "^5.2.2",
     "@casl/mongoose": "^5.0.0",
+    "@turf/turf": "^6.5.0",
     "@ucast/mongo2js": "^1.3.3",
     "amqplib": "^0.8.0",
     "apollo-datasource-rest": "^3.5.2",

--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { generateGeoJson } from '@utils/geojson/generateGeoJson';
 
 /**
  * Endpoint for custom feature layers
@@ -12,38 +13,45 @@ const router = express.Router();
  * @param res http response
  * @returns GeoJSON feature collection
  */
-
-/**
- *
- */
-const features = [
-  {
-    type: 'Feature',
-    geometry: {
+router.get('/feature/:type', async (req, res) => {
+  const property = {
+    Polygon: {
+      type: 'Polygon',
+      generateProperties: () => {
+        const randomString = Math.random().toString(36).substring(7);
+        return {
+          name: `Polygon ${randomString}`,
+        };
+      },
+      numGeometries: 10,
+    },
+    LineString: {
+      type: 'LineString',
+      generateProperties: () => {
+        const randomString = Math.random().toString(36).substring(7);
+        return {
+          name: `LineString ${randomString}`,
+        };
+      },
+      numGeometries: 10,
+    },
+    Point: {
       type: 'Point',
-      coordinates: [-122.419416, 37.774929],
+      generateProperties: () => {
+        const randomString = Math.random().toString(36).substring(7);
+        return {
+          name: `Point ${randomString}`,
+        };
+      },
+      numGeometries: 10,
     },
-    properties: {
-      name: 'San Francisco',
-    },
-  },
-  {
-    type: 'Feature',
-    geometry: {
-      type: 'Point',
-      coordinates: [-73.935242, 40.73061],
-    },
-    properties: {
-      name: 'New York City',
-    },
-  },
-];
+  };
 
-router.get('/feature', async (req, res) => {
   const featureCollection = {
     type: 'FeatureCollection',
-    features: features,
+    features: generateGeoJson(property[req.params.type]),
   };
+
   res.send(featureCollection);
 });
 

--- a/src/utils/geojson/generateGeoJson.ts
+++ b/src/utils/geojson/generateGeoJson.ts
@@ -1,55 +1,4 @@
-// import { getRandomIcon } from '../const/fa-icons';
-// import { MarkerIconOptions } from '../utils/create-div-icon';
-
-/** Represents the types of geometries that can be generated */
-type FeatureTypes = 'Point' | 'Polygon' | 'LineString';
-
-/** Options for generating random features */
-type CollectionGeneratorOptions = {
-  [key in FeatureTypes]?: {
-    generateProperties: () => any;
-    probability?: number;
-    numCoordinates?: number;
-    maxDistance?: number;
-    minDistance?: number;
-  };
-} & {
-  numFeatures: number;
-};
-
-/** Default max distance in degrees */
-const DEFAULT_MAX_DISTANCE = 15;
-
-/** Default min distance in degrees */
-const DEFAULT_MIN_DISTANCE = 5;
-
-/**
- * Returns a random item from the given options based on the weights provided.
- *
- * @param options - Array of options to choose from
- * @param weights - Array of weights for each option
- * @returns The randomly selected item from the options array
- */
-const weightedRandom = (
-  options: FeatureTypes[],
-  weights: { [key in FeatureTypes]: number }
-) => {
-  let sum = 0;
-  const keys = Object.keys(weights) as FeatureTypes[];
-  for (const key of keys) {
-    sum += weights[key];
-  }
-
-  const randomNum = Math.random() * sum;
-  let weightSum = 0;
-  for (const key of options) {
-    weightSum += weights[key];
-    if (randomNum <= weightSum) {
-      return key;
-    }
-  }
-  return options[options.length - 1];
-};
+import * as turf from '@turf/turf';
 
 /**
  * Generates random features based on the specified options
@@ -57,63 +6,48 @@ const weightedRandom = (
  * @param options Options for generating random features
  * @returns Array of generated features
  */
-export const generateGeoJson = (options: CollectionGeneratorOptions) => {
-  const featureTypes = Object.keys(options) as FeatureTypes[];
-  const typeProbabilities = featureTypes.reduce((probabilities, type) => {
-    const prob = options[type]?.probability;
-    if (prob !== undefined) {
-      probabilities[type] = prob;
-    }
-    return probabilities;
-  }, {} as { [key in FeatureTypes]: number });
-
-  const features = [];
-  for (let i = 0; i < options.numFeatures; i++) {
-    const type = weightedRandom(featureTypes, typeProbabilities);
-    const option = options[type];
-    if (!option) continue;
-    const properties = option.generateProperties();
-    const maxDistance = option.maxDistance || DEFAULT_MAX_DISTANCE;
-    const minDistance = option.minDistance || DEFAULT_MIN_DISTANCE;
-    let coordinates;
-    switch (type) {
-      case 'Point':
-        coordinates = [Math.random() * 360 - 180, Math.random() * 180 - 90];
-        break;
-      case 'Polygon':
-      case 'LineString':
-        const numCoordinates = options[type]?.numCoordinates || 3;
-        coordinates = [];
-        let previousLat = 0;
-        let previousLng = 0;
-        for (let j = 0; j < numCoordinates; j++) {
-          let lat = Math.random() * 180 - 90;
-          let lng = Math.random() * 360 - 180;
-          if (j !== 0) {
-            let latDifference = Math.abs(previousLat - lat);
-            let lngDifference = Math.abs(previousLng - lng);
-            while (
-              latDifference > maxDistance ||
-              lngDifference > maxDistance ||
-              latDifference < minDistance ||
-              lngDifference < minDistance
-            ) {
-              lat = Math.random() * 180 - 90;
-              lng = Math.random() * 360 - 180;
-              latDifference = Math.abs(previousLat - lat);
-              lngDifference = Math.abs(previousLng - lng);
-            }
-          }
-          previousLat = lat;
-          previousLng = lng;
-          coordinates.push([lat, lng]);
-        }
-        if (type === 'Polygon') {
-          coordinates = [coordinates];
-        }
-        break;
-    }
-    features.push({ type, properties, coordinates });
+export const generateGeoJson = (options) => {
+  let features;
+  switch (options.type) {
+    case 'Point':
+      const pointGeo = turf.randomPoint(options.numGeometries);
+      features = pointGeo.features.map((geoData) => {
+        Object.assign(geoData.geometry, {
+          properties: options.generateProperties(),
+        });
+        return geoData.geometry;
+      });
+      break;
+    case 'Polygon':
+      const polygons = turf.randomPolygon(options.numGeometries, {
+        max_radial_length: 2,
+      });
+      const simplifiedPolygons = turf.simplify(polygons, {
+        tolerance: 0.9,
+        highQuality: true,
+      });
+      features = simplifiedPolygons.features.map((geoData) => {
+        Object.assign(geoData.geometry, {
+          properties: options.generateProperties(),
+        });
+        return geoData.geometry;
+      });
+      break;
+    case 'LineString':
+      const lineString = turf.randomLineString(options.numGeometries, {
+        num_vertices: 15,
+      });
+      const simplifiedLineString = turf.simplify(lineString, {
+        tolerance: 0.9,
+        highQuality: true,
+      });
+      features = simplifiedLineString.features.map((geoData) => {
+        Object.assign(geoData.geometry, {
+          properties: options.generateProperties(),
+        });
+        return geoData.geometry;
+      });
+      break;
   }
   return features;
 };


### PR DESCRIPTION
# Description
+ new route: gis/feature
Use new geojson generation in this route, so the route returns a custom geojson.
if possible, I'd like to see also if we can reuse the result from this ticket:
https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Dashboards/Stories/?workitem=54346
so we have a parameter in the endpoint that we can use to reduce the geojson size
Based on main GIS branch

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
You can test this end-point from postman, here end-point
`gis/feature/:type`
if you need to pass type as parameter in the URL
Polygon, LineString, Point pass one any as type in the URL

# Checklist:
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

