### PR TITLE
Feat/ab#54941 db create proxy for arc gis api to keep api key safe

### DIFF
--- a/config/custom-environment-variables.js
+++ b/config/custom-environment-variables.js
@@ -50,4 +50,8 @@ module.exports = {
     user: 'RABBITMQ_DEFAULT_USER',
     pass: 'RABBITMQ_DEFAULT_PASS',
   },
+  arcgis: {
+    api_key: 'ARCGIS_API_KEY',
+    api_url: 'ARCGIS_API_URL',
+  },
 };

--- a/src/routes/arcgis/index.ts
+++ b/src/routes/arcgis/index.ts
@@ -1,0 +1,63 @@
+import express from 'express';
+import { request as httpsRequest } from 'https';
+import config from 'config';
+import { isEmpty } from 'lodash';
+
+/**
+ * Endpoint for arcgis API call
+ */
+const router = express.Router();
+
+/**
+ * Build endpoint
+ *
+ * @param req current http request
+ * @param res http response
+ * @returns GeoJSON feature collection
+ */
+router.get('/data', async (req, res) => {
+  try {
+    const arcgisUrl = new URL(`${config.get('arcgis.api_url')}`);
+    let path: any = req.query.path;
+    path = path.includes('?')
+      ? `${req.query.path}&apiKey=${config.get('arcgis.api_key')}`
+      : `${req.query.path}?apiKey=${config.get('arcgis.api_key')}`;
+
+    const options = {
+      host: arcgisUrl.hostname,
+      path: path,
+      method: 'GET',
+    };
+    let statusCode = 200;
+    const response = await new Promise((resolve, reject) => {
+      let body: any = [];
+      const req = httpsRequest(options, (resquest) => {
+        statusCode = resquest.statusCode;
+        if (resquest.statusCode < 200 || resquest.statusCode >= 300) {
+          return reject(new Error('statusCode=' + resquest.statusCode));
+        }
+        resquest.on('data', function (chunk) {
+          body.push(chunk);
+        });
+        resquest.on('end', function () {
+          try {
+            body = JSON.parse(Buffer.concat(body).toString());
+          } catch (e) {
+            reject(e);
+          }
+          return resolve(body);
+        });
+      });
+      req.on('error', (e) => {
+        reject(e.message);
+      });
+      req.end();
+    });
+    console.log('statusCode ==>> ', statusCode);
+    res.status(statusCode).send(response);
+  } catch (error) {
+    console.log('try catch error ==>> ', error);
+  }
+});
+
+export default router;

--- a/src/routes/arcgis/index.ts
+++ b/src/routes/arcgis/index.ts
@@ -1,7 +1,6 @@
 import express from 'express';
 import { request as httpsRequest } from 'https';
 import config from 'config';
-import { isEmpty } from 'lodash';
 
 /**
  * Endpoint for arcgis API call
@@ -31,7 +30,7 @@ router.get('/data', async (req, res) => {
     let statusCode = 200;
     const response = await new Promise((resolve, reject) => {
       let body: any = [];
-      const req = httpsRequest(options, (resquest) => {
+      const request = httpsRequest(options, (resquest) => {
         statusCode = resquest.statusCode;
         if (resquest.statusCode < 200 || resquest.statusCode >= 300) {
           return reject(new Error('statusCode=' + resquest.statusCode));
@@ -48,10 +47,10 @@ router.get('/data', async (req, res) => {
           return resolve(body);
         });
       });
-      req.on('error', (e) => {
+      request.on('error', (e) => {
         reject(e.message);
       });
-      req.end();
+      request.end();
     });
     console.log('statusCode ==>> ', statusCode);
     res.status(statusCode).send(response);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -9,6 +9,7 @@ import fileUpload from 'express-fileupload';
 import permissions from './permissions';
 import roles from './roles';
 import gis from './gis';
+import arcgis from './arcgis';
 
 /** Express router instance */
 const router = express.Router();
@@ -24,5 +25,6 @@ router.use('/permissions', permissions);
 router.use('/summarycards', summarycards);
 router.use('/roles', roles);
 router.use('/gis', gis);
+router.use('/arcgis', arcgis);
 
 export { router };


### PR DESCRIPTION
# Description
Add a new proxy router in the back-end, called 'arcgis' that the front-end would use in order to contact arcgis, to prevent using the API key in the front

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
please run this end-point in the postman with path query parameter
`/arcgis/data/`
![image](https://user-images.githubusercontent.com/111883188/224732525-bc17c5d2-cb0d-4472-84e8-89a261446cca.png)

pass like data in the path paramer
`/arcgis/rest/services/styles/OSM:Standard?type=style`

## ENV
I have added this both parameter in the env file
`ARCGIS_API_KEY,
ARCGIS_API_URL`

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

