### PR TITLE
fix/AB#60680 no data available on summary cards when concat

### DIFF
--- a/src/utils/aggregation/buildCalculatedFieldPipeline.ts
+++ b/src/utils/aggregation/buildCalculatedFieldPipeline.ts
@@ -268,7 +268,9 @@ const resolveMultipleOperators = (
                         date: value,
                       },
                     },
-                    else: { $toString: value },
+                    else: {
+                      $convert: { input: value, to: 'string', onError: null },
+                    },
                   },
                 };
               } else {


### PR DESCRIPTION
# Description

I change the $toString operator to $convert in the concat pipeline stage. It prevents crash sending null when an error occurs.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/60680/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The previous code didn't handle errors, the new code prevents crashing when it happens with fields that can't be concatenated.

## Sreenshots

Before the fix:
![Screenshot 2023-04-11 at 15 40 17](https://user-images.githubusercontent.com/9751045/231181694-476268dc-e2c5-48f4-8113-d90bc1b4c601.png)

After the fix:
![Screenshot 2023-04-11 at 15 38 04](https://user-images.githubusercontent.com/9751045/231181713-6f2d1aea-0ca2-4df2-aaa4-aff168b47b3c.png)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

