### PR TITLE
AB#58658 changed the logic of the editForm mutation to modify the structure as…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - 'rabbitmq_data:/data'
       - ./.docker/rabbitmq/etc/:/etc/rabbitmq/
       - ./.docker/rabbitmq/data/:/var/lib/rabbitmq/
-      - ./.docker/rabbitmq/logs/:/var/log/rabbitmq/
+      #- ./.docker/rabbitmq/logs/:/var/log/rabbitmq/
       - ./rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins
     ports:
       - '5672:5672'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - 'rabbitmq_data:/data'
       - ./.docker/rabbitmq/etc/:/etc/rabbitmq/
       - ./.docker/rabbitmq/data/:/var/lib/rabbitmq/
-      #- ./.docker/rabbitmq/logs/:/var/log/rabbitmq/
+      - ./.docker/rabbitmq/logs/:/var/log/rabbitmq/
       - ./rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins
     ports:
       - '5672:5672'

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -244,10 +244,11 @@ export default {
           }
         }
       }
-      // Resource inheritance management
-      if (form.resource) {
+      // === Resource inheritance management ===
+      const prevStructure = JSON.parse(form.structure ? form.structure : ''); // Get the current form's state structure
+      if (form.resource && !isEqual(prevStructure, structure)) {
+        // If the form has a resource and its structure has changed
         const resource = await Resource.findById(form.resource);
-        const prevStructure = JSON.parse(form.structure ? form.structure : ''); // Get the current form's state structure
         const templates = await Form.find({
           resource: form.resource,
           _id: { $ne: mongoose.Types.ObjectId(args.id) },
@@ -269,16 +270,16 @@ export default {
           } else {
             // Check if field can be updated
             if (!oldField.isCore || (oldField.isCore && form.core)) {
-              //If resource's field isn't core or if it's core but the edited form is core too, make it writable
-              if (!isEqual(oldField, field)) {
-                // If the resource's field and the current form's field are different OR if the structure haas changed
+              // If resource's field isn't core or if it's core but the edited form is core too, make it writable
+              const storedFieldChanged = !isEqual(oldField, field);
+              if (storedFieldChanged) {
+                // If the resource's field and the current form's field are different
                 const index = oldFields.findIndex((x) => x.name === field.name); // Get the index of the form's field in the resources
                 oldFields.splice(index, 1, field); // Replace resource's field by the form's field
               }
-              if (!isEqual(prevStructure, structure)) {
-                //As soon as the structure is changed, we change the templates that inherit from it
-                for (const template of templates) {
-                  // For each form that inherits from the same resource
+              for (const template of templates) {
+                // For each form that inherits from the same resource
+                if (storedFieldChanged) {
                   template.fields = template.fields.map((x) => {
                     // For each field of the childForm
                     return x.name === field.name // If the child field's name equals the parent field's name
@@ -288,17 +289,17 @@ export default {
                         : field // Else replace child's field by parent's field
                       : x; // Else don't change the child's field
                   });
-                  if (!field.generated) {
-                    // Update structure
-                    const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
-                    replaceField(
-                      field.name,
-                      newStructure,
-                      structure,
-                      prevStructure
-                    ); // Replace the inheriting form's field by the edited form's field
-                    template.structure = JSON.stringify(newStructure); // Save the new structure
-                  }
+                }
+                if (!field.generated) {
+                  // Update structure
+                  const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
+                  replaceField(
+                    field.name,
+                    newStructure,
+                    structure,
+                    prevStructure
+                  ); // Replace the inheriting form's field by the edited form's field
+                  template.structure = JSON.stringify(newStructure); // Save the new structure
                 }
               }
             }


### PR DESCRIPTION
# Description

Changed the logic of the edit form mutation: now, if a form is core, as soon as the structure is changed, change is reflected upon the children.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Created a radio group question on a core form. Created a form inheriting from the core form. Upon changing the name or the 'show clear button' options (both structure only changes), change is now reflected to the child.

## Sreenshots



# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules



