### PR TITLE
Fix/ab#61522 put mutations inside try catch

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -6,6 +6,7 @@
 			"duplicatedGraphQLTypeName": "A form or a reference data with a similar name already exists. Please provide a different name.",
 			"fileExtensionNotAllowed": "File extension not allowed",
 			"fileSizeLimitReached": "File size exceed 5MB",
+			"internalServerError": "Internal Server Error",
 			"invalidAPI": "API cannot be reached.",
 			"invalidEmailsInput": "Wrong format detected. Please provide valid emails.",
 			"invalidGraphQLName": "The name can only consist of alphanumeric characters and underscores, and must start with a letter. Please choose a different name.",

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -6,6 +6,7 @@
 			"duplicatedGraphQLTypeName": "******",
 			"fileExtensionNotAllowed": "******",
 			"fileSizeLimitReached": "******",
+			"internalServerError": "******",
 			"invalidAPI": "******",
 			"invalidEmailsInput": "******",
 			"invalidGraphQLName": "******",

--- a/src/schema/mutation/addAggregation.mutation.ts
+++ b/src/schema/mutation/addAggregation.mutation.ts
@@ -16,7 +16,7 @@ export default {
     resource: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       if (!args.resource || !args.aggregation) {
         throw new GraphQLError(
           context.i18next.t('mutations.aggregation.add.errors.invalidArguments')
@@ -24,7 +24,9 @@ export default {
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       // Edition of a resource
@@ -42,7 +44,7 @@ export default {
         await resource.save();
         return resource.aggregations.pop();
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addApiConfiguration.mutation.ts
+++ b/src/schema/mutation/addApiConfiguration.mutation.ts
@@ -16,10 +16,12 @@ export default {
     name: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       if (ability.can('create', 'ApiConfiguration')) {
@@ -35,7 +37,7 @@ export default {
               canDelete: [],
             },
           });
-          return apiConfiguration.save();
+          return await apiConfiguration.save();
         }
         throw new GraphQLError(
           context.i18next.t(
@@ -47,7 +49,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addApiConfiguration.mutation.ts
+++ b/src/schema/mutation/addApiConfiguration.mutation.ts
@@ -4,6 +4,7 @@ import { ApiConfigurationType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { authType, status } from '@const/enumTypes';
 import { validateApi } from '@utils/validators/validateApi';
+import { logger } from '@services/logger.service';
 
 /**
  * Create a new apiConfiguration.
@@ -15,34 +16,41 @@ export default {
     name: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    if (ability.can('create', 'ApiConfiguration')) {
-      if (args.name !== '') {
-        validateApi(args.name);
-        const apiConfiguration = new ApiConfiguration({
-          name: args.name,
-          status: status.pending,
-          authType: authType.serviceToService,
-          permissions: {
-            canSee: [],
-            canUpdate: [],
-            canDelete: [],
-          },
-        });
-        return apiConfiguration.save();
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
+      const ability: AppAbility = user.ability;
+      if (ability.can('create', 'ApiConfiguration')) {
+        if (args.name !== '') {
+          validateApi(args.name);
+          const apiConfiguration = new ApiConfiguration({
+            name: args.name,
+            status: status.pending,
+            authType: authType.serviceToService,
+            permissions: {
+              canSee: [],
+              canUpdate: [],
+              canDelete: [],
+            },
+          });
+          return apiConfiguration.save();
+        }
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.apiConfiguration.add.errors.invalidArguments'
+          )
+        );
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t(
-          'mutations.apiConfiguration.add.errors.invalidArguments'
-        )
-      );
-    } else {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/addApplication.mutation.ts
+++ b/src/schema/mutation/addApplication.mutation.ts
@@ -6,6 +6,7 @@ import { ApplicationType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { status } from '@const/enumTypes';
 import permissions from '@const/permissions';
+import { logger } from '@services/logger.service';
 
 /**
  * Create a new application.
@@ -15,91 +16,103 @@ export default {
   type: ApplicationType,
   args: {},
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    if (ability.can('create', 'Application')) {
-      // Find suitable application name
-      let appName = '';
-      try {
-        const existingUntitledApps = await Application.find({
-          name: { $regex: new RegExp(/^(Untitled application (\d+))$/) },
-        }).select('name');
-
-        // Get only the number from the app name to allow using the Math.max() function
-        const formattedAppsNumbers = existingUntitledApps.map((app) => {
-          return parseInt(app.name.replace('Untitled application ', ''), 10);
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      if (ability.can('create', 'Application')) {
+        // Find suitable application name
+        let appName = '';
+        try {
+          const existingUntitledApps = await Application.find({
+            name: { $regex: new RegExp(/^(Untitled application (\d+))$/) },
+          }).select('name');
+  
+          // Get only the number from the app name to allow using the Math.max() function
+          const formattedAppsNumbers = existingUntitledApps.map((app) => {
+            return parseInt(app.name.replace('Untitled application ', ''), 10);
+          });
+  
+          // If there is no previous app, set to 0. Else, set to the maximal value + 1
+          const nextAppNameNumber = formattedAppsNumbers.length
+            ? Math.max(...formattedAppsNumbers) + 1
+            : 0;
+  
+          appName = `Untitled application ${nextAppNameNumber}`;
+        } catch {
+          appName = 'Untitled application 0';
+        }
+        const application = new Application({
+          name: appName,
+          //createdAt: new Date(),
+          status: status.pending,
+          createdBy: user._id,
+          permissions: {
+            canSee: [],
+            canUpdate: [],
+            canDelete: [],
+          },
         });
-
-        // If there is no previous app, set to 0. Else, set to the maximal value + 1
-        const nextAppNameNumber = formattedAppsNumbers.length
-          ? Math.max(...formattedAppsNumbers) + 1
-          : 0;
-
-        appName = `Untitled application ${nextAppNameNumber}`;
-      } catch {
-        appName = 'Untitled application 0';
-      }
-      const application = new Application({
-        name: appName,
-        //createdAt: new Date(),
-        status: status.pending,
-        createdBy: user._id,
-        permissions: {
-          canSee: [],
-          canUpdate: [],
-          canDelete: [],
-        },
-      });
-      if (ability.cannot('manage', 'Application')) {
-        const firstAdminRole = user.roles.find(
-          (x) =>
-            !x.application &&
-            x.permissions.some(
-              (y) => y.type === permissions.canCreateApplications
-            )
-        )?.id;
-        application.permissions = {
-          canSee: [firstAdminRole],
-          canUpdate: [firstAdminRole],
-          canDelete: [firstAdminRole],
-        };
-      }
-      await application.save();
-      // Send notification
-      const channel = await Channel.findOne({ title: channels.applications });
-      const notification = new Notification({
-        action: 'Application created',
-        content: application,
-        //createdAt: new Date(),
-        channel: channel.id,
-        seenBy: [],
-      });
-      await notification.save();
-      const publisher = await pubsub();
-      publisher.publish(channel.id, { notification });
-      // Create main channel
-      const mainChannel = new Channel({
-        title: 'main',
-        application: application._id,
-      });
-      await mainChannel.save();
-      // Create roles
-      for (const name of ['Editor', 'Manager', 'Guest']) {
-        const role = new Role({
-          title: name,
-          application: application.id,
-          channels: [mainChannel._id],
+        if (ability.cannot('manage', 'Application')) {
+          const firstAdminRole = user.roles.find(
+            (x) =>
+              !x.application &&
+              x.permissions.some(
+                (y) => y.type === permissions.canCreateApplications
+              )
+          )?.id;
+          application.permissions = {
+            canSee: [firstAdminRole],
+            canUpdate: [firstAdminRole],
+            canDelete: [firstAdminRole],
+          };
+        }
+        await application.save();
+        // Send notification
+        const channel = await Channel.findOne({ title: channels.applications });
+        if (!channel) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
+        }
+        const notification = new Notification({
+          action: 'Application created',
+          content: application,
+          //createdAt: new Date(),
+          channel: channel.id,
+          seenBy: [],
         });
-        await role.save();
-        application.permissions.canSee.push(role._id);
+        await notification.save();
+        const publisher = await pubsub();
+        publisher.publish(channel.id, { notification });
+        // Create main channel
+        const mainChannel = new Channel({
+          title: 'main',
+          application: application._id,
+        });
+        await mainChannel.save();
+        // Create roles
+        for (const name of ['Editor', 'Manager', 'Guest']) {
+          const role = new Role({
+            title: name,
+            application: application.id,
+            channels: [mainChannel._id],
+          });
+          await role.save();
+          application.permissions.canSee.push(role._id);
+        }
+        return application;
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
       }
-      return application;
-    } else {
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/addApplication.mutation.ts
+++ b/src/schema/mutation/addApplication.mutation.ts
@@ -16,10 +16,12 @@ export default {
   type: ApplicationType,
   args: {},
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       if (ability.can('create', 'Application')) {
@@ -29,17 +31,17 @@ export default {
           const existingUntitledApps = await Application.find({
             name: { $regex: new RegExp(/^(Untitled application (\d+))$/) },
           }).select('name');
-  
+
           // Get only the number from the app name to allow using the Math.max() function
           const formattedAppsNumbers = existingUntitledApps.map((app) => {
             return parseInt(app.name.replace('Untitled application ', ''), 10);
           });
-  
+
           // If there is no previous app, set to 0. Else, set to the maximal value + 1
           const nextAppNameNumber = formattedAppsNumbers.length
             ? Math.max(...formattedAppsNumbers) + 1
             : 0;
-  
+
           appName = `Untitled application ${nextAppNameNumber}`;
         } catch {
           appName = 'Untitled application 0';
@@ -109,7 +111,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addChannel.mutation.ts
+++ b/src/schema/mutation/addChannel.mutation.ts
@@ -20,10 +20,12 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       const application = await Application.findById(args.application);
@@ -34,13 +36,13 @@ export default {
           title: args.title,
           application: args.application,
         });
-        return channel.save();
+        return await channel.save();
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addCustomNotification.mutation.ts
+++ b/src/schema/mutation/addCustomNotification.mutation.ts
@@ -66,7 +66,7 @@ export default {
         update,
         { new: true }
       );
-      if (!application){
+      if (!application) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const notificationDetail = application.customNotifications.pop();

--- a/src/schema/mutation/addCustomNotification.mutation.ts
+++ b/src/schema/mutation/addCustomNotification.mutation.ts
@@ -66,6 +66,9 @@ export default {
         update,
         { new: true }
       );
+      if (!application){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const notificationDetail = application.customNotifications.pop();
       if (
         args.notification.notification_status ===

--- a/src/schema/mutation/addDashboardWithContext.mutation.ts
+++ b/src/schema/mutation/addDashboardWithContext.mutation.ts
@@ -11,6 +11,8 @@ import { DashboardType } from '../types';
 import { Types } from 'mongoose';
 import { CustomAPI } from '@server/apollo/dataSources';
 import GraphQLJSON from 'graphql-type-json';
+import { logger } from '@services/logger.service';
+
 
 /**
  * Get the name of the new dashboard, based on the context.
@@ -62,78 +64,85 @@ export default {
     record: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    // Check arguments
-    if ((!args.element && !args.record) || (args.element && args.record)) {
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+  
+      // Check arguments
+      if ((!args.element && !args.record) || (args.element && args.record)) {
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.dashboard.addWithContext.errors.invalidArguments'
+          )
+        );
+      }
+  
+      // Check if element is valid
+      if (args.element && !['string', 'number'].includes(typeof args.element))
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.dashboard.addWithContext.errors.invalidElement'
+          )
+        );
+  
+      // Check if the user can create a dashboard
+      const ability: AppAbility = user.ability;
+      if (ability.cannot('create', 'Dashboard'))
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+  
+      const abilityFilters = Page.accessibleBy(ability, 'read').getFilter();
+      const page = await Page.findOne({
+        _id: args.page,
+        ...abilityFilters,
+      });
+  
+      if (!page)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+  
+      // Check if page type is dashboard
+      if (page.type !== 'dashboard')
+        throw new GraphQLError(
+          context.i18next.t('mutations.dashboard.add.errors.invalidPageType')
+        );
+  
+      // Fetches the dashboard from the page
+      const dashboard = await Dashboard.findById(page.content);
+  
+      // Duplicates the dashboard
+      const newDashboard = await new Dashboard({
+        name: await getNewDashboardName(
+          dashboard,
+          page.context,
+          args.record || args.element,
+          context.dataSources
+        ),
+        structure: dashboard.structure || [],
+      }).save();
+  
+      const newContentWithContext = args.record
+        ? ({
+            record: args.record,
+            content: newDashboard._id,
+          } as Page['contentWithContext'][number])
+        : ({
+            element: args.element,
+            content: newDashboard._id,
+          } as Page['contentWithContext'][number]);
+  
+      // Adds the dashboard to the page
+      page.contentWithContext.push(newContentWithContext);
+      await page.save();
+  
+      return newDashboard;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t(
-          'mutations.dashboard.addWithContext.errors.invalidArguments'
-        )
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-
-    // Check if element is valid
-    if (args.element && !['string', 'number'].includes(typeof args.element))
-      throw new GraphQLError(
-        context.i18next.t(
-          'mutations.dashboard.addWithContext.errors.invalidElement'
-        )
-      );
-
-    // Check if the user can create a dashboard
-    const ability: AppAbility = user.ability;
-    if (ability.cannot('create', 'Dashboard'))
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-
-    const abilityFilters = Page.accessibleBy(ability, 'read').getFilter();
-    const page = await Page.findOne({
-      _id: args.page,
-      ...abilityFilters,
-    });
-
-    if (!page)
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-
-    // Check if page type is dashboard
-    if (page.type !== 'dashboard')
-      throw new GraphQLError(
-        context.i18next.t('mutations.dashboard.add.errors.invalidPageType')
-      );
-
-    // Fetches the dashboard from the page
-    const dashboard = await Dashboard.findById(page.content);
-
-    // Duplicates the dashboard
-    const newDashboard = await new Dashboard({
-      name: await getNewDashboardName(
-        dashboard,
-        page.context,
-        args.record || args.element,
-        context.dataSources
-      ),
-      structure: dashboard.structure || [],
-    }).save();
-
-    const newContentWithContext = args.record
-      ? ({
-          record: args.record,
-          content: newDashboard._id,
-        } as Page['contentWithContext'][number])
-      : ({
-          element: args.element,
-          content: newDashboard._id,
-        } as Page['contentWithContext'][number]);
-
-    // Adds the dashboard to the page
-    page.contentWithContext.push(newContentWithContext);
-    await page.save();
-
-    return newDashboard;
   },
 };

--- a/src/schema/mutation/addDistributionList.mutation.ts
+++ b/src/schema/mutation/addDistributionList.mutation.ts
@@ -53,7 +53,7 @@ export default {
       { new: true }
     );
 
-    if (!application){
+    if (!application) {
       throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 

--- a/src/schema/mutation/addDistributionList.mutation.ts
+++ b/src/schema/mutation/addDistributionList.mutation.ts
@@ -53,6 +53,10 @@ export default {
       { new: true }
     );
 
+    if (!application){
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    }
+
     return application.distributionLists.pop();
   },
 };

--- a/src/schema/mutation/addForm.mutation.ts
+++ b/src/schema/mutation/addForm.mutation.ts
@@ -95,6 +95,9 @@ export default {
         } else {
           // fetch the resource and the core form
           const resource = await Resource.findById(args.resource);
+          if (!resource){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
           const coreForm = await Form.findOne({
             resource: args.resource,
             core: true,

--- a/src/schema/mutation/addForm.mutation.ts
+++ b/src/schema/mutation/addForm.mutation.ts
@@ -24,11 +24,13 @@ export default {
     template: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Check authentication
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       // Check permission to create form
@@ -95,8 +97,10 @@ export default {
         } else {
           // fetch the resource and the core form
           const resource = await Resource.findById(args.resource);
-          if (!resource){
-            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          if (!resource) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
           }
           const coreForm = await Form.findOne({
             resource: args.resource,
@@ -141,7 +145,7 @@ export default {
           context.i18next.t('mutations.form.add.errors.resourceDuplicated')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addForm.mutation.ts
+++ b/src/schema/mutation/addForm.mutation.ts
@@ -10,6 +10,7 @@ import { buildTypes } from '@utils/schema';
 import { FormType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { status } from '@const/enumTypes';
+import { logger } from '@services/logger.service';
 
 /**
  * Create a new form
@@ -23,107 +24,124 @@ export default {
     template: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // Check authentication
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    // Check permission to create form
-    if (ability.cannot('create', 'Form')) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-    // Check if another form with same name exists
-    const graphQLTypeName = Form.getGraphQLTypeName(args.name);
-    validateGraphQLTypeName(graphQLTypeName, context.i18next);
-    if (
-      (await Form.hasDuplicate(graphQLTypeName)) ||
-      (await ReferenceData.hasDuplicate(graphQLTypeName))
-    ) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.duplicatedGraphQLTypeName')
-      );
-    }
-    // define default permission lists
-    const userGlobalRoles =
-      user.roles
-        .filter((role: Role) => !role.application)
-        .map((role: Role) => role._id) || [];
-    const defaultFormPermissions = {
-      canSee: userGlobalRoles,
-      canUpdate: userGlobalRoles,
-      canDelete: userGlobalRoles,
-    };
-    const defaultResourcePermissions = {
-      ...defaultFormPermissions,
-      canSeeRecords: [],
-      canCreateRecords: [],
-      canUpdateRecords: [],
-      canDeleteRecords: [],
-    };
-    try {
-      if (!args.resource) {
-        // Check permission to create resource
-        if (ability.cannot('create', 'Resource')) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
-        }
-        // create resource
-        const resource = new Resource({
-          name: args.name,
-          //createdAt: new Date(),
-          permissions: defaultResourcePermissions,
-        });
-        await resource.save();
-        // create form
-        const form = new Form({
-          name: args.name,
-          graphQLTypeName,
-          status: status.pending,
-          resource,
-          core: true,
-          permissions: defaultFormPermissions,
-        });
-        await form.save();
-        buildTypes();
-        return form;
-      } else {
-        // fetch the resource and the core form
-        const resource = await Resource.findById(args.resource);
-        const coreForm = await Form.findOne({
-          resource: args.resource,
-          core: true,
-        });
-        // create the form following the template or the core form
-        let fields = coreForm.fields;
-        let structure = coreForm.structure;
-        if (args.template) {
-          const templateForm = await Form.findOne({
-            resource: args.resource,
-            _id: args.template,
-          });
-          if (templateForm) structure = templateForm.structure;
-          if (templateForm.fields.length > 0) fields = templateForm.fields;
-        }
-        const form = new Form({
-          name: args.name,
-          graphQLTypeName,
-          status: status.pending,
-          resource,
-          structure,
-          fields,
-          permissions: defaultFormPermissions,
-        });
-        await form.save();
-        buildTypes();
-        return form;
+    try{
+      // Check authentication
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-    } catch (error) {
+      const ability: AppAbility = user.ability;
+      // Check permission to create form
+      if (ability.cannot('create', 'Form')) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      // Check if another form with same name exists
+      const graphQLTypeName = Form.getGraphQLTypeName(args.name);
+      validateGraphQLTypeName(graphQLTypeName, context.i18next);
+      if (
+        (await Form.hasDuplicate(graphQLTypeName)) ||
+        (await ReferenceData.hasDuplicate(graphQLTypeName))
+      ) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.duplicatedGraphQLTypeName')
+        );
+      }
+      // define default permission lists
+      const userGlobalRoles =
+        user.roles
+          .filter((role: Role) => !role.application)
+          .map((role: Role) => role._id) || [];
+      const defaultFormPermissions = {
+        canSee: userGlobalRoles,
+        canUpdate: userGlobalRoles,
+        canDelete: userGlobalRoles,
+      };
+      const defaultResourcePermissions = {
+        ...defaultFormPermissions,
+        canSeeRecords: [],
+        canCreateRecords: [],
+        canUpdateRecords: [],
+        canDeleteRecords: [],
+      };
+      try {
+        if (!args.resource) {
+          // Check permission to create resource
+          if (ability.cannot('create', 'Resource')) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.permissionNotGranted')
+            );
+          }
+          // create resource
+          const resource = new Resource({
+            name: args.name,
+            //createdAt: new Date(),
+            permissions: defaultResourcePermissions,
+          });
+          await resource.save();
+          // create form
+          const form = new Form({
+            name: args.name,
+            graphQLTypeName,
+            status: status.pending,
+            resource,
+            core: true,
+            permissions: defaultFormPermissions,
+          });
+          await form.save();
+          buildTypes();
+          return form;
+        } else {
+          // fetch the resource and the core form
+          const resource = await Resource.findById(args.resource);
+          const coreForm = await Form.findOne({
+            resource: args.resource,
+            core: true,
+          });
+          if (!coreForm) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
+          }
+          // create the form following the template or the core form
+          let fields = coreForm.fields;
+          let structure = coreForm.structure;
+          if (args.template) {
+            const templateForm = await Form.findOne({
+              resource: args.resource,
+              _id: args.template,
+            });
+            if (!templateForm) {
+              throw new GraphQLError(
+                context.i18next.t('common.errors.dataNotFound')
+              );
+            }
+            if (templateForm) structure = templateForm.structure;
+            if (templateForm.fields.length > 0) fields = templateForm.fields;
+          }
+          const form = new Form({
+            name: args.name,
+            graphQLTypeName,
+            status: status.pending,
+            resource,
+            structure,
+            fields,
+            permissions: defaultFormPermissions,
+          });
+          await form.save();
+          buildTypes();
+          return form;
+        }
+      } catch (error) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.form.add.errors.resourceDuplicated')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('mutations.form.add.errors.resourceDuplicated')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/addGroup.mutation.ts
+++ b/src/schema/mutation/addGroup.mutation.ts
@@ -15,10 +15,12 @@ export default {
     title: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       if (!config.get('user.groups.local')) {
@@ -33,12 +35,12 @@ export default {
         title: args.title,
       });
       if (ability.can('create', group)) {
-        return group.save();
+        return await group.save();
       }
       throw new GraphQLError(
         context.i18next.t('common.errors.permissionNotGranted')
       );
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addLayout.mutation.ts
+++ b/src/schema/mutation/addLayout.mutation.ts
@@ -17,15 +17,19 @@ export default {
     form: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       if (args.form && args.resource) {
         throw new GraphQLError(
-          context.i18next.t('mutations.layout.add.errors.invalidAddPageArguments')
+          context.i18next.t(
+            'mutations.layout.add.errors.invalidAddPageArguments'
+          )
         );
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       // Edition of a resource
@@ -57,7 +61,7 @@ export default {
         await form.save();
         return form.layouts.pop();
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addLayout.mutation.ts
+++ b/src/schema/mutation/addLayout.mutation.ts
@@ -3,6 +3,7 @@ import { Resource, Form } from '@models';
 import { LayoutType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import LayoutInputType from '../../schema/inputs/layout.input';
+import { logger } from '@services/logger.service';
 
 /**
  * Add new grid layout.
@@ -16,44 +17,51 @@ export default {
     form: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    if (args.form && args.resource) {
+    try{
+      if (args.form && args.resource) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.layout.add.errors.invalidAddPageArguments')
+        );
+      }
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      // Edition of a resource
+      if (args.resource) {
+        const filters = Resource.accessibleBy(ability, 'update')
+          .where({ _id: args.resource })
+          .getFilter();
+        const resource: Resource = await Resource.findOne(filters);
+        if (!resource) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+        resource.layouts.push(args.layout);
+        await resource.save();
+        return resource.layouts.pop();
+      } else {
+        // Edition of a Form
+        const filters = Form.accessibleBy(ability, 'update')
+          .where({ _id: args.form })
+          .getFilter();
+        const form: Form = await Form.findOne(filters);
+        if (!form) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+        form.layouts.push(args.layout);
+        await form.save();
+        return form.layouts.pop();
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('mutations.layout.add.errors.invalidAddPageArguments')
+        context.i18next.t('common.errors.internalServerError')
       );
-    }
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    // Edition of a resource
-    if (args.resource) {
-      const filters = Resource.accessibleBy(ability, 'update')
-        .where({ _id: args.resource })
-        .getFilter();
-      const resource: Resource = await Resource.findOne(filters);
-      if (!resource) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      resource.layouts.push(args.layout);
-      await resource.save();
-      return resource.layouts.pop();
-    } else {
-      // Edition of a Form
-      const filters = Form.accessibleBy(ability, 'update')
-        .where({ _id: args.form })
-        .getFilter();
-      const form: Form = await Form.findOne(filters);
-      if (!form) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      form.layouts.push(args.layout);
-      await form.save();
-      return form.layouts.pop();
     }
   },
 };

--- a/src/schema/mutation/addPage.mutation.ts
+++ b/src/schema/mutation/addPage.mutation.ts
@@ -4,6 +4,7 @@ import { Application, Workflow, Dashboard, Form, Page, Role } from '@models';
 import { PageType } from '../types';
 import { ContentEnumType } from '@const/enumTypes';
 import extendAbilityForPage from '@security/extendAbilityForPage';
+import { logger } from '@services/logger.service';
 
 /**
  * Create a new page linked to an existing application.
@@ -19,86 +20,93 @@ export default {
     duplicate: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // check user
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    // check inputs
-    if (!args.application || !(args.type in contentType)) {
-      throw new GraphQLError(
-        context.i18next.t('mutations.page.add.errors.invalidArguments')
-      );
-    }
-    // check data
-    const application = await Application.findById(args.application);
-    if (!application) {
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
-    // check permission
-    const ability = await extendAbilityForPage(user, application);
-    if (ability.cannot('create', 'Page')) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-    // Create the linked Workflow or Dashboard
-    let pageName = '';
-    let content = args.content;
-    switch (args.type) {
-      case contentType.workflow: {
-        pageName = 'Workflow';
-        const workflow = new Workflow({
-          name: pageName,
-          //createdAt: new Date(),
-        });
-        await workflow.save();
-        content = workflow._id;
-        break;
+    try{
+      // check user
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-      case contentType.dashboard: {
-        pageName = 'Dashboard';
-        const dashboard = new Dashboard({
-          name: pageName,
-          //createdAt: new Date(),
-        });
-        await dashboard.save();
-        content = dashboard._id;
-        break;
+      // check inputs
+      if (!args.application || !(args.type in contentType)) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.page.add.errors.invalidArguments')
+        );
       }
-      case contentType.form: {
-        const form = await Form.findById(content);
-        if (!form) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
+      // check data
+      const application = await Application.findById(args.application);
+      if (!application) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+      // check permission
+      const ability = await extendAbilityForPage(user, application);
+      if (ability.cannot('create', 'Page')) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      // Create the linked Workflow or Dashboard
+      let pageName = '';
+      let content = args.content;
+      switch (args.type) {
+        case contentType.workflow: {
+          pageName = 'Workflow';
+          const workflow = new Workflow({
+            name: pageName,
+            //createdAt: new Date(),
+          });
+          await workflow.save();
+          content = workflow._id;
+          break;
         }
-        pageName = form.name;
-        break;
+        case contentType.dashboard: {
+          pageName = 'Dashboard';
+          const dashboard = new Dashboard({
+            name: pageName,
+            //createdAt: new Date(),
+          });
+          await dashboard.save();
+          content = dashboard._id;
+          break;
+        }
+        case contentType.form: {
+          const form = await Form.findById(content);
+          if (!form) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
+          }
+          pageName = form.name;
+          break;
+        }
+        default:
+          break;
       }
-      default:
-        break;
+      // Create a new page.
+      const roles = await Role.find({ application: application._id });
+      const page = new Page({
+        name: pageName,
+        //createdAt: new Date(),
+        type: args.type,
+        content,
+        permissions: {
+          canSee: roles.map((x) => x.id),
+          canUpdate: [],
+          canDelete: [],
+        },
+      });
+      await page.save();
+      // Link the new page to the corresponding application by updating this application.
+      const update = {
+        //modifiedAt: new Date(),
+        $push: { pages: page.id },
+      };
+      await application.updateOne(update);
+      return page;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    // Create a new page.
-    const roles = await Role.find({ application: application._id });
-    const page = new Page({
-      name: pageName,
-      //createdAt: new Date(),
-      type: args.type,
-      content,
-      permissions: {
-        canSee: roles.map((x) => x.id),
-        canUpdate: [],
-        canDelete: [],
-      },
-    });
-    await page.save();
-    // Link the new page to the corresponding application by updating this application.
-    const update = {
-      //modifiedAt: new Date(),
-      $push: { pages: page.id },
-    };
-    await application.updateOne(update);
-    return page;
   },
 };

--- a/src/schema/mutation/addPage.mutation.ts
+++ b/src/schema/mutation/addPage.mutation.ts
@@ -20,11 +20,13 @@ export default {
     duplicate: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // check user
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       // check inputs
       if (!args.application || !(args.type in contentType)) {
@@ -102,7 +104,7 @@ export default {
       };
       await application.updateOne(update);
       return page;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addPositionAttribute.mutation.ts
+++ b/src/schema/mutation/addPositionAttribute.mutation.ts
@@ -3,6 +3,7 @@ import { PositionAttribute, PositionAttributeCategory, User } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { PositionAttributeInputType } from '../inputs';
 import { UserType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Add new position attribute.
@@ -14,37 +15,44 @@ export default {
     positionAttribute: { type: new GraphQLNonNull(PositionAttributeInputType) },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    const category = await PositionAttributeCategory.findById(
-      args.positionAttribute.category
-    ).populate('application');
-    if (!category)
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    if (ability.cannot('update', category.application, 'users')) {
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      const category = await PositionAttributeCategory.findById(
+        args.positionAttribute.category
+      ).populate('application');
+      if (!category)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      if (ability.cannot('update', category.application, 'users')) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      let modifiedUser = await User.findById(args.user);
+      if (modifiedUser) {
+        const positionAttribute = new PositionAttribute(args.positionAttribute);
+        modifiedUser = await User.findByIdAndUpdate(
+          args.user,
+          {
+            $push: { positionAttributes: positionAttribute },
+          },
+          { new: true }
+        ).populate({
+          path: 'positionAttributes',
+          match: { 'category.application': { $eq: category.application } },
+        });
+        return modifiedUser;
+      } else {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
-    }
-    let modifiedUser = await User.findById(args.user);
-    if (modifiedUser) {
-      const positionAttribute = new PositionAttribute(args.positionAttribute);
-      modifiedUser = await User.findByIdAndUpdate(
-        args.user,
-        {
-          $push: { positionAttributes: positionAttribute },
-        },
-        { new: true }
-      ).populate({
-        path: 'positionAttributes',
-        match: { 'category.application': { $eq: category.application } },
-      });
-      return modifiedUser;
-    } else {
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
   },
 };

--- a/src/schema/mutation/addPositionAttribute.mutation.ts
+++ b/src/schema/mutation/addPositionAttribute.mutation.ts
@@ -15,10 +15,12 @@ export default {
     positionAttribute: { type: new GraphQLNonNull(PositionAttributeInputType) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       const category = await PositionAttributeCategory.findById(
@@ -48,7 +50,7 @@ export default {
       } else {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/addPositionAttributeCategory.mutation.ts
@@ -7,6 +7,7 @@ import {
 import { Application, PositionAttributeCategory } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { PositionAttributeCategoryType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Add new position attribute category.
@@ -18,23 +19,30 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    const application = await Application.findById(args.application);
-    if (!application)
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    if (ability.can('update', application)) {
-      const category = new PositionAttributeCategory({
-        title: args.title,
-        application: args.application,
-      });
-      return category.save();
-    } else {
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      const application = await Application.findById(args.application);
+      if (!application)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      if (ability.can('update', application)) {
+        const category = new PositionAttributeCategory({
+          title: args.title,
+          application: args.application,
+        });
+        return category.save();
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/addPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/addPositionAttributeCategory.mutation.ts
@@ -19,10 +19,12 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       const application = await Application.findById(args.application);
@@ -33,13 +35,13 @@ export default {
           title: args.title,
           application: args.application,
         });
-        return category.save();
+        return await category.save();
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addPullJob.mutation.ts
+++ b/src/schema/mutation/addPullJob.mutation.ts
@@ -33,12 +33,14 @@ export default {
     channel: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
-  
+
       const ability: AppAbility = user.ability;
       if (ability.can('create', 'PullJob')) {
         if (args.convertTo) {
@@ -48,7 +50,7 @@ export default {
               context.i18next.t('common.errors.dataNotFound')
             );
         }
-  
+
         if (args.channel) {
           const filters = {
             _id: args.channel,
@@ -59,7 +61,7 @@ export default {
               context.i18next.t('common.errors.dataNotFound')
             );
         }
-  
+
         try {
           // Create a new PullJob
           const pullJob = new PullJob({
@@ -75,15 +77,17 @@ export default {
             channel: args.channel,
           });
           await pullJob.save();
-  
+
           // If the pullJob is active, schedule it immediately
           if (args.status === status.active) {
             const fullPullJob = await PullJob.findById(pullJob.id).populate({
               path: 'apiConfiguration',
               model: 'ApiConfiguration',
             });
-            if (!fullPullJob){
-              throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+            if (!fullPullJob) {
+              throw new GraphQLError(
+                context.i18next.t('common.errors.dataNotFound')
+              );
             }
             scheduleJob(fullPullJob);
           } else {
@@ -99,7 +103,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addPullJob.mutation.ts
+++ b/src/schema/mutation/addPullJob.mutation.ts
@@ -82,6 +82,9 @@ export default {
               path: 'apiConfiguration',
               model: 'ApiConfiguration',
             });
+            if (!fullPullJob){
+              throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+            }
             scheduleJob(fullPullJob);
           } else {
             unscheduleJob(pullJob);

--- a/src/schema/mutation/addRecord.mutation.ts
+++ b/src/schema/mutation/addRecord.mutation.ts
@@ -7,6 +7,7 @@ import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import pubsub from '../../server/pubsub';
 import { getFormPermissionFilter } from '@utils/filter';
 import { GraphQLUpload } from 'apollo-server-core';
+import { logger } from '@services/logger.service';
 
 /**
  * Add a record to a form, if user authorized.
@@ -21,93 +22,104 @@ export default {
     files: { type: new GraphQLList(GraphQLUpload) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    // Get the form
-    const form = await Form.findById(args.form);
-    if (!form)
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      // Get the form
+      const form = await Form.findById(args.form);
+      if (!form)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
 
-    // Check the ability with permissions for this form
-    const ability = await extendAbilityForRecords(user, form);
-    if (ability.cannot('create', 'Record')) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
+      // Check the ability with permissions for this form
+      const ability = await extendAbilityForRecords(user, form);
+      if (ability.cannot('create', 'Record')) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
 
-    // Check unicity of record
-    if (
-      form.permissions.recordsUnicity &&
-      form.permissions.recordsUnicity.length > 0 &&
-      form.permissions.recordsUnicity[0].role
-    ) {
-      const unicityFilters = getFormPermissionFilter(
-        user,
-        form,
-        'recordsUnicity'
-      );
-      if (unicityFilters.length > 0) {
-        const uniqueRecordAlreadyExists = await Record.exists({
-          $and: [
-            { form: form._id, archived: { $ne: true } },
-            { $or: unicityFilters },
-          ],
-        });
-        if (uniqueRecordAlreadyExists) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
+      // Check unicity of record
+      if (
+        form.permissions.recordsUnicity &&
+        form.permissions.recordsUnicity.length > 0 &&
+        form.permissions.recordsUnicity[0].role
+      ) {
+        const unicityFilters = getFormPermissionFilter(
+          user,
+          form,
+          'recordsUnicity'
+        );
+        if (unicityFilters.length > 0) {
+          const uniqueRecordAlreadyExists = await Record.exists({
+            $and: [
+              { form: form._id, archived: { $ne: true } },
+              { $or: unicityFilters },
+            ],
+          });
+          if (uniqueRecordAlreadyExists) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.permissionNotGranted')
+            );
+          }
         }
       }
-    }
 
-    // Create the record instance
-    transformRecord(args.data, form.fields);
-    const record = new Record({
-      incrementalId: await getNextId(
-        String(form.resource ? form.resource : args.form)
-      ),
-      form: args.form,
-      //createdAt: new Date(),
-      //modifiedAt: new Date(),
-      data: args.data,
-      resource: form.resource ? form.resource : null,
-      createdBy: {
-        user: user._id,
-        roles: user.roles.map((x) => x._id),
-        positionAttributes: user.positionAttributes.map((x) => {
-          return {
-            value: x.value,
-            category: x.category._id,
-          };
-        }),
-      },
-    });
-    // Update the createdBy property if we pass some owner data
-    const ownership = getOwnership(form.fields, args.data);
-    if (ownership) {
-      record.createdBy = { ...record.createdBy, ...ownership };
-    }
-    // send notifications to channel
-    const channel = await Channel.findOne({ form: form._id });
-    if (channel) {
-      const notification = new Notification({
-        action: `New record - ${form.name}`,
-        content: record,
+      // Create the record instance
+      transformRecord(args.data, form.fields);
+      const record = new Record({
+        incrementalId: await getNextId(
+          String(form.resource ? form.resource : args.form)
+        ),
+        form: args.form,
         //createdAt: new Date(),
-        channel: channel.id,
-        seenBy: [],
+        //modifiedAt: new Date(),
+        data: args.data,
+        resource: form.resource ? form.resource : null,
+        createdBy: {
+          user: user._id,
+          roles: user.roles.map((x) => x._id),
+          positionAttributes: user.positionAttributes.map((x) => {
+            return {
+              value: x.value,
+              category: x.category._id,
+            };
+          }),
+        },
       });
-      await notification.save();
-      const publisher = await pubsub();
-      publisher.publish(channel.id, { notification });
+      // Update the createdBy property if we pass some owner data
+      const ownership = getOwnership(form.fields, args.data);
+      if (ownership) {
+        record.createdBy = { ...record.createdBy, ...ownership };
+      }
+      // send notifications to channel
+      const channel = await Channel.findOne({ form: form._id });
+      if (channel) {
+        const notification = new Notification({
+          action: `New record - ${form.name}`,
+          content: record,
+          //createdAt: new Date(),
+          channel: channel.id,
+          seenBy: [],
+        });
+        await notification.save();
+        const publisher = await pubsub();
+        publisher.publish(channel.id, { notification });
+      }else{
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+      await record.save();
+      return record;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    await record.save();
-    return record;
   },
 };

--- a/src/schema/mutation/addRecord.mutation.ts
+++ b/src/schema/mutation/addRecord.mutation.ts
@@ -22,11 +22,13 @@ export default {
     files: { type: new GraphQLList(GraphQLUpload) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // Get the form
@@ -108,14 +110,12 @@ export default {
         await notification.save();
         const publisher = await pubsub();
         publisher.publish(channel.id, { notification });
-      }else{
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+      } else {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       await record.save();
       return record;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addReferenceData.mutation.ts
+++ b/src/schema/mutation/addReferenceData.mutation.ts
@@ -3,6 +3,7 @@ import { Form, ReferenceData } from '@models';
 import { ReferenceDataType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { validateGraphQLTypeName } from '@utils/validators';
+import { logger } from '@services/logger.service';
 
 /**
  * Creates a new referenceData.
@@ -14,51 +15,58 @@ export default {
     name: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    if (ability.can('create', 'ReferenceData')) {
-      if (args.name !== '') {
-        // Check name
-        const graphQLTypeName = ReferenceData.getGraphQLTypeName(args.name);
-        validateGraphQLTypeName(graphQLTypeName, context.i18next);
-        if (
-          (await Form.hasDuplicate(graphQLTypeName)) ||
-          (await ReferenceData.hasDuplicate(graphQLTypeName))
-        ) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.duplicatedGraphQLTypeName')
-          );
-        }
-
-        // Create reference data model
-        const referenceData = new ReferenceData({
-          name: args.name,
-          graphQLTypeName: ReferenceData.getGraphQLTypeName(args.name),
-          //modifiedAt: new Date(),
-          type: undefined,
-          valueField: '',
-          fields: [],
-          apiConfiguration: null,
-          path: '',
-          query: '',
-          data: [],
-          permissions: {
-            canSee: [],
-            canUpdate: [],
-            canDelete: [],
-          },
-        });
-        return referenceData.save();
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
+      const ability: AppAbility = user.ability;
+      if (ability.can('create', 'ReferenceData')) {
+        if (args.name !== '') {
+          // Check name
+          const graphQLTypeName = ReferenceData.getGraphQLTypeName(args.name);
+          validateGraphQLTypeName(graphQLTypeName, context.i18next);
+          if (
+            (await Form.hasDuplicate(graphQLTypeName)) ||
+            (await ReferenceData.hasDuplicate(graphQLTypeName))
+          ) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.duplicatedGraphQLTypeName')
+            );
+          }
+  
+          // Create reference data model
+          const referenceData = new ReferenceData({
+            name: args.name,
+            graphQLTypeName: ReferenceData.getGraphQLTypeName(args.name),
+            //modifiedAt: new Date(),
+            type: undefined,
+            valueField: '',
+            fields: [],
+            apiConfiguration: null,
+            path: '',
+            query: '',
+            data: [],
+            permissions: {
+              canSee: [],
+              canUpdate: [],
+              canDelete: [],
+            },
+          });
+          return referenceData.save();
+        }
+        throw new GraphQLError(
+          context.i18next.t('mutations.reference.add.errors.invalidArguments')
+        );
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('mutations.reference.add.errors.invalidArguments')
-      );
-    } else {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/addReferenceData.mutation.ts
+++ b/src/schema/mutation/addReferenceData.mutation.ts
@@ -15,10 +15,12 @@ export default {
     name: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       if (ability.can('create', 'ReferenceData')) {
@@ -34,7 +36,7 @@ export default {
               context.i18next.t('common.errors.duplicatedGraphQLTypeName')
             );
           }
-  
+
           // Create reference data model
           const referenceData = new ReferenceData({
             name: args.name,
@@ -53,7 +55,7 @@ export default {
               canDelete: [],
             },
           });
-          return referenceData.save();
+          return await referenceData.save();
         }
         throw new GraphQLError(
           context.i18next.t('mutations.reference.add.errors.invalidArguments')
@@ -63,7 +65,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addRole.mutation.ts
+++ b/src/schema/mutation/addRole.mutation.ts
@@ -20,37 +20,43 @@ export default {
     application: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       if (args.application) {
         const application = await Application.findById(args.application);
         if (!application)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         const role = new Role({
           title: args.title,
         });
         if (!application)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         role.application = args.application;
         if (ability.can('create', role)) {
-          return role.save();
+          return await role.save();
         }
       } else {
         const role = new Role({
           title: args.title,
         });
         if (ability.can('create', role)) {
-          return role.save();
+          return await role.save();
         }
       }
       throw new GraphQLError(
         context.i18next.t('common.errors.permissionNotGranted')
       );
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addRole.mutation.ts
+++ b/src/schema/mutation/addRole.mutation.ts
@@ -7,6 +7,7 @@ import {
 import { Role, Application } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { RoleType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Create a new role.
@@ -19,34 +20,41 @@ export default {
     application: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    if (args.application) {
-      const application = await Application.findById(args.application);
-      if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-      const role = new Role({
-        title: args.title,
-      });
-      if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-      role.application = args.application;
-      if (ability.can('create', role)) {
-        return role.save();
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-    } else {
-      const role = new Role({
-        title: args.title,
-      });
-      if (ability.can('create', role)) {
-        return role.save();
+      const ability: AppAbility = user.ability;
+      if (args.application) {
+        const application = await Application.findById(args.application);
+        if (!application)
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const role = new Role({
+          title: args.title,
+        });
+        if (!application)
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        role.application = args.application;
+        if (ability.can('create', role)) {
+          return role.save();
+        }
+      } else {
+        const role = new Role({
+          title: args.title,
+        });
+        if (ability.can('create', role)) {
+          return role.save();
+        }
       }
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    throw new GraphQLError(
-      context.i18next.t('common.errors.permissionNotGranted')
-    );
   },
 };

--- a/src/schema/mutation/addRoleToUsers.mutation.ts
+++ b/src/schema/mutation/addRoleToUsers.mutation.ts
@@ -11,6 +11,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import { validateEmail } from '@utils/validators';
 import { PositionAttributeInputType } from '../inputs';
 import { UserType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Add new role to existing user.
@@ -23,79 +24,86 @@ export default {
     positionAttributes: { type: new GraphQLList(PositionAttributeInputType) },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    const role = await Role.findById(args.role).populate('application');
-    if (!role)
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    // Check permissions depending if it's an application's user or a global user
-    if (ability.cannot('update', 'User')) {
-      if (role.application) {
-        const canUpdate = user.roles
-          .filter((x) =>
-            x.application ? x.application.equals(role.application) : false
-          )
-          .flatMap((x) => x.permissions)
-          .some((x) => x.type === permissions.canSeeUsers);
-        if (!canUpdate) {
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      const role = await Role.findById(args.role).populate('application');
+      if (!role)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      // Check permissions depending if it's an application's user or a global user
+      if (ability.cannot('update', 'User')) {
+        if (role.application) {
+          const canUpdate = user.roles
+            .filter((x) =>
+              x.application ? x.application.equals(role.application) : false
+            )
+            .flatMap((x) => x.permissions)
+            .some((x) => x.type === permissions.canSeeUsers);
+          if (!canUpdate) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.permissionNotGranted')
+            );
+          }
+        } else {
           throw new GraphQLError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
-      } else {
+      }
+      // Prevent wrong emails to be invited.
+      if (args.usernames.filter((x) => !validateEmail(x)).length > 0) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t('common.errors.invalidEmailsInput')
         );
       }
-    }
-    // Prevent wrong emails to be invited.
-    if (args.usernames.filter((x) => !validateEmail(x)).length > 0) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.invalidEmailsInput')
-      );
-    }
-    // Perform the add role to users
-    const invitedUsers: User[] = [];
-    // Separate registered users and new users
-    const registeredUsers = await User.find({
-      username: { $in: args.usernames },
-    });
-    const registeredEmails = registeredUsers.map((x) => x.username);
-    args.usernames
-      .filter((x) => !registeredEmails.includes(x))
-      .forEach((x) => {
-        const newUser = new User();
-        newUser.username = x;
-        newUser.roles = [args.role];
-        if (args.positionAttributes) {
-          newUser.positionAttributes = args.positionAttributes;
-        }
-        invitedUsers.push(newUser);
+      // Perform the add role to users
+      const invitedUsers: User[] = [];
+      // Separate registered users and new users
+      const registeredUsers = await User.find({
+        username: { $in: args.usernames },
       });
-    // Save the new users
-    await User.insertMany(invitedUsers);
-    if (registeredEmails.length > 0) {
-      await User.updateMany(
-        {
-          username: {
-            $in: registeredEmails,
+      const registeredEmails = registeredUsers.map((x) => x.username);
+      args.usernames
+        .filter((x) => !registeredEmails.includes(x))
+        .forEach((x) => {
+          const newUser = new User();
+          newUser.username = x;
+          newUser.roles = [args.role];
+          if (args.positionAttributes) {
+            newUser.positionAttributes = args.positionAttributes;
+          }
+          invitedUsers.push(newUser);
+        });
+      // Save the new users
+      await User.insertMany(invitedUsers);
+      if (registeredEmails.length > 0) {
+        await User.updateMany(
+          {
+            username: {
+              $in: registeredEmails,
+            },
           },
-        },
-        {
-          $push: {
-            roles: [args.role],
-            positionAttributes: args.positionAttributes,
+          {
+            $push: {
+              roles: [args.role],
+              positionAttributes: args.positionAttributes,
+            },
           },
-        },
-        { new: true }
+          { new: true }
+        );
+      }
+      return User.find({ username: { $in: args.usernames } }).populate({
+        path: 'roles',
+        match: { application: { $eq: role.application } },
+      });
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    return User.find({ username: { $in: args.usernames } }).populate({
-      path: 'roles',
-      match: { application: { $eq: role.application } },
-    });
   },
 };

--- a/src/schema/mutation/addRoleToUsers.mutation.ts
+++ b/src/schema/mutation/addRoleToUsers.mutation.ts
@@ -24,10 +24,12 @@ export default {
     positionAttributes: { type: new GraphQLList(PositionAttributeInputType) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       const role = await Role.findById(args.role).populate('application');
@@ -95,11 +97,11 @@ export default {
           { new: true }
         );
       }
-      return User.find({ username: { $in: args.usernames } }).populate({
+      return await User.find({ username: { $in: args.usernames } }).populate({
         path: 'roles',
         match: { application: { $eq: role.application } },
       });
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addStep.mutation.ts
+++ b/src/schema/mutation/addStep.mutation.ts
@@ -32,10 +32,12 @@ export default {
     workflow: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       if (!args.workflow || !(args.type in contentType)) {
@@ -50,16 +52,16 @@ export default {
       const application = await Application.findOne({
         pages: { $elemMatch: { $eq: mongoose.Types.ObjectId(page._id) } },
       });
-      if(!application){
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+      if (!application) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       let stepName = '';
       if (ability.can('update', application)) {
         const workflow = await Workflow.findById(args.workflow);
         if (!workflow)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         // Create a linked Dashboard if necessary
         if (args.type === contentType.dashboard) {
           stepName = 'Dashboard';
@@ -104,7 +106,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addStep.mutation.ts
+++ b/src/schema/mutation/addStep.mutation.ts
@@ -17,6 +17,7 @@ import {
 import { StepType } from '../types';
 import mongoose from 'mongoose';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Creates a new step linked to an existing workflow.
@@ -31,70 +32,82 @@ export default {
     workflow: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    if (!args.workflow || !(args.type in contentType)) {
-      throw new GraphQLError(
-        context.i18next.t('mutations.step.add.errors.invalidArguments')
-      );
-    }
-    const page = await Page.findOne({ content: args.workflow });
-    if (!page) {
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
-    const application = await Application.findOne({
-      pages: { $elemMatch: { $eq: mongoose.Types.ObjectId(page._id) } },
-    });
-    let stepName = '';
-    if (ability.can('update', application)) {
-      const workflow = await Workflow.findById(args.workflow);
-      if (!workflow)
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      if (!args.workflow || !(args.type in contentType)) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.step.add.errors.invalidArguments')
+        );
+      }
+      const page = await Page.findOne({ content: args.workflow });
+      if (!page) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-      // Create a linked Dashboard if necessary
-      if (args.type === contentType.dashboard) {
-        stepName = 'Dashboard';
-        const dashboard = new Dashboard({
+      }
+      const application = await Application.findOne({
+        pages: { $elemMatch: { $eq: mongoose.Types.ObjectId(page._id) } },
+      });
+      if(!application){
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+      let stepName = '';
+      if (ability.can('update', application)) {
+        const workflow = await Workflow.findById(args.workflow);
+        if (!workflow)
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        // Create a linked Dashboard if necessary
+        if (args.type === contentType.dashboard) {
+          stepName = 'Dashboard';
+          const dashboard = new Dashboard({
+            name: stepName,
+            //createdAt: new Date(),
+          });
+          await dashboard.save();
+          args.content = dashboard._id;
+        } else {
+          const form = await Form.findById(args.content);
+          if (!form) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
+          }
+          stepName = form.name;
+        }
+        // Create a new step.
+        const roles = await Role.find({ application: application._id });
+        const step = new Step({
           name: stepName,
           //createdAt: new Date(),
+          type: args.type,
+          content: args.content,
+          permissions: {
+            canSee: roles.map((x) => x.id),
+            canUpdate: [],
+            canDelete: [],
+          },
         });
-        await dashboard.save();
-        args.content = dashboard._id;
+        await step.save();
+        // Link the new step to the corresponding application by updating this application.
+        const update = {
+          //modifiedAt: new Date(),
+          $push: { steps: step.id },
+        };
+        await Workflow.findByIdAndUpdate(args.workflow, update);
+        return step;
       } else {
-        const form = await Form.findById(args.content);
-        if (!form) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
-        }
-        stepName = form.name;
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
       }
-      // Create a new step.
-      const roles = await Role.find({ application: application._id });
-      const step = new Step({
-        name: stepName,
-        //createdAt: new Date(),
-        type: args.type,
-        content: args.content,
-        permissions: {
-          canSee: roles.map((x) => x.id),
-          canUpdate: [],
-          canDelete: [],
-        },
-      });
-      await step.save();
-      // Link the new step to the corresponding application by updating this application.
-      const update = {
-        //modifiedAt: new Date(),
-        $push: { steps: step.id },
-      };
-      await Workflow.findByIdAndUpdate(args.workflow, update);
-      return step;
-    } else {
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/addSubscription.mutation.ts
+++ b/src/schema/mutation/addSubscription.mutation.ts
@@ -9,6 +9,7 @@ import { Application, Channel, Form } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { createAndConsumeQueue } from '../../server/subscriberSafe';
 import { SubscriptionType } from '../types/subscription.type';
+import { logger } from '@services/logger.service';
 
 /**
  * Creates a new subscription
@@ -24,51 +25,58 @@ export default {
     channel: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    const application = await Application.findById(args.application);
-    if (!application)
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-
-    if (args.convertTo) {
-      const form = await Form.findById(args.convertTo);
-      if (!form)
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      const application = await Application.findById(args.application);
+      if (!application)
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
-
-    if (args.channel) {
-      const filters = {
-        application: mongoose.Types.ObjectId(args.application),
-        _id: args.channel,
+  
+      if (args.convertTo) {
+        const form = await Form.findById(args.convertTo);
+        if (!form)
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+  
+      if (args.channel) {
+        const filters = {
+          application: mongoose.Types.ObjectId(args.application),
+          _id: args.channel,
+        };
+        const channel = await Channel.findOne(filters);
+        if (!channel)
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+  
+      const subscription = {
+        routingKey: args.routingKey,
+        title: args.title,
       };
-      const channel = await Channel.findOne(filters);
-      if (!channel)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      Object.assign(
+        subscription,
+        args.convertTo && { convertTo: args.convertTo },
+        args.channel && { channel: args.channel }
+      );
+  
+      const update = {
+        //modifiedAt: new Date(),
+        $push: { subscriptions: subscription },
+      };
+  
+      const filters = Application.accessibleBy(ability, 'update')
+        .where({ _id: args.application })
+        .getFilter();
+      await Application.findOneAndUpdate(filters, update);
+      createAndConsumeQueue(args.routingKey);
+      return subscription;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-
-    const subscription = {
-      routingKey: args.routingKey,
-      title: args.title,
-    };
-    Object.assign(
-      subscription,
-      args.convertTo && { convertTo: args.convertTo },
-      args.channel && { channel: args.channel }
-    );
-
-    const update = {
-      //modifiedAt: new Date(),
-      $push: { subscriptions: subscription },
-    };
-
-    const filters = Application.accessibleBy(ability, 'update')
-      .where({ _id: args.application })
-      .getFilter();
-    await Application.findOneAndUpdate(filters, update);
-    createAndConsumeQueue(args.routingKey);
-    return subscription;
   },
 };

--- a/src/schema/mutation/addTemplate.mutation.ts
+++ b/src/schema/mutation/addTemplate.mutation.ts
@@ -44,7 +44,9 @@ export default {
       update,
       { new: true }
     );
-
+    if (!application){
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    }
     return application.templates.pop();
   },
 };

--- a/src/schema/mutation/addTemplate.mutation.ts
+++ b/src/schema/mutation/addTemplate.mutation.ts
@@ -44,7 +44,7 @@ export default {
       update,
       { new: true }
     );
-    if (!application){
+    if (!application) {
       throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
     return application.templates.pop();

--- a/src/schema/mutation/addUsers.mutation.ts
+++ b/src/schema/mutation/addUsers.mutation.ts
@@ -7,6 +7,7 @@ import UserInputType from '../inputs/user.input';
 import { validateEmail } from '@utils/validators';
 import { sendAppInvitation, sendCreateAccountInvitation } from '@utils/user';
 import config from 'config';
+import { logger } from '@services/logger.service';
 
 /**
  * Add new users.
@@ -18,106 +19,113 @@ export default {
     application: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-
-    // Check permissions depending if it's an application's user or a global user
-    if (ability.cannot('update', 'User')) {
-      if (args.application) {
-        const canUpdate = user.roles
-          .filter((x) =>
-            x.application ? x.application.equals(args.application) : false
-          )
-          .flatMap((x) => x.permissions)
-          .some((x) => x.type === permissions.canSeeUsers);
-        if (!canUpdate) {
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+  
+      // Check permissions depending if it's an application's user or a global user
+      if (ability.cannot('update', 'User')) {
+        if (args.application) {
+          const canUpdate = user.roles
+            .filter((x) =>
+              x.application ? x.application.equals(args.application) : false
+            )
+            .flatMap((x) => x.permissions)
+            .some((x) => x.type === permissions.canSeeUsers);
+          if (!canUpdate) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.permissionNotGranted')
+            );
+          }
+        } else {
           throw new GraphQLError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
-      } else {
+      }
+      if (args.users.filter((x) => !validateEmail(x.email)).length > 0) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t('common.errors.invalidEmailsInput')
         );
       }
-    }
-    if (args.users.filter((x) => !validateEmail(x.email)).length > 0) {
+      // Separate registered users and new users
+      const invitedUsers: User[] = [];
+      const existingUserUpdates: any[] = [];
+      const registeredUsers = await User.find({
+        username: { $in: args.users.map((x) => x.email) },
+      }).select('username');
+      const registeredEmails = registeredUsers.map((x) => x.username);
+      // New users
+      args.users
+        .filter((x) => !registeredEmails.includes(x.email))
+        .forEach((x) => {
+          const newUser = new User();
+          newUser.username = x.email;
+          newUser.roles = [x.role];
+          if (x.positionAttributes) {
+            newUser.positionAttributes = x.positionAttributes;
+          }
+          // remove after 7 days if the user does not activate the account
+          const date = new Date();
+          date.setDate(date.getDate() + 7);
+          newUser.deleteAt = date;
+          invitedUsers.push(newUser);
+        });
+      // Registered users
+      args.users
+        .filter((x) => registeredEmails.includes(x.email))
+        .forEach((x) => {
+          const updateUser = {
+            $addToSet: {
+              roles: x.role,
+              positionAttributes: { $each: x.positionAttributes },
+            },
+          };
+          existingUserUpdates.push({
+            updateOne: {
+              filter: { username: x.email },
+              update: updateUser,
+            },
+          });
+        });
+  
+      const application = args.application
+        ? await Application.findById(args.application)
+        : null;
+      // Save the new users
+      if (invitedUsers.length > 0) {
+        await User.insertMany(invitedUsers);
+        if (config.get('email.sendInvite')) {
+          await sendCreateAccountInvitation(
+            invitedUsers.map((x) => x.username),
+            user,
+            application
+          );
+        }
+      }
+      //Update the existing ones
+      if (registeredEmails.length > 0) {
+        await User.bulkWrite(existingUserUpdates);
+        if (application && config.get('email.sendInvite')) {
+          await sendAppInvitation(registeredEmails, user, application);
+        }
+      }
+  
+      // Return the full list of users
+      return User.find({
+        username: { $in: args.users.map((x) => x.email) },
+      }).populate({
+        path: 'roles',
+        match: { application: { $eq: args.application } },
+      });
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.invalidEmailsInput')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    // Separate registered users and new users
-    const invitedUsers: User[] = [];
-    const existingUserUpdates: any[] = [];
-    const registeredUsers = await User.find({
-      username: { $in: args.users.map((x) => x.email) },
-    }).select('username');
-    const registeredEmails = registeredUsers.map((x) => x.username);
-    // New users
-    args.users
-      .filter((x) => !registeredEmails.includes(x.email))
-      .forEach((x) => {
-        const newUser = new User();
-        newUser.username = x.email;
-        newUser.roles = [x.role];
-        if (x.positionAttributes) {
-          newUser.positionAttributes = x.positionAttributes;
-        }
-        // remove after 7 days if the user does not activate the account
-        const date = new Date();
-        date.setDate(date.getDate() + 7);
-        newUser.deleteAt = date;
-        invitedUsers.push(newUser);
-      });
-    // Registered users
-    args.users
-      .filter((x) => registeredEmails.includes(x.email))
-      .forEach((x) => {
-        const updateUser = {
-          $addToSet: {
-            roles: x.role,
-            positionAttributes: { $each: x.positionAttributes },
-          },
-        };
-        existingUserUpdates.push({
-          updateOne: {
-            filter: { username: x.email },
-            update: updateUser,
-          },
-        });
-      });
-
-    const application = args.application
-      ? await Application.findById(args.application)
-      : null;
-    // Save the new users
-    if (invitedUsers.length > 0) {
-      await User.insertMany(invitedUsers);
-      if (config.get('email.sendInvite')) {
-        await sendCreateAccountInvitation(
-          invitedUsers.map((x) => x.username),
-          user,
-          application
-        );
-      }
-    }
-    //Update the existing ones
-    if (registeredEmails.length > 0) {
-      await User.bulkWrite(existingUserUpdates);
-      if (application && config.get('email.sendInvite')) {
-        await sendAppInvitation(registeredEmails, user, application);
-      }
-    }
-
-    // Return the full list of users
-    return User.find({
-      username: { $in: args.users.map((x) => x.email) },
-    }).populate({
-      path: 'roles',
-      match: { application: { $eq: args.application } },
-    });
   },
 };

--- a/src/schema/mutation/addUsers.mutation.ts
+++ b/src/schema/mutation/addUsers.mutation.ts
@@ -19,13 +19,15 @@ export default {
     application: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
-  
+
       // Check permissions depending if it's an application's user or a global user
       if (ability.cannot('update', 'User')) {
         if (args.application) {
@@ -91,11 +93,11 @@ export default {
             },
           });
         });
-  
+
       const application = args.application
         ? await Application.findById(args.application)
         : null;
-      if (!application){
+      if (!application) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       // Save the new users
@@ -116,15 +118,15 @@ export default {
           await sendAppInvitation(registeredEmails, user, application);
         }
       }
-  
+
       // Return the full list of users
-      return User.find({
+      return await User.find({
         username: { $in: args.users.map((x) => x.email) },
       }).populate({
         path: 'roles',
         match: { application: { $eq: args.application } },
       });
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addUsers.mutation.ts
+++ b/src/schema/mutation/addUsers.mutation.ts
@@ -95,6 +95,9 @@ export default {
       const application = args.application
         ? await Application.findById(args.application)
         : null;
+      if (!application){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       // Save the new users
       if (invitedUsers.length > 0) {
         await User.insertMany(invitedUsers);

--- a/src/schema/mutation/addWorkflow.mutation.ts
+++ b/src/schema/mutation/addWorkflow.mutation.ts
@@ -22,7 +22,7 @@ export default {
     page: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       if (!args.page) {
         throw new GraphQLError(
           context.i18next.t('mutations.workflow.add.errors.invalidArguments')
@@ -64,7 +64,7 @@ export default {
           );
         }
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addWorkflow.mutation.ts
+++ b/src/schema/mutation/addWorkflow.mutation.ts
@@ -8,6 +8,7 @@ import { contentType } from '@const/enumTypes';
 import { Page, Workflow } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { WorkflowType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Creates a new workflow linked to an existing page.
@@ -21,46 +22,53 @@ export default {
     page: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    if (!args.page) {
-      throw new GraphQLError(
-        context.i18next.t('mutations.workflow.add.errors.invalidArguments')
-      );
-    } else {
-      const user = context.user;
-      if (!user) {
+    try{
+      if (!args.page) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
+          context.i18next.t('mutations.workflow.add.errors.invalidArguments')
         );
-      }
-      const ability: AppAbility = user.ability;
-      if (ability.can('create', 'Workflow')) {
-        const page = await Page.findById(args.page);
-        if (!page)
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
-        if (page.type !== contentType.workflow)
-          throw new GraphQLError(
-            context.i18next.t('mutations.workflow.add.errors.pageTypeError')
-          );
-        // Create a workflow.
-        const workflow = new Workflow({
-          name: args.name,
-          //createdAt: new Date(),
-        });
-        await workflow.save();
-        // Link the new workflow to the corresponding page by updating this page.
-        const update = {
-          //modifiedAt: new Date(),
-          content: workflow._id,
-        };
-        await Page.findByIdAndUpdate(args.page, update);
-        return workflow;
       } else {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
+        const user = context.user;
+        if (!user) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.userNotLogged')
+          );
+        }
+        const ability: AppAbility = user.ability;
+        if (ability.can('create', 'Workflow')) {
+          const page = await Page.findById(args.page);
+          if (!page)
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
+          if (page.type !== contentType.workflow)
+            throw new GraphQLError(
+              context.i18next.t('mutations.workflow.add.errors.pageTypeError')
+            );
+          // Create a workflow.
+          const workflow = new Workflow({
+            name: args.name,
+            //createdAt: new Date(),
+          });
+          await workflow.save();
+          // Link the new workflow to the corresponding page by updating this page.
+          const update = {
+            //modifiedAt: new Date(),
+            content: workflow._id,
+          };
+          await Page.findByIdAndUpdate(args.page, update);
+          return workflow;
+        } else {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
       }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
   },
 };

--- a/src/schema/mutation/convertRecord.mutation.ts
+++ b/src/schema/mutation/convertRecord.mutation.ts
@@ -22,24 +22,26 @@ export default {
     copyRecord: { type: new GraphQLNonNull(GraphQLBoolean) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // Get the record and forms
       const oldRecord = await Record.findById(args.id);
-      if (!oldRecord){
+      if (!oldRecord) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const oldForm = await Form.findById(oldRecord.form);
-      if (!oldForm){
+      if (!oldForm) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const targetForm = await Form.findById(args.form);
-      if (!targetForm){
+      if (!targetForm) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       if (!oldForm.resource.equals(targetForm.resource))
@@ -74,19 +76,21 @@ export default {
           resource: oldForm.resource,
           versions: oldVersions,
         });
-        return targetRecord.save();
+        return await targetRecord.save();
       } else {
         const update: any = {
           form: args.form,
           //modifiedAt: new Date(),
         };
         const record = Record.findByIdAndUpdate(args.id, update, { new: true });
-        if (!record){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!record) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
-        return record;
+        return await record;
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/convertRecord.mutation.ts
+++ b/src/schema/mutation/convertRecord.mutation.ts
@@ -8,6 +8,7 @@ import { getNextId } from '@utils/form';
 import { Form, Record } from '@models';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import { RecordType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Convert a record from one form type to an other form type from the same family (i. e. with same parent resource)
@@ -21,55 +22,62 @@ export default {
     copyRecord: { type: new GraphQLNonNull(GraphQLBoolean) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    // Get the record and forms
-    const oldRecord = await Record.findById(args.id);
-    const oldForm = await Form.findById(oldRecord.form);
-    const targetForm = await Form.findById(args.form);
-    if (!oldForm.resource.equals(targetForm.resource))
+      // Get the record and forms
+      const oldRecord = await Record.findById(args.id);
+      const oldForm = await Form.findById(oldRecord.form);
+      const targetForm = await Form.findById(args.form);
+      if (!oldForm.resource.equals(targetForm.resource))
+        throw new GraphQLError(
+          context.i18next.t('mutations.record.convert.errors.invalidConversion')
+        );
+
+      // Check permissions
+      const oldFormAbility = await extendAbilityForRecords(user, oldForm);
+      const targetFormAbility = await extendAbilityForRecords(user, targetForm);
+      if (
+        oldFormAbility.cannot('update', oldRecord) ||
+        targetFormAbility.cannot('create', 'Record')
+      ) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      // Convert the record
+      if (args.copyRecord) {
+        const data = oldRecord.data;
+        const oldVersions = oldRecord.versions;
+        const targetRecord = new Record({
+          incrementalId: await getNextId(
+            String(oldForm.resource ? oldForm.resource : args.form)
+          ),
+          form: args.form,
+          //createdAt: new Date(),
+          //modifiedAt: new Date(),
+          data,
+          resource: oldForm.resource,
+          versions: oldVersions,
+        });
+        return targetRecord.save();
+      } else {
+        const update: any = {
+          form: args.form,
+          //modifiedAt: new Date(),
+        };
+        return Record.findByIdAndUpdate(args.id, update, { new: true });
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('mutations.record.convert.errors.invalidConversion')
+        context.i18next.t('common.errors.internalServerError')
       );
-
-    // Check permissions
-    const oldFormAbility = await extendAbilityForRecords(user, oldForm);
-    const targetFormAbility = await extendAbilityForRecords(user, targetForm);
-    if (
-      oldFormAbility.cannot('update', oldRecord) ||
-      targetFormAbility.cannot('create', 'Record')
-    ) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-
-    // Convert the record
-    if (args.copyRecord) {
-      const data = oldRecord.data;
-      const oldVersions = oldRecord.versions;
-      const targetRecord = new Record({
-        incrementalId: await getNextId(
-          String(oldForm.resource ? oldForm.resource : args.form)
-        ),
-        form: args.form,
-        //createdAt: new Date(),
-        //modifiedAt: new Date(),
-        data,
-        resource: oldForm.resource,
-        versions: oldVersions,
-      });
-      return targetRecord.save();
-    } else {
-      const update: any = {
-        form: args.form,
-        //modifiedAt: new Date(),
-      };
-      return Record.findByIdAndUpdate(args.id, update, { new: true });
     }
   },
 };

--- a/src/schema/mutation/convertRecord.mutation.ts
+++ b/src/schema/mutation/convertRecord.mutation.ts
@@ -31,8 +31,17 @@ export default {
 
       // Get the record and forms
       const oldRecord = await Record.findById(args.id);
+      if (!oldRecord){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const oldForm = await Form.findById(oldRecord.form);
+      if (!oldForm){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const targetForm = await Form.findById(args.form);
+      if (!targetForm){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       if (!oldForm.resource.equals(targetForm.resource))
         throw new GraphQLError(
           context.i18next.t('mutations.record.convert.errors.invalidConversion')
@@ -71,7 +80,11 @@ export default {
           form: args.form,
           //modifiedAt: new Date(),
         };
-        return Record.findByIdAndUpdate(args.id, update, { new: true });
+        const record = Record.findByIdAndUpdate(args.id, update, { new: true });
+        if (!record){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return record;
       }
     }catch (err){
       logger.error(err.message, { stack: err.stack });

--- a/src/schema/mutation/deleteAggregation.mutation.ts
+++ b/src/schema/mutation/deleteAggregation.mutation.ts
@@ -2,6 +2,7 @@ import { GraphQLError, GraphQLID, GraphQLNonNull } from 'graphql';
 import { Resource } from '@models';
 import { AggregationType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete existing aggregation.
@@ -14,33 +15,40 @@ export default {
     resource: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    if (!args.resource) {
-      throw new GraphQLError(
-        context.i18next.t(
-          'mutations.aggregation.delete.errors.invalidArguments'
-        )
-      );
-    }
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    // Edition of a resource
-    if (args.resource) {
-      const filters = Resource.accessibleBy(ability, 'update')
-        .where({ _id: args.resource })
-        .getFilter();
-      const resource: Resource = await Resource.findOne(filters);
-      if (!resource) {
+    try{
+      if (!args.resource) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t(
+            'mutations.aggregation.delete.errors.invalidArguments'
+          )
         );
       }
-
-      const aggregation = resource.aggregations.id(args.id).remove();
-      await resource.save();
-      return aggregation;
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      // Edition of a resource
+      if (args.resource) {
+        const filters = Resource.accessibleBy(ability, 'update')
+          .where({ _id: args.resource })
+          .getFilter();
+        const resource: Resource = await Resource.findOne(filters);
+        if (!resource) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+  
+        const aggregation = resource.aggregations.id(args.id).remove();
+        await resource.save();
+        return aggregation;
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
   },
 };

--- a/src/schema/mutation/deleteAggregation.mutation.ts
+++ b/src/schema/mutation/deleteAggregation.mutation.ts
@@ -15,7 +15,7 @@ export default {
     resource: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       if (!args.resource) {
         throw new GraphQLError(
           context.i18next.t(
@@ -25,7 +25,9 @@ export default {
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       // Edition of a resource
@@ -39,12 +41,12 @@ export default {
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
-  
+
         const aggregation = resource.aggregations.id(args.id).remove();
         await resource.save();
         return aggregation;
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteApiConfiguration.mutation.ts
+++ b/src/schema/mutation/deleteApiConfiguration.mutation.ts
@@ -16,10 +16,12 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       const filters = ApiConfiguration.accessibleBy(ability, 'delete')
@@ -34,7 +36,7 @@ export default {
         buildTypes();
       }
       return apiConfiguration;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteApiConfiguration.mutation.ts
+++ b/src/schema/mutation/deleteApiConfiguration.mutation.ts
@@ -4,6 +4,7 @@ import { ApiConfigurationType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { status } from '@const/enumTypes';
 import { buildTypes } from '@utils/schema';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete the passed apiConfiguration if authorized.
@@ -15,22 +16,29 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    const filters = ApiConfiguration.accessibleBy(ability, 'delete')
-      .where({ _id: args.id })
-      .getFilter();
-    const apiConfiguration = await ApiConfiguration.findOneAndDelete(filters);
-    if (!apiConfiguration)
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      const filters = ApiConfiguration.accessibleBy(ability, 'delete')
+        .where({ _id: args.id })
+        .getFilter();
+      const apiConfiguration = await ApiConfiguration.findOneAndDelete(filters);
+      if (!apiConfiguration)
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      if (apiConfiguration.status === status.active) {
+        buildTypes();
+      }
+      return apiConfiguration;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
-    if (apiConfiguration.status === status.active) {
-      buildTypes();
     }
-    return apiConfiguration;
   },
 };

--- a/src/schema/mutation/deleteApplication.mutation.ts
+++ b/src/schema/mutation/deleteApplication.mutation.ts
@@ -4,6 +4,7 @@ import { Application, Channel, Notification } from '@models';
 import pubsub from '../../server/pubsub';
 import channels from '@const/channels';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Deletes an application from its id.
@@ -16,31 +17,43 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      // Delete the application
+      const ability: AppAbility = context.user.ability;
+      const filters = Application.accessibleBy(ability, 'delete')
+        .where({ _id: args.id })
+        .getFilter();
+      const application = await Application.findOneAndDelete(filters);
+      if (!application)
+        throw new GraphQLError('common.errors.permissionNotGranted');
+      // Send notification
+      const channel = await Channel.findOne({ title: channels.applications });
+      if (!channel) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+      const notification = new Notification({
+        action: 'Application deleted',
+        content: application,
+        //createdAt: new Date(),
+        channel: channel.id,
+        seenBy: [],
+      });
+      await notification.save();
+      const publisher = await pubsub();
+      publisher.publish(channel.id, { notification });
+      return application;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    // Delete the application
-    const ability: AppAbility = context.user.ability;
-    const filters = Application.accessibleBy(ability, 'delete')
-      .where({ _id: args.id })
-      .getFilter();
-    const application = await Application.findOneAndDelete(filters);
-    if (!application)
-      throw new GraphQLError('common.errors.permissionNotGranted');
-    // Send notification
-    const channel = await Channel.findOne({ title: channels.applications });
-    const notification = new Notification({
-      action: 'Application deleted',
-      content: application,
-      //createdAt: new Date(),
-      channel: channel.id,
-      seenBy: [],
-    });
-    await notification.save();
-    const publisher = await pubsub();
-    publisher.publish(channel.id, { notification });
-    return application;
   },
 };

--- a/src/schema/mutation/deleteApplication.mutation.ts
+++ b/src/schema/mutation/deleteApplication.mutation.ts
@@ -17,11 +17,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       // Delete the application
       const ability: AppAbility = context.user.ability;
@@ -34,9 +36,7 @@ export default {
       // Send notification
       const channel = await Channel.findOne({ title: channels.applications });
       if (!channel) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const notification = new Notification({
         action: 'Application deleted',
@@ -49,7 +49,7 @@ export default {
       const publisher = await pubsub();
       publisher.publish(channel.id, { notification });
       return application;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteChannel.mutation.ts
+++ b/src/schema/mutation/deleteChannel.mutation.ts
@@ -32,7 +32,11 @@ export default {
             { new: true }
           );
         }
-        return Channel.findByIdAndDelete(args.id);
+        const channel = Channel.findByIdAndDelete(args.id);
+        if (!channel){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return channel;
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')

--- a/src/schema/mutation/deleteChannel.mutation.ts
+++ b/src/schema/mutation/deleteChannel.mutation.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { Channel, Role } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { ChannelType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete a channel from its id and all linked notifications.
@@ -13,27 +14,34 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability: AppAbility = context.user.ability;
+      const ability: AppAbility = context.user.ability;
 
-    if (ability.can('delete', 'Channel')) {
-      const roles = await Role.find({ channels: args.id });
-      for (const role of roles) {
-        await Role.findByIdAndUpdate(
-          role.id,
-          { $pull: { channels: args.id } },
-          { new: true }
+      if (ability.can('delete', 'Channel')) {
+        const roles = await Role.find({ channels: args.id });
+        for (const role of roles) {
+          await Role.findByIdAndUpdate(
+            role.id,
+            { $pull: { channels: args.id } },
+            { new: true }
+          );
+        }
+        return Channel.findByIdAndDelete(args.id);
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-      return Channel.findByIdAndDelete(args.id);
-    } else {
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/deleteChannel.mutation.ts
+++ b/src/schema/mutation/deleteChannel.mutation.ts
@@ -14,11 +14,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -33,16 +35,18 @@ export default {
           );
         }
         const channel = Channel.findByIdAndDelete(args.id);
-        if (!channel){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!channel) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
-        return channel;
+        return await channel;
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteCustomNotification.mutation.ts
+++ b/src/schema/mutation/deleteCustomNotification.mutation.ts
@@ -37,6 +37,9 @@ export default {
       args.application,
       update
     );
+    if (!application){
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    }
 
     const notificationDetail = application.customNotifications.find(
       (x) => x.id.toString() === args.id

--- a/src/schema/mutation/deleteCustomNotification.mutation.ts
+++ b/src/schema/mutation/deleteCustomNotification.mutation.ts
@@ -37,7 +37,7 @@ export default {
       args.application,
       update
     );
-    if (!application){
+    if (!application) {
       throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 

--- a/src/schema/mutation/deleteDashboard.mutation.ts
+++ b/src/schema/mutation/deleteDashboard.mutation.ts
@@ -24,7 +24,11 @@ export default {
 
       const ability: AppAbility = context.user.ability;
       if (ability.can('delete', 'Dashboard')) {
-        return Dashboard.findByIdAndDelete(args.id);
+        const dashboard = Dashboard.findByIdAndDelete(args.id);
+        if (!dashboard){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return dashboard;
       } else {
         const page = await Page.accessibleBy(ability, 'delete').where({
           content: args.id,
@@ -33,7 +37,11 @@ export default {
           content: args.id,
         });
         if (page || step) {
-          return Dashboard.findByIdAndDelete(args.id);
+          const dashboard = Dashboard.findByIdAndDelete(args.id);
+          if (!dashboard){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
+          return dashboard;
         }
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')

--- a/src/schema/mutation/deleteDashboard.mutation.ts
+++ b/src/schema/mutation/deleteDashboard.mutation.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { DashboardType } from '../types';
 import { Dashboard, Page, Step } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Finds dashboard from its id and delete it, if user is authorized.
@@ -14,27 +15,34 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    const ability: AppAbility = context.user.ability;
-    if (ability.can('delete', 'Dashboard')) {
-      return Dashboard.findByIdAndDelete(args.id);
-    } else {
-      const page = await Page.accessibleBy(ability, 'delete').where({
-        content: args.id,
-      });
-      const step = await Step.accessibleBy(ability, 'delete').where({
-        content: args.id,
-      });
-      if (page || step) {
-        return Dashboard.findByIdAndDelete(args.id);
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
+
+      const ability: AppAbility = context.user.ability;
+      if (ability.can('delete', 'Dashboard')) {
+        return Dashboard.findByIdAndDelete(args.id);
+      } else {
+        const page = await Page.accessibleBy(ability, 'delete').where({
+          content: args.id,
+        });
+        const step = await Step.accessibleBy(ability, 'delete').where({
+          content: args.id,
+        });
+        if (page || step) {
+          return Dashboard.findByIdAndDelete(args.id);
+        }
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/deleteDashboard.mutation.ts
+++ b/src/schema/mutation/deleteDashboard.mutation.ts
@@ -15,20 +15,24 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
       if (ability.can('delete', 'Dashboard')) {
         const dashboard = Dashboard.findByIdAndDelete(args.id);
-        if (!dashboard){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!dashboard) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
-        return dashboard;
+        return await dashboard;
       } else {
         const page = await Page.accessibleBy(ability, 'delete').where({
           content: args.id,
@@ -38,16 +42,18 @@ export default {
         });
         if (page || step) {
           const dashboard = Dashboard.findByIdAndDelete(args.id);
-          if (!dashboard){
-            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          if (!dashboard) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
           }
-          return dashboard;
+          return await dashboard;
         }
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteDistributionList.mutation.ts
+++ b/src/schema/mutation/deleteDistributionList.mutation.ts
@@ -36,6 +36,9 @@ export default {
       args.application,
       update
     );
+    if (!application){
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    }
 
     return application.distributionLists.find(
       (x) => x.id.toString() === args.id

--- a/src/schema/mutation/deleteDistributionList.mutation.ts
+++ b/src/schema/mutation/deleteDistributionList.mutation.ts
@@ -36,7 +36,7 @@ export default {
       args.application,
       update
     );
-    if (!application){
+    if (!application) {
       throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
 

--- a/src/schema/mutation/deleteForm.mutation.ts
+++ b/src/schema/mutation/deleteForm.mutation.ts
@@ -15,11 +15,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       // Get ability
       const ability: AppAbility = user.ability;
@@ -43,7 +45,7 @@ export default {
       }
       buildTypes();
       return form;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteForm.mutation.ts
+++ b/src/schema/mutation/deleteForm.mutation.ts
@@ -3,6 +3,7 @@ import { FormType } from '../types';
 import { Form, Resource } from '@models';
 import { buildTypes } from '@utils/schema';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Find form from its id and delete it, and all records associated, if user is authorized.
@@ -14,32 +15,39 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    // Get ability
-    const ability: AppAbility = user.ability;
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      // Get ability
+      const ability: AppAbility = user.ability;
 
-    // Get the form
-    const filters = Form.accessibleBy(ability, 'delete')
-      .where({ _id: args.id })
-      .getFilter();
-    const form = await Form.findOne(filters);
-    if (!form) {
+      // Get the form
+      const filters = Form.accessibleBy(ability, 'delete')
+        .where({ _id: args.id })
+        .getFilter();
+      const form = await Form.findOne(filters);
+      if (!form) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      // if is core form we have to delete the linked forms and resource
+      if (form.core) {
+        // delete the resource and all forms associated
+        await Resource.deleteOne({ _id: form.resource });
+      } else {
+        await form.deleteOne();
+      }
+      buildTypes();
+      return form;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    // if is core form we have to delete the linked forms and resource
-    if (form.core) {
-      // delete the resource and all forms associated
-      await Resource.deleteOne({ _id: form.resource });
-    } else {
-      await form.deleteOne();
-    }
-    buildTypes();
-    return form;
   },
 };

--- a/src/schema/mutation/deleteGroup.mutation.ts
+++ b/src/schema/mutation/deleteGroup.mutation.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { Group } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { GroupType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Deletes a group.
@@ -13,22 +14,29 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability: AppAbility = context.user.ability;
-    const filters = Group.accessibleBy(ability, 'delete')
-      .where({ _id: args.id })
-      .getFilter();
-    const group = await Group.findOneAndDelete(filters);
-    if (group) {
-      return group;
-    } else {
+      const ability: AppAbility = context.user.ability;
+      const filters = Group.accessibleBy(ability, 'delete')
+        .where({ _id: args.id })
+        .getFilter();
+      const group = await Group.findOneAndDelete(filters);
+      if (group) {
+        return group;
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/deleteGroup.mutation.ts
+++ b/src/schema/mutation/deleteGroup.mutation.ts
@@ -14,11 +14,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -33,7 +35,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteLayout.mutation.ts
+++ b/src/schema/mutation/deleteLayout.mutation.ts
@@ -16,7 +16,7 @@ export default {
     form: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       if (args.form && args.resource) {
         throw new GraphQLError(
           context.i18next.t('mutations.layout.delete.errors.invalidArguments')
@@ -24,7 +24,9 @@ export default {
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       // Edition of a resource
@@ -56,7 +58,7 @@ export default {
         await form.save();
         return layout;
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteLayout.mutation.ts
+++ b/src/schema/mutation/deleteLayout.mutation.ts
@@ -2,6 +2,7 @@ import { GraphQLError, GraphQLID, GraphQLNonNull } from 'graphql';
 import { Resource, Form } from '@models';
 import { LayoutType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Deletes an existing layout.
@@ -15,44 +16,51 @@ export default {
     form: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    if (args.form && args.resource) {
+    try{
+      if (args.form && args.resource) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.layout.delete.errors.invalidArguments')
+        );
+      }
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      // Edition of a resource
+      if (args.resource) {
+        const filters = Resource.accessibleBy(ability, 'update')
+          .where({ _id: args.resource })
+          .getFilter();
+        const resource: Resource = await Resource.findOne(filters);
+        if (!resource) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+        const layout = resource.layouts.id(args.id).remove();
+        await resource.save();
+        return layout;
+      } else {
+        // Edition of a Form
+        const filters = Form.accessibleBy(ability, 'update')
+          .where({ _id: args.form })
+          .getFilter();
+        const form: Form = await Form.findOne(filters);
+        if (!form) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+        const layout = form.layouts.id(args.id).remove();
+        await form.save();
+        return layout;
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('mutations.layout.delete.errors.invalidArguments')
+        context.i18next.t('common.errors.internalServerError')
       );
-    }
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    // Edition of a resource
-    if (args.resource) {
-      const filters = Resource.accessibleBy(ability, 'update')
-        .where({ _id: args.resource })
-        .getFilter();
-      const resource: Resource = await Resource.findOne(filters);
-      if (!resource) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      const layout = resource.layouts.id(args.id).remove();
-      await resource.save();
-      return layout;
-    } else {
-      // Edition of a Form
-      const filters = Form.accessibleBy(ability, 'update')
-        .where({ _id: args.form })
-        .getFilter();
-      const form: Form = await Form.findOne(filters);
-      if (!form) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      const layout = form.layouts.id(args.id).remove();
-      await form.save();
-      return layout;
     }
   },
 };

--- a/src/schema/mutation/deletePage.mutation.ts
+++ b/src/schema/mutation/deletePage.mutation.ts
@@ -15,16 +15,18 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user)
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
 
       // get data
       const page = await Page.findById(args.id);
 
-      if (!page){
+      if (!page) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
 
@@ -39,7 +41,7 @@ export default {
       // delete page
       await page.deleteOne();
       return page;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deletePage.mutation.ts
+++ b/src/schema/mutation/deletePage.mutation.ts
@@ -24,6 +24,10 @@ export default {
       // get data
       const page = await Page.findById(args.id);
 
+      if (!page){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+
       // get permissions
       const ability = await extendAbilityForPage(user, page);
       if (ability.cannot('delete', page)) {

--- a/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { Application, PositionAttributeCategory } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { PositionAttributeCategoryType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete a position attribute category.
@@ -14,20 +15,27 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = context.user.ability;
-    const application = await Application.findById(args.application);
-    if (!application)
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    if (ability.can('update', application)) {
-      return PositionAttributeCategory.findByIdAndDelete(args.id);
-    } else {
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = context.user.ability;
+      const application = await Application.findById(args.application);
+      if (!application)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      if (ability.can('update', application)) {
+        return PositionAttributeCategory.findByIdAndDelete(args.id);
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
@@ -26,7 +26,11 @@ export default {
       if (!application)
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       if (ability.can('update', application)) {
-        return PositionAttributeCategory.findByIdAndDelete(args.id);
+        const position = PositionAttributeCategory.findByIdAndDelete(args.id);
+        if (!position){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return position;
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')

--- a/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
@@ -15,11 +15,13 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = context.user.ability;
       const application = await Application.findById(args.application);
@@ -27,16 +29,18 @@ export default {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       if (ability.can('update', application)) {
         const position = PositionAttributeCategory.findByIdAndDelete(args.id);
-        if (!position){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!position) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
-        return position;
+        return await position;
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deletePullJob.mutation.ts
+++ b/src/schema/mutation/deletePullJob.mutation.ts
@@ -3,6 +3,7 @@ import { PullJobType } from '../types';
 import { PullJob } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { unscheduleJob } from '../../server/pullJobScheduler';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete a pullJob
@@ -13,22 +14,29 @@ export default {
     id: { type: GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-
-    const filters = PullJob.accessibleBy(ability, 'delete')
-      .where({ _id: args.id })
-      .getFilter();
-    const pullJob = await PullJob.findOneAndDelete(filters);
-    if (!pullJob)
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+  
+      const filters = PullJob.accessibleBy(ability, 'delete')
+        .where({ _id: args.id })
+        .getFilter();
+      const pullJob = await PullJob.findOneAndDelete(filters);
+      if (!pullJob)
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+  
+      unscheduleJob(pullJob);
+      return pullJob;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
-
-    unscheduleJob(pullJob);
-    return pullJob;
+    }
   },
 };

--- a/src/schema/mutation/deletePullJob.mutation.ts
+++ b/src/schema/mutation/deletePullJob.mutation.ts
@@ -14,13 +14,15 @@ export default {
     id: { type: GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
-  
+
       const filters = PullJob.accessibleBy(ability, 'delete')
         .where({ _id: args.id })
         .getFilter();
@@ -29,10 +31,10 @@ export default {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
-  
+
       unscheduleJob(pullJob);
       return pullJob;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteRecord.mutation.ts
+++ b/src/schema/mutation/deleteRecord.mutation.ts
@@ -29,7 +29,13 @@ export default {
 
       // Get the record and form objects
       const record = await Record.findById(args.id);
+      if (!record){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const form = await Form.findById(record.form);
+      if (!form){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
 
       // Check the ability
       const ability = await extendAbilityForRecords(user, form);
@@ -41,13 +47,21 @@ export default {
 
       // Delete the record
       if (args.hardDelete) {
-        return Record.findByIdAndDelete(record._id);
+        const recordFound = Record.findByIdAndDelete(record._id);
+        if (!recordFound){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return recordFound;
       } else {
-        return Record.findByIdAndUpdate(
+        const recordFound = Record.findByIdAndUpdate(
           record._id,
           { archived: true },
           { new: true }
         );
+        if (!recordFound){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return recordFound;
       } 
     }catch (err){
       logger.error(err.message, { stack: err.stack });

--- a/src/schema/mutation/deleteRecord.mutation.ts
+++ b/src/schema/mutation/deleteRecord.mutation.ts
@@ -7,6 +7,7 @@ import {
 import { Form, Record } from '@models';
 import { RecordType } from '../types';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete a record, if user has permission to update associated form / resource.
@@ -19,32 +20,39 @@ export default {
     hardDelete: { type: GraphQLBoolean },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    // Get the record and form objects
-    const record = await Record.findById(args.id);
-    const form = await Form.findById(record.form);
+      // Get the record and form objects
+      const record = await Record.findById(args.id);
+      const form = await Form.findById(record.form);
 
-    // Check the ability
-    const ability = await extendAbilityForRecords(user, form);
-    if (ability.cannot('delete', record)) {
+      // Check the ability
+      const ability = await extendAbilityForRecords(user, form);
+      if (ability.cannot('delete', record)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      // Delete the record
+      if (args.hardDelete) {
+        return Record.findByIdAndDelete(record._id);
+      } else {
+        return Record.findByIdAndUpdate(
+          record._id,
+          { archived: true },
+          { new: true }
+        );
+      } 
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-
-    // Delete the record
-    if (args.hardDelete) {
-      return Record.findByIdAndDelete(record._id);
-    } else {
-      return Record.findByIdAndUpdate(
-        record._id,
-        { archived: true },
-        { new: true }
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/deleteRecord.mutation.ts
+++ b/src/schema/mutation/deleteRecord.mutation.ts
@@ -20,20 +20,22 @@ export default {
     hardDelete: { type: GraphQLBoolean },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // Get the record and form objects
       const record = await Record.findById(args.id);
-      if (!record){
+      if (!record) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const form = await Form.findById(record.form);
-      if (!form){
+      if (!form) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
 
@@ -48,22 +50,26 @@ export default {
       // Delete the record
       if (args.hardDelete) {
         const recordFound = Record.findByIdAndDelete(record._id);
-        if (!recordFound){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!recordFound) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
-        return recordFound;
+        return await recordFound;
       } else {
         const recordFound = Record.findByIdAndUpdate(
           record._id,
           { archived: true },
           { new: true }
         );
-        if (!recordFound){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!recordFound) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
-        return recordFound;
-      } 
-    }catch (err){
+        return await recordFound;
+      }
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteRecords.mutation.ts
+++ b/src/schema/mutation/deleteRecords.mutation.ts
@@ -8,6 +8,7 @@ import {
 } from 'graphql';
 import { Record } from '@models';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete multiple records.
@@ -20,43 +21,50 @@ export default {
     hardDelete: { type: GraphQLBoolean },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    // Get records and forms objects
-    const toDelete: Record[] = [];
-    const records: Record[] = await Record.find({
-      _id: { $in: args.ids },
-    }).populate({
-      path: 'form',
-      model: 'Form',
-    });
-
-    // Create list of records to delete
-    for (const record of records) {
-      // Check ability
-      const ability = await extendAbilityForRecords(user, record.form);
-      if (ability.can('delete', record)) {
-        toDelete.push(record);
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-    }
 
-    // Delete the records
-    if (args.hardDelete) {
-      const result = await Record.deleteMany({
-        _id: { $in: toDelete.map((x) => x._id) },
+      // Get records and forms objects
+      const toDelete: Record[] = [];
+      const records: Record[] = await Record.find({
+        _id: { $in: args.ids },
+      }).populate({
+        path: 'form',
+        model: 'Form',
       });
-      return result.deletedCount;
-    } else {
-      const result = await Record.updateMany(
-        { _id: { $in: toDelete.map((x) => x._id) } },
-        { archived: true },
-        { new: true }
+
+      // Create list of records to delete
+      for (const record of records) {
+        // Check ability
+        const ability = await extendAbilityForRecords(user, record.form);
+        if (ability.can('delete', record)) {
+          toDelete.push(record);
+        }
+      }
+
+      // Delete the records
+      if (args.hardDelete) {
+        const result = await Record.deleteMany({
+          _id: { $in: toDelete.map((x) => x._id) },
+        });
+        return result.deletedCount;
+      } else {
+        const result = await Record.updateMany(
+          { _id: { $in: toDelete.map((x) => x._id) } },
+          { archived: true },
+          { new: true }
+        );
+        return result.nModified;
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
       );
-      return result.nModified;
     }
   },
 };

--- a/src/schema/mutation/deleteRecords.mutation.ts
+++ b/src/schema/mutation/deleteRecords.mutation.ts
@@ -21,11 +21,13 @@ export default {
     hardDelete: { type: GraphQLBoolean },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // Get records and forms objects
@@ -60,7 +62,7 @@ export default {
         );
         return result.nModified;
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteReferenceData.mutation.ts
+++ b/src/schema/mutation/deleteReferenceData.mutation.ts
@@ -15,10 +15,12 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       const filters = ReferenceData.accessibleBy(ability, 'delete')
@@ -30,11 +32,11 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-  
+
       // Rebuild schema
       buildTypes();
       return referenceData;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteResource.mutation.ts
+++ b/src/schema/mutation/deleteResource.mutation.ts
@@ -15,11 +15,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = user.ability;
@@ -37,7 +39,7 @@ export default {
 
       buildTypes();
       return deletedResource;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteRole.mutation.ts
+++ b/src/schema/mutation/deleteRole.mutation.ts
@@ -14,11 +14,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -33,7 +35,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteStep.mutation.ts
+++ b/src/schema/mutation/deleteStep.mutation.ts
@@ -23,6 +23,9 @@ export default {
       }
 
       const step = await Step.findById(args.id);
+      if (!step){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const ability = await extendAbilityForStep(user, step);
       if (ability.cannot('delete', step)) {
         throw new GraphQLError(

--- a/src/schema/mutation/deleteStep.mutation.ts
+++ b/src/schema/mutation/deleteStep.mutation.ts
@@ -15,15 +15,17 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const step = await Step.findById(args.id);
-      if (!step){
+      if (!step) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const ability = await extendAbilityForStep(user, step);
@@ -35,7 +37,7 @@ export default {
 
       await step.deleteOne();
       return step;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteStep.mutation.ts
+++ b/src/schema/mutation/deleteStep.mutation.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { StepType } from '../types';
 import { Step } from '@models';
 import extendAbilityForStep from '@security/extendAbilityForStep';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete a step from its id and erase its reference in the corresponding workflow.
@@ -14,21 +15,28 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const step = await Step.findById(args.id);
-    const ability = await extendAbilityForStep(user, step);
-    if (ability.cannot('delete', step)) {
+      const step = await Step.findById(args.id);
+      const ability = await extendAbilityForStep(user, step);
+      if (ability.cannot('delete', step)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      await step.deleteOne();
+      return step;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-
-    await step.deleteOne();
-    return step;
   },
 };

--- a/src/schema/mutation/deleteSubscription.mutation.ts
+++ b/src/schema/mutation/deleteSubscription.mutation.ts
@@ -21,11 +21,13 @@ export default {
     routingKey: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -43,7 +45,7 @@ export default {
       });
       deleteQueue(args.routingKey);
       return application;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteSubscription.mutation.ts
+++ b/src/schema/mutation/deleteSubscription.mutation.ts
@@ -8,6 +8,7 @@ import { Application } from '@models';
 import { ApplicationType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { deleteQueue } from '../../server/subscriberSafe';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete a subscription.
@@ -20,26 +21,33 @@ export default {
     routingKey: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability: AppAbility = context.user.ability;
-    const filters = Application.accessibleBy(ability, 'update')
-      .where({ _id: args.applicationId })
-      .getFilter();
-    const application = await Application.findOne(filters);
-    if (!application)
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    application.subscriptions = await application.subscriptions.filter(
-      (sub) => sub.routingKey !== args.routingKey
-    );
-    await Application.findByIdAndUpdate(args.applicationId, application, {
-      new: true,
-    });
-    deleteQueue(args.routingKey);
-    return application;
+      const ability: AppAbility = context.user.ability;
+      const filters = Application.accessibleBy(ability, 'update')
+        .where({ _id: args.applicationId })
+        .getFilter();
+      const application = await Application.findOne(filters);
+      if (!application)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      application.subscriptions = await application.subscriptions.filter(
+        (sub) => sub.routingKey !== args.routingKey
+      );
+      await Application.findByIdAndUpdate(args.applicationId, application, {
+        new: true,
+      });
+      deleteQueue(args.routingKey);
+      return application;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
+    }
   },
 };

--- a/src/schema/mutation/deleteTemplate.mutation.ts
+++ b/src/schema/mutation/deleteTemplate.mutation.ts
@@ -36,7 +36,9 @@ export default {
       args.application,
       update
     );
-
+    if (!application){
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    }
     return application.templates.find((x) => x.id.toString() === args.id);
   },
 };

--- a/src/schema/mutation/deleteTemplate.mutation.ts
+++ b/src/schema/mutation/deleteTemplate.mutation.ts
@@ -36,7 +36,7 @@ export default {
       args.application,
       update
     );
-    if (!application){
+    if (!application) {
       throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
     }
     return application.templates.find((x) => x.id.toString() === args.id);

--- a/src/schema/mutation/deleteUsers.mutation.ts
+++ b/src/schema/mutation/deleteUsers.mutation.ts
@@ -19,11 +19,13 @@ export default {
     ids: { type: new GraphQLNonNull(new GraphQLList(GraphQLID)) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       if (ability.can('delete', 'User')) {
@@ -34,7 +36,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteUsers.mutation.ts
+++ b/src/schema/mutation/deleteUsers.mutation.ts
@@ -7,6 +7,7 @@ import {
 } from 'graphql';
 import { User } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete a user.
@@ -18,18 +19,25 @@ export default {
     ids: { type: new GraphQLNonNull(new GraphQLList(GraphQLID)) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    if (ability.can('delete', 'User')) {
-      const result = await User.deleteMany({ _id: { $in: args.ids } });
-      return result.deletedCount;
-    } else {
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      if (ability.can('delete', 'User')) {
+        const result = await User.deleteMany({ _id: { $in: args.ids } });
+        return result.deletedCount;
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/deleteUsersFromApplication.mutation.ts
+++ b/src/schema/mutation/deleteUsersFromApplication.mutation.ts
@@ -3,6 +3,7 @@ import permissions from '@const/permissions';
 import { PositionAttributeCategory, Role, User } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { UserType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete a user from application.
@@ -15,47 +16,54 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    // Test global permissions and application permission
-    if (ability.cannot('delete', 'User')) {
-      const canDelete = user.roles.some(
-        (x) =>
-          x.application &&
-          x.application.equals(args.application) &&
-          x.permissions.some(
-            (y) => y.type === permissions.canSeeUsers && !y.global
-          )
-      );
-      if (!canDelete) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-    }
-    const roles = await Role.find({ application: args.application });
-    const positionAttributeCategories = await PositionAttributeCategory.find({
-      application: args.application,
-    });
-    await User.updateMany(
-      {
-        _id: {
-          $in: args.ids,
-        },
-      },
-      {
-        $pull: {
-          roles: { $in: roles.map((x) => x.id) },
-          positionAttributes: {
-            category: { $in: positionAttributeCategories.map((x) => x.id) },
+      const ability: AppAbility = user.ability;
+      // Test global permissions and application permission
+      if (ability.cannot('delete', 'User')) {
+        const canDelete = user.roles.some(
+          (x) =>
+            x.application &&
+            x.application.equals(args.application) &&
+            x.permissions.some(
+              (y) => y.type === permissions.canSeeUsers && !y.global
+            )
+        );
+        if (!canDelete) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+      }
+      const roles = await Role.find({ application: args.application });
+      const positionAttributeCategories = await PositionAttributeCategory.find({
+        application: args.application,
+      });
+      await User.updateMany(
+        {
+          _id: {
+            $in: args.ids,
           },
         },
-      }
-    );
-    return User.find({ _id: { $in: args.ids } });
+        {
+          $pull: {
+            roles: { $in: roles.map((x) => x.id) },
+            positionAttributes: {
+              category: { $in: positionAttributeCategories.map((x) => x.id) },
+            },
+          },
+        }
+      );
+      return User.find({ _id: { $in: args.ids } });
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
+    }
   },
 };

--- a/src/schema/mutation/deleteUsersFromApplication.mutation.ts
+++ b/src/schema/mutation/deleteUsersFromApplication.mutation.ts
@@ -16,11 +16,13 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       // Test global permissions and application permission
@@ -58,8 +60,8 @@ export default {
           },
         }
       );
-      return User.find({ _id: { $in: args.ids } });
-    }catch (err){
+      return await User.find({ _id: { $in: args.ids } });
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteWorkflow.mutation.ts
+++ b/src/schema/mutation/deleteWorkflow.mutation.ts
@@ -14,11 +14,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -41,7 +43,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       return workflow;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteWorkflow.mutation.ts
+++ b/src/schema/mutation/deleteWorkflow.mutation.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { WorkflowType } from '../types';
 import { Workflow, Page, Step } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Delete a workflow from its id and recursively delete steps.
@@ -13,31 +14,38 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    const ability: AppAbility = context.user.ability;
-    let workflow = null;
-    if (ability.can('delete', 'Workflow')) {
-      workflow = await Workflow.findByIdAndDelete(args.id);
-    } else {
-      const page = await Page.accessibleBy(ability, 'delete').where({
-        content: args.id,
-      });
-      const step = await Step.accessibleBy(ability, 'delete').where({
-        content: args.id,
-      });
-      if (page || step) {
-        workflow = await Workflow.findByIdAndDelete(args.id);
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-    }
-    if (!workflow)
+
+      const ability: AppAbility = context.user.ability;
+      let workflow = null;
+      if (ability.can('delete', 'Workflow')) {
+        workflow = await Workflow.findByIdAndDelete(args.id);
+      } else {
+        const page = await Page.accessibleBy(ability, 'delete').where({
+          content: args.id,
+        });
+        const step = await Step.accessibleBy(ability, 'delete').where({
+          content: args.id,
+        });
+        if (page || step) {
+          workflow = await Workflow.findByIdAndDelete(args.id);
+        }
+      }
+      if (!workflow)
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      return workflow;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
-    return workflow;
+    }
   },
 };

--- a/src/schema/mutation/duplicateApplication.mutation.ts
+++ b/src/schema/mutation/duplicateApplication.mutation.ts
@@ -22,11 +22,13 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -34,7 +36,9 @@ export default {
         const baseApplication = await Application.findById(args.application);
         const copiedPages = await duplicatePages(baseApplication);
         if (!baseApplication)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         if (args.name !== '') {
           const application = new Application({
             name: args.name,
@@ -87,7 +91,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/duplicateApplication.mutation.ts
+++ b/src/schema/mutation/duplicateApplication.mutation.ts
@@ -9,6 +9,7 @@ import { ApplicationType } from '../types';
 import { duplicatePages } from '../../services/page.service';
 import { AppAbility } from '@security/defineUserAbility';
 import { status } from '@const/enumTypes';
+import { logger } from '@services/logger.service';
 
 /**
  * Create a new application from a given id.
@@ -21,68 +22,75 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    const ability: AppAbility = context.user.ability;
-    if (ability.can('create', 'Application')) {
-      const baseApplication = await Application.findById(args.application);
-      const copiedPages = await duplicatePages(baseApplication);
-      if (!baseApplication)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-      if (args.name !== '') {
-        const application = new Application({
-          name: args.name,
-          //createdAt: new Date(),
-          status: status.pending,
-          createdBy: user._id,
-          pages: copiedPages,
-          permissions: {
-            canSee: baseApplication.permissions.canSee,
-            canUpdate: baseApplication.permissions.canUpdate,
-            canDelete: baseApplication.permissions.canDelete,
-          },
-        });
-        await application.save();
-
-        // Copy Channels
-        const appChannels = await Channel.find({
-          application: baseApplication.id,
-        });
-        await Promise.all(
-          appChannels.map(async (c) => {
-            const tempChannel = new Channel({
-              title: c.title,
-              application: application._id,
-            });
-            await tempChannel.save();
-            return c;
-          })
-        );
-
-        // Create roles
-        const roles = await Role.find({ application: baseApplication._id });
-        for (const name of roles) {
-          const role = new Role({
-            title: name.title,
-            application: application.id,
-            channels: name.channels,
-          });
-          await role.save();
-        }
-        return application;
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
+
+      const ability: AppAbility = context.user.ability;
+      if (ability.can('create', 'Application')) {
+        const baseApplication = await Application.findById(args.application);
+        const copiedPages = await duplicatePages(baseApplication);
+        if (!baseApplication)
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (args.name !== '') {
+          const application = new Application({
+            name: args.name,
+            //createdAt: new Date(),
+            status: status.pending,
+            createdBy: user._id,
+            pages: copiedPages,
+            permissions: {
+              canSee: baseApplication.permissions.canSee,
+              canUpdate: baseApplication.permissions.canUpdate,
+              canDelete: baseApplication.permissions.canDelete,
+            },
+          });
+          await application.save();
+
+          // Copy Channels
+          const appChannels = await Channel.find({
+            application: baseApplication.id,
+          });
+          await Promise.all(
+            appChannels.map(async (c) => {
+              const tempChannel = new Channel({
+                title: c.title,
+                application: application._id,
+              });
+              await tempChannel.save();
+              return c;
+            })
+          );
+
+          // Create roles
+          const roles = await Role.find({ application: baseApplication._id });
+          for (const name of roles) {
+            const role = new Role({
+              title: name.title,
+              application: application.id,
+              channels: name.channels,
+            });
+            await role.save();
+          }
+          return application;
+        }
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.application.duplicate.errors.invalidArguments'
+          )
+        );
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t(
-          'mutations.application.duplicate.errors.invalidArguments'
-        )
-      );
-    } else {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/duplicatePage.mutation.ts
+++ b/src/schema/mutation/duplicatePage.mutation.ts
@@ -3,6 +3,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import { PageType } from '../types';
 import { Application, Page, Role, Step, Workflow } from '@models';
 import { duplicatePage } from '../../services/page.service';
+import { logger } from '@services/logger.service';
 
 /**
  * Duplicate existing page in a new application.
@@ -17,103 +18,110 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Check ability
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    // Check parameters
-    if (!args.page && !args.step) {
-      throw new GraphQLError(
-        context.i18next.t(
-          'mutations.application.content.duplicate.errors.missingArguments'
-        )
-      );
-    }
-    if (args.page && args.step) {
-      throw new GraphQLError(
-        context.i18next.t(
-          'mutations.application.content.duplicate.errors.incompatibleArguments'
-        )
-      );
-    }
-    // Find application
-    const application = await Application.findById(args.application);
-    if (!application)
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    // Check access to the application
-    if (ability.can('update', application)) {
-      if (args.page) {
-        // If page
-        const page = await Page.findById(args.page);
-        if (!page) throw new GraphQLError('common.errors.dataNotFound');
-        const pageApplication = await Application.findOne({
-          pages: { $in: [args.page] },
-        });
-        if (!pageApplication)
-          throw new GraphQLError('common.errors.dataNotFound');
-        if (ability.can('update', pageApplication)) {
-          // Get list of roles for default permissions
-          const roles = await Role.find({ application: application._id });
-          const permissions = {
-            canSee: roles.map((x) => x.id),
-            canUpdate: [],
-            canDelete: [],
-          };
-          // Create the new page and set the permissions
-          const newPage = await duplicatePage(
-            page,
-            `${page.name} Copy`,
-            permissions
-          );
-          const update = {
-            $push: { pages: newPage.id },
-          };
-          await Application.findByIdAndUpdate(args.application, update);
-          return newPage;
+    try{
+      // Check ability
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      // Check parameters
+      if (!args.page && !args.step) {
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.application.content.duplicate.errors.missingArguments'
+          )
+        );
+      }
+      if (args.page && args.step) {
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.application.content.duplicate.errors.incompatibleArguments'
+          )
+        );
+      }
+      // Find application
+      const application = await Application.findById(args.application);
+      if (!application)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      // Check access to the application
+      if (ability.can('update', application)) {
+        if (args.page) {
+          // If page
+          const page = await Page.findById(args.page);
+          if (!page) throw new GraphQLError('common.errors.dataNotFound');
+          const pageApplication = await Application.findOne({
+            pages: { $in: [args.page] },
+          });
+          if (!pageApplication)
+            throw new GraphQLError('common.errors.dataNotFound');
+          if (ability.can('update', pageApplication)) {
+            // Get list of roles for default permissions
+            const roles = await Role.find({ application: application._id });
+            const permissions = {
+              canSee: roles.map((x) => x.id),
+              canUpdate: [],
+              canDelete: [],
+            };
+            // Create the new page and set the permissions
+            const newPage = await duplicatePage(
+              page,
+              `${page.name} Copy`,
+              permissions
+            );
+            const update = {
+              $push: { pages: newPage.id },
+            };
+            await Application.findByIdAndUpdate(args.application, update);
+            return newPage;
+          }
+        } else {
+          // If step
+          const step = await Step.findById(args.step);
+          if (!step) throw new GraphQLError('common.errors.dataNotFound');
+          const workflow = await Workflow.findOne({
+            steps: { $in: [args.step] },
+          });
+          if (!workflow) throw new GraphQLError('common.errors.dataNotFound');
+          const page = await Page.findOne({
+            content: workflow._id,
+          });
+          if (!page) throw new GraphQLError('common.errors.dataNotFound');
+          const stepApplication = await Application.findOne({
+            pages: { $in: [page._id] },
+          });
+          if (!stepApplication)
+            throw new GraphQLError('common.errors.dataNotFound');
+          if (ability.can('update', stepApplication)) {
+            // Get list of roles for default permissions
+            const roles = await Role.find({ application: application._id });
+            const permissions = {
+              canSee: roles.map((x) => x.id),
+              canUpdate: [],
+              canDelete: [],
+            };
+            // Create the new page and set the permissions
+            const newPage = await duplicatePage(
+              new Page(step),
+              `${step.name} Copy`,
+              permissions
+            );
+            const update = {
+              $push: { pages: newPage.id },
+            };
+            await Application.findByIdAndUpdate(args.application, update);
+            return newPage;
+          }
         }
       } else {
-        // If step
-        const step = await Step.findById(args.step);
-        if (!step) throw new GraphQLError('common.errors.dataNotFound');
-        const workflow = await Workflow.findOne({
-          steps: { $in: [args.step] },
-        });
-        if (!workflow) throw new GraphQLError('common.errors.dataNotFound');
-        const page = await Page.findOne({
-          content: workflow._id,
-        });
-        if (!page) throw new GraphQLError('common.errors.dataNotFound');
-        const stepApplication = await Application.findOne({
-          pages: { $in: [page._id] },
-        });
-        if (!stepApplication)
-          throw new GraphQLError('common.errors.dataNotFound');
-        if (ability.can('update', stepApplication)) {
-          // Get list of roles for default permissions
-          const roles = await Role.find({ application: application._id });
-          const permissions = {
-            canSee: roles.map((x) => x.id),
-            canUpdate: [],
-            canDelete: [],
-          };
-          // Create the new page and set the permissions
-          const newPage = await duplicatePage(
-            new Page(step),
-            `${step.name} Copy`,
-            permissions
-          );
-          const update = {
-            $push: { pages: newPage.id },
-          };
-          await Application.findByIdAndUpdate(args.application, update);
-          return newPage;
-        }
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
       }
-    } else {
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/duplicatePage.mutation.ts
+++ b/src/schema/mutation/duplicatePage.mutation.ts
@@ -18,11 +18,13 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Check ability
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       // Check parameters
@@ -118,7 +120,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editAggregation.mutation.ts
+++ b/src/schema/mutation/editAggregation.mutation.ts
@@ -17,15 +17,19 @@ export default {
     resource: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       if (!args.resource || !args.aggregation) {
         throw new GraphQLError(
-          context.i18next.t('mutations.aggregation.edit.errors.invalidArguments')
+          context.i18next.t(
+            'mutations.aggregation.edit.errors.invalidArguments'
+          )
         );
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       // Edition of a resource
@@ -39,17 +43,17 @@ export default {
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
-  
+
         resource.aggregations.id(args.id).sourceFields =
           args.aggregation.sourceFields;
         resource.aggregations.id(args.id).pipeline = args.aggregation.pipeline;
         resource.aggregations.id(args.id).mapping = args.aggregation.mapping;
         resource.aggregations.id(args.id).name = args.aggregation.name;
-  
+
         await resource.save();
         return resource.aggregations.id(args.id);
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editAggregation.mutation.ts
+++ b/src/schema/mutation/editAggregation.mutation.ts
@@ -3,6 +3,7 @@ import { Resource } from '@models';
 import { AggregationType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import AggregationInputType from '../../schema/inputs/aggregation.input';
+import { logger } from '@services/logger.service';
 
 /**
  * Edit existing aggregation.
@@ -16,36 +17,43 @@ export default {
     resource: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    if (!args.resource || !args.aggregation) {
-      throw new GraphQLError(
-        context.i18next.t('mutations.aggregation.edit.errors.invalidArguments')
-      );
-    }
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    // Edition of a resource
-    if (args.resource) {
-      const filters = Resource.accessibleBy(ability, 'update')
-        .where({ _id: args.resource })
-        .getFilter();
-      const resource: Resource = await Resource.findOne(filters);
-      if (!resource) {
+    try{
+      if (!args.resource || !args.aggregation) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t('mutations.aggregation.edit.errors.invalidArguments')
         );
       }
-
-      resource.aggregations.id(args.id).sourceFields =
-        args.aggregation.sourceFields;
-      resource.aggregations.id(args.id).pipeline = args.aggregation.pipeline;
-      resource.aggregations.id(args.id).mapping = args.aggregation.mapping;
-      resource.aggregations.id(args.id).name = args.aggregation.name;
-
-      await resource.save();
-      return resource.aggregations.id(args.id);
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      // Edition of a resource
+      if (args.resource) {
+        const filters = Resource.accessibleBy(ability, 'update')
+          .where({ _id: args.resource })
+          .getFilter();
+        const resource: Resource = await Resource.findOne(filters);
+        if (!resource) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+  
+        resource.aggregations.id(args.id).sourceFields =
+          args.aggregation.sourceFields;
+        resource.aggregations.id(args.id).pipeline = args.aggregation.pipeline;
+        resource.aggregations.id(args.id).mapping = args.aggregation.mapping;
+        resource.aggregations.id(args.id).name = args.aggregation.name;
+  
+        await resource.save();
+        return resource.aggregations.id(args.id);
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
   },
 };

--- a/src/schema/mutation/editApiConfiguration.mutation.ts
+++ b/src/schema/mutation/editApiConfiguration.mutation.ts
@@ -13,6 +13,7 @@ import * as CryptoJS from 'crypto-js';
 import { buildTypes } from '@utils/schema';
 import { validateApi } from '@utils/validators/validateApi';
 import config from 'config';
+import { logger } from '@services/logger.service';
 
 /**
  * Edit the passed apiConfiguration if authorized.
@@ -32,63 +33,70 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    if (
-      !args.name &&
-      !args.status &&
-      !args.authType &&
-      !args.endpoint &&
-      !args.pingUrl &&
-      !args.graphQLEndpoint &&
-      !args.settings &&
-      !args.permissions
-    ) {
-      throw new GraphQLError(
-        context.i18next.t(
-          'mutations.apiConfiguration.edit.errors.invalidArguments'
-        )
-      );
-    }
-    const update = {};
-    if (args.name) {
-      validateApi(args.name);
-    }
-    Object.assign(
-      update,
-      args.name && { name: args.name },
-      args.status && { status: args.status },
-      args.authType && { authType: args.authType },
-      args.endpoint && { endpoint: args.endpoint },
-      args.graphQLEndpoint && { graphQLEndpoint: args.graphQLEndpoint },
-      args.pingUrl && { pingUrl: args.pingUrl },
-      args.settings && {
-        settings: CryptoJS.AES.encrypt(
-          JSON.stringify(args.settings),
-          config.get('encryption.key')
-        ).toString(),
-      },
-      args.permissions && { permissions: args.permissions }
-    );
-    const filters = ApiConfiguration.accessibleBy(ability, 'update')
-      .where({ _id: args.id })
-      .getFilter();
-    const apiConfiguration = await ApiConfiguration.findOneAndUpdate(
-      filters,
-      update,
-      { new: true }
-    );
-    if (apiConfiguration) {
-      if (args.status || apiConfiguration.status === status.active) {
-        buildTypes();
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-      return apiConfiguration;
-    } else {
+      const ability: AppAbility = user.ability;
+      if (
+        !args.name &&
+        !args.status &&
+        !args.authType &&
+        !args.endpoint &&
+        !args.pingUrl &&
+        !args.graphQLEndpoint &&
+        !args.settings &&
+        !args.permissions
+      ) {
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.apiConfiguration.edit.errors.invalidArguments'
+          )
+        );
+      }
+      const update = {};
+      if (args.name) {
+        validateApi(args.name);
+      }
+      Object.assign(
+        update,
+        args.name && { name: args.name },
+        args.status && { status: args.status },
+        args.authType && { authType: args.authType },
+        args.endpoint && { endpoint: args.endpoint },
+        args.graphQLEndpoint && { graphQLEndpoint: args.graphQLEndpoint },
+        args.pingUrl && { pingUrl: args.pingUrl },
+        args.settings && {
+          settings: CryptoJS.AES.encrypt(
+            JSON.stringify(args.settings),
+            config.get('encryption.key')
+          ).toString(),
+        },
+        args.permissions && { permissions: args.permissions }
+      );
+      const filters = ApiConfiguration.accessibleBy(ability, 'update')
+        .where({ _id: args.id })
+        .getFilter();
+      const apiConfiguration = await ApiConfiguration.findOneAndUpdate(
+        filters,
+        update,
+        { new: true }
+      );
+      if (apiConfiguration) {
+        if (args.status || apiConfiguration.status === status.active) {
+          buildTypes();
+        }
+        return apiConfiguration;
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/editApiConfiguration.mutation.ts
+++ b/src/schema/mutation/editApiConfiguration.mutation.ts
@@ -33,10 +33,12 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       if (
@@ -93,7 +95,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editApplication.mutation.ts
+++ b/src/schema/mutation/editApplication.mutation.ts
@@ -29,11 +29,13 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = context.user.ability;
       if (
@@ -80,10 +82,8 @@ export default {
       application = await Application.findOneAndUpdate(filters, update, {
         new: true,
       });
-      if(!application){
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+      if (!application) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const publisher = await pubsub();
       publisher.publish('app_edited', {
@@ -95,7 +95,7 @@ export default {
         user: user._id,
       });
       return application;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editApplication.mutation.ts
+++ b/src/schema/mutation/editApplication.mutation.ts
@@ -11,6 +11,7 @@ import { ApplicationType } from '../types';
 import { Application } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { StatusEnumType } from '@const/enumTypes';
+import { logger } from '@services/logger.service';
 
 /**
  * Find application from its id and update it, if user is authorized.
@@ -28,65 +29,77 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = context.user.ability;
-    if (
-      !args ||
-      (!args.name &&
-        !args.status &&
-        !args.pages &&
-        !args.settings &&
-        !args.permissions)
-    ) {
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = context.user.ability;
+      if (
+        !args ||
+        (!args.name &&
+          !args.status &&
+          !args.pages &&
+          !args.settings &&
+          !args.permissions)
+      ) {
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.application.duplicate.errors.invalidArguments'
+          )
+        );
+      }
+      const filters = Application.accessibleBy(ability, 'update')
+        .where({ _id: args.id })
+        .getFilter();
+      let application = await Application.findOne(filters);
+      if (!application) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      if (
+        application.lockedBy &&
+        application.lockedBy.toString() !== user._id.toString()
+      ) {
+        throw new GraphQLError('Please unlock application for edition.');
+      }
+      const update = {
+        // lockedBy: user._id,
+      };
+      Object.assign(
+        update,
+        args.name && { name: args.name },
+        args.description && { description: args.description },
+        args.status && { status: args.status },
+        args.pages && { pages: args.pages },
+        args.settings && { settings: args.settings },
+        args.permissions && { permissions: args.permissions }
+      );
+      application = await Application.findOneAndUpdate(filters, update, {
+        new: true,
+      });
+      if(!application){
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+      const publisher = await pubsub();
+      publisher.publish('app_edited', {
+        application,
+        user: user._id,
+      });
+      publisher.publish('app_lock', {
+        application,
+        user: user._id,
+      });
+      return application;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t(
-          'mutations.application.duplicate.errors.invalidArguments'
-        )
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    const filters = Application.accessibleBy(ability, 'update')
-      .where({ _id: args.id })
-      .getFilter();
-    let application = await Application.findOne(filters);
-    if (!application) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-    if (
-      application.lockedBy &&
-      application.lockedBy.toString() !== user._id.toString()
-    ) {
-      throw new GraphQLError('Please unlock application for edition.');
-    }
-    const update = {
-      // lockedBy: user._id,
-    };
-    Object.assign(
-      update,
-      args.name && { name: args.name },
-      args.description && { description: args.description },
-      args.status && { status: args.status },
-      args.pages && { pages: args.pages },
-      args.settings && { settings: args.settings },
-      args.permissions && { permissions: args.permissions }
-    );
-    application = await Application.findOneAndUpdate(filters, update, {
-      new: true,
-    });
-    const publisher = await pubsub();
-    publisher.publish('app_edited', {
-      application,
-      user: user._id,
-    });
-    publisher.publish('app_lock', {
-      application,
-      user: user._id,
-    });
-    return application;
   },
 };

--- a/src/schema/mutation/editChannel.mutation.ts
+++ b/src/schema/mutation/editChannel.mutation.ts
@@ -20,18 +20,20 @@ export default {
     title: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = context.user.ability;
       const channel = await Channel.findById(args.id);
       if (!channel)
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       if (ability.can('update', channel)) {
-        return Channel.findByIdAndUpdate(
+        return await Channel.findByIdAndUpdate(
           args.id,
           {
             title: args.title,
@@ -43,7 +45,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editCustomNotification.mutation.ts
+++ b/src/schema/mutation/editCustomNotification.mutation.ts
@@ -70,9 +70,7 @@ export default {
         { new: true }
       );
       if (!application) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const notificationDetail = application.customNotifications.find(
         (customNotification) => customNotification.id.toString() === args.id

--- a/src/schema/mutation/editCustomNotification.mutation.ts
+++ b/src/schema/mutation/editCustomNotification.mutation.ts
@@ -69,7 +69,11 @@ export default {
         update,
         { new: true }
       );
-
+      if (!application) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
       const notificationDetail = application.customNotifications.find(
         (customNotification) => customNotification.id.toString() === args.id
       );

--- a/src/schema/mutation/editDashboard.mutation.ts
+++ b/src/schema/mutation/editDashboard.mutation.ts
@@ -22,11 +22,13 @@ export default {
     name: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       // check inputs
       if (!args || (!args.name && !args.structure)) {
@@ -36,7 +38,7 @@ export default {
       }
       // get data
       let dashboard = await Dashboard.findById(args.id);
-      if (!dashboard){
+      if (!dashboard) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       // check permissions
@@ -65,20 +67,22 @@ export default {
         modifiedAt: dashboard.modifiedAt,
         name: dashboard.name,
       };
-      const page = await Page.findOneAndUpdate({ content: dashboard.id }, update);
+      const page = await Page.findOneAndUpdate(
+        { content: dashboard.id },
+        update
+      );
       if (!page) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
-      const step = await Step.findOneAndUpdate({ content: dashboard.id }, update);
+      const step = await Step.findOneAndUpdate(
+        { content: dashboard.id },
+        update
+      );
       if (!step) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       return dashboard;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editDashboard.mutation.ts
+++ b/src/schema/mutation/editDashboard.mutation.ts
@@ -36,6 +36,9 @@ export default {
       }
       // get data
       let dashboard = await Dashboard.findById(args.id);
+      if (!dashboard){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       // check permissions
       const ability = await extendAbilityForContent(user, dashboard);
       if (ability.cannot('update', dashboard)) {

--- a/src/schema/mutation/editDashboard.mutation.ts
+++ b/src/schema/mutation/editDashboard.mutation.ts
@@ -8,6 +8,7 @@ import GraphQLJSON from 'graphql-type-json';
 import { DashboardType } from '../types';
 import { Dashboard, Page, Step } from '@models';
 import extendAbilityForContent from '@security/extendAbilityForContent';
+import { logger } from '@services/logger.service';
 
 /**
  * Find dashboard from its id and update it, if user is authorized.
@@ -21,47 +22,64 @@ export default {
     name: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    // check inputs
-    if (!args || (!args.name && !args.structure)) {
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      // check inputs
+      if (!args || (!args.name && !args.structure)) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.dashboard.edit.errors.invalidArguments')
+        );
+      }
+      // get data
+      let dashboard = await Dashboard.findById(args.id);
+      // check permissions
+      const ability = await extendAbilityForContent(user, dashboard);
+      if (ability.cannot('update', dashboard)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      // do the update on dashboard
+      const updateDashboard: {
+        //modifiedAt?: Date;
+        structure?: any;
+        name?: string;
+      } = {};
+      Object.assign(
+        updateDashboard,
+        args.structure && { structure: args.structure },
+        args.name && { name: args.name }
+      );
+      dashboard = await Dashboard.findByIdAndUpdate(args.id, updateDashboard, {
+        new: true,
+      });
+      // update the related page or step
+      const update = {
+        modifiedAt: dashboard.modifiedAt,
+        name: dashboard.name,
+      };
+      const page = await Page.findOneAndUpdate({ content: dashboard.id }, update);
+      if (!page) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+      const step = await Step.findOneAndUpdate({ content: dashboard.id }, update);
+      if (!step) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+      return dashboard;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('mutations.dashboard.edit.errors.invalidArguments')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    // get data
-    let dashboard = await Dashboard.findById(args.id);
-    // check permissions
-    const ability = await extendAbilityForContent(user, dashboard);
-    if (ability.cannot('update', dashboard)) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-    // do the update on dashboard
-    const updateDashboard: {
-      //modifiedAt?: Date;
-      structure?: any;
-      name?: string;
-    } = {};
-    Object.assign(
-      updateDashboard,
-      args.structure && { structure: args.structure },
-      args.name && { name: args.name }
-    );
-    dashboard = await Dashboard.findByIdAndUpdate(args.id, updateDashboard, {
-      new: true,
-    });
-    // update the related page or step
-    const update = {
-      modifiedAt: dashboard.modifiedAt,
-      name: dashboard.name,
-    };
-    await Page.findOneAndUpdate({ content: dashboard.id }, update);
-    await Step.findOneAndUpdate({ content: dashboard.id }, update);
-    return dashboard;
   },
 };

--- a/src/schema/mutation/editDistributionList.mutation.ts
+++ b/src/schema/mutation/editDistributionList.mutation.ts
@@ -51,9 +51,14 @@ export default {
       update,
       { new: true }
     );
-
-    return application.distributionLists.find(
-      (distributionList) => distributionList.id.toString() === args.id
-    );
+    if(!application){
+      throw new GraphQLError(
+        context.i18next.t('common.errors.dataNotFound')
+      );
+    }else{
+      return application.distributionLists.find(
+        (distributionList) => distributionList.id.toString() === args.id
+      );
+    }
   },
 };

--- a/src/schema/mutation/editDistributionList.mutation.ts
+++ b/src/schema/mutation/editDistributionList.mutation.ts
@@ -51,11 +51,9 @@ export default {
       update,
       { new: true }
     );
-    if(!application){
-      throw new GraphQLError(
-        context.i18next.t('common.errors.dataNotFound')
-      );
-    }else{
+    if (!application) {
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    } else {
       return application.distributionLists.find(
         (distributionList) => distributionList.id.toString() === args.id
       );

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -24,6 +24,7 @@ import differenceWith from 'lodash/differenceWith';
 import unionWith from 'lodash/unionWith';
 import i18next from 'i18next';
 import { isArray } from 'lodash';
+import { logger } from '@services/logger.service';
 
 /**
  * List of keys of the structure's object which we want to inherit to the children forms when they are modified on the core form
@@ -78,420 +79,431 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    // Permission check
-    const ability: AppAbility = user.ability;
-    const form = await Form.findById(args.id);
-    if (ability.cannot('update', form)) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-
-    // Initialize the update object --- TODO = put interface
-    /* const update: any = {
-      modifiedAt: new Date(),
-    }; */
-    const update: any = {};
-
-    // Update name
-    if (args.name) {
-      const graphQLTypeName = Form.getGraphQLTypeName(args.name);
-      validateGraphQLTypeName(
-        Form.getGraphQLTypeName(args.name),
-        context.i18next
-      );
-      if (
-        (await Form.hasDuplicate(graphQLTypeName, form.id)) ||
-        (await ReferenceData.hasDuplicate(graphQLTypeName))
-      ) {
+      // Permission check
+      const ability: AppAbility = user.ability;
+      const form = await Form.findById(args.id);
+      if (ability.cannot('update', form)) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.duplicatedGraphQLTypeName')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-      update.name = args.name;
-      update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
-      if (form.core) {
-        await Resource.findByIdAndUpdate(form.resource, {
-          name: args.name,
-        });
-      }
-    }
 
-    // Update status
-    if (args.status) {
-      update.status = args.status;
-      // Activate the form.
-      if (update.status === status.active) {
-        // Create notification channel
-        const notificationChannel = new Channel({
-          title: `Form - ${form.name}`,
-          form: form._id,
-        });
-        await notificationChannel.save();
-        update.channel = notificationChannel.form;
-      } else {
-        // Deactivate the form
-        // delete channel and notifications if form not active anymore
-        const channel = await Channel.findOneAndDelete({ form: form._id });
-        if (channel) {
-          update.channel = [];
+      // Initialize the update object --- TODO = put interface
+      /* const update: any = {
+        modifiedAt: new Date(),
+      }; */
+      const update: any = {};
+
+      // Update name
+      if (args.name) {
+        const graphQLTypeName = Form.getGraphQLTypeName(args.name);
+        validateGraphQLTypeName(
+          Form.getGraphQLTypeName(args.name),
+          context.i18next
+        );
+        if (
+          (await Form.hasDuplicate(graphQLTypeName, form.id)) ||
+          (await ReferenceData.hasDuplicate(graphQLTypeName))
+        ) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.duplicatedGraphQLTypeName')
+          );
+        }
+        update.name = args.name;
+        update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
+        if (form.core) {
+          await Resource.findByIdAndUpdate(form.resource, {
+            name: args.name,
+          });
         }
       }
-    }
 
-    // Update permissions
-    if (args.permissions) {
-      const permissions: PermissionChange = args.permissions;
-      for (const permission in permissions) {
-        if (isArray(permissions[permission])) {
-          // if it's an array, replace the old value with the provided list
-          update['permissions.' + permission] = permissions[permission];
+      // Update status
+      if (args.status) {
+        update.status = args.status;
+        // Activate the form.
+        if (update.status === status.active) {
+          // Create notification channel
+          const notificationChannel = new Channel({
+            title: `Form - ${form.name}`,
+            form: form._id,
+          });
+          await notificationChannel.save();
+          update.channel = notificationChannel.form;
         } else {
-          const obj = permissions[permission];
-          if (obj.add && obj.add.length) {
-            const pushRoles = {
-              [`permissions.${permission}`]: { $each: obj.add },
-            };
-
-            if (update.$addToSet) Object.assign(update.$addToSet, pushRoles);
-            else Object.assign(update, { $addToSet: pushRoles });
-          }
-          if (obj.remove && obj.remove.length) {
-            let pullRoles: any;
-
-            if (typeof obj.remove[0] === 'string') {
-              // CanSee, canUpdate, canDelete, canCreateRecords
-              pullRoles = {
-                [`permissions.${permission}`]: {
-                  $in: obj.remove.map(
-                    (role: any) => new mongoose.Types.ObjectId(role)
-                  ),
-                },
-              };
-            } else {
-              // canSeeRecords, canUpdateRecords, canDeleteRecords, recordsUnicity
-              pullRoles = {
-                [`permissions.${permission}`]: {
-                  $in: obj.remove.map((perm: any) =>
-                    perm.access
-                      ? {
-                          role: new mongoose.Types.ObjectId(perm.role),
-                          access: perm.access,
-                        }
-                      : {
-                          role: new mongoose.Types.ObjectId(perm.role),
-                        }
-                  ),
-                },
-              };
-            }
-
-            if (update.$pull) Object.assign(update.$pull, pullRoles);
-            else Object.assign(update, { $pull: pullRoles });
-          }
-        }
-      }
-    }
-
-    // Update fields and structure, check that structure is different
-    if (args.structure && !isEqual(form.structure, args.structure)) {
-      update.structure = args.structure;
-      const structure = JSON.parse(args.structure);
-      const fields = [];
-      for (const page of structure.pages) {
-        await extractFields(page, fields, form.core);
-        findDuplicateFields(fields);
-        for (const field of fields.filter((x) =>
-          ['resource', 'resources'].includes(x.type)
-        )) {
-          // Raises an error if the field is already used as related name for this resource
-          if (
-            await Form.findOne({
-              fields: {
-                $elemMatch: {
-                  resource: field.resource,
-                  relatedName: field.relatedName,
-                },
-              },
-              _id: { $ne: form.id },
-              ...(form.resource && { resource: { $ne: form.resource } }),
-            })
-          ) {
+          // Deactivate the form
+          // delete channel and notifications if form not active anymore
+          const channel = await Channel.findOneAndDelete({ form: form._id });
+          if (channel) {
+            update.channel = [];
+          }else{
             throw new GraphQLError(
-              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
-                name: field.relatedName,
-              })
-            );
-          }
-          // Raises an error if the field exists in the resource
-          if (
-            await Resource.findOne({
-              fields: { $elemMatch: { name: field.relatedName } },
-              _id: field.resource,
-            })
-          ) {
-            throw new GraphQLError(
-              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
-                name: field.relatedName,
-              })
+              context.i18next.t('common.errors.dataNotFound')
             );
           }
         }
       }
-      // Resource inheritance management
-      if (form.resource) {
-        const resource = await Resource.findById(form.resource);
-        const templates = await Form.find({
-          resource: form.resource,
-          _id: { $ne: mongoose.Types.ObjectId(args.id) },
-        }).select('_id structure fields');
-        const oldFields: any[] = JSON.parse(JSON.stringify(resource.fields));
-        const usedFields = templates
-          .map((x) => x.fields)
-          .flat()
-          .concat(fields);
-        // Check fields against the resource to add new ones or edit old ones
-        for (const field of fields) {
-          // For each field in the form being saved
-          const oldField = oldFields.find((x) => x.name === field.name); // Find the equivalent field in the ressource's fields
-          if (!oldField) {
-            // If the field isn't found in the resource
-            const newField: any = Object.assign({}, field); // Create a copy of the form's field
-            newField.isRequired = form.core && field.isRequired ? true : false; // If it's a core form and the field isRequired, copy this property
-            oldFields.push(newField); // Add this field to the list of the resource's fields
+
+      // Update permissions
+      if (args.permissions) {
+        const permissions: PermissionChange = args.permissions;
+        for (const permission in permissions) {
+          if (isArray(permissions[permission])) {
+            // if it's an array, replace the old value with the provided list
+            update['permissions.' + permission] = permissions[permission];
           } else {
-            // Check if field can be updated
-            if (!oldField.isCore || (oldField.isCore && form.core)) {
-              //If resource's field isn't core or if it's core but the edited form is core too, make it writable
-              if (!isEqual(oldField, field)) {
-                // If the resource's field and the current form's field are different
-                const index = oldFields.findIndex((x) => x.name === field.name); // Get the index of the form's field in the resources
-                oldFields.splice(index, 1, field); // Replace resource's field by the form's field
-                // === REFLECT UPDATE ===
-                for (const template of templates) {
-                  // For each form that inherits from the same resource
+            const obj = permissions[permission];
+            if (obj.add && obj.add.length) {
+              const pushRoles = {
+                [`permissions.${permission}`]: { $each: obj.add },
+              };
 
-                  template.fields = template.fields.map((x) => {
-                    // For each field of the childForm
-                    return x.name === field.name // If the child field's name equals the parent field's name
-                      ? x.hasOwnProperty('defaultValue') &&
-                        !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
-                        ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
-                        : field // Else replace child's field by parent's field
-                      : x; // Else don't change the child's field
-                  });
-                  if (!field.generated) {
-                    // Update structure
-                    const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
-                    const prevStructure = JSON.parse(
-                      form.structure ? form.structure : ''
-                    ); // Get the current form's state structure
-                    replaceField(
-                      field.name,
-                      newStructure,
-                      structure,
-                      prevStructure
-                    ); // Replace the inheriting form's field by the edited form's field
-                    template.structure = JSON.stringify(newStructure); // Save the new structure
+              if (update.$addToSet) Object.assign(update.$addToSet, pushRoles);
+              else Object.assign(update, { $addToSet: pushRoles });
+            }
+            if (obj.remove && obj.remove.length) {
+              let pullRoles: any;
+
+              if (typeof obj.remove[0] === 'string') {
+                // CanSee, canUpdate, canDelete, canCreateRecords
+                pullRoles = {
+                  [`permissions.${permission}`]: {
+                    $in: obj.remove.map(
+                      (role: any) => new mongoose.Types.ObjectId(role)
+                    ),
+                  },
+                };
+              } else {
+                // canSeeRecords, canUpdateRecords, canDeleteRecords, recordsUnicity
+                pullRoles = {
+                  [`permissions.${permission}`]: {
+                    $in: obj.remove.map((perm: any) =>
+                      perm.access
+                        ? {
+                            role: new mongoose.Types.ObjectId(perm.role),
+                            access: perm.access,
+                          }
+                        : {
+                            role: new mongoose.Types.ObjectId(perm.role),
+                          }
+                    ),
+                  },
+                };
+              }
+
+              if (update.$pull) Object.assign(update.$pull, pullRoles);
+              else Object.assign(update, { $pull: pullRoles });
+            }
+          }
+        }
+      }
+
+      // Update fields and structure, check that structure is different
+      if (args.structure && !isEqual(form.structure, args.structure)) {
+        update.structure = args.structure;
+        const structure = JSON.parse(args.structure);
+        const fields = [];
+        for (const page of structure.pages) {
+          await extractFields(page, fields, form.core);
+          findDuplicateFields(fields);
+          for (const field of fields.filter((x) =>
+            ['resource', 'resources'].includes(x.type)
+          )) {
+            // Raises an error if the field is already used as related name for this resource
+            if (
+              await Form.findOne({
+                fields: {
+                  $elemMatch: {
+                    resource: field.resource,
+                    relatedName: field.relatedName,
+                  },
+                },
+                _id: { $ne: form.id },
+                ...(form.resource && { resource: { $ne: form.resource } }),
+              })
+            ) {
+              throw new GraphQLError(
+                i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
+                  name: field.relatedName,
+                })
+              );
+            }
+            // Raises an error if the field exists in the resource
+            if (
+              await Resource.findOne({
+                fields: { $elemMatch: { name: field.relatedName } },
+                _id: field.resource,
+              })
+            ) {
+              throw new GraphQLError(
+                i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
+                  name: field.relatedName,
+                })
+              );
+            }
+          }
+        }
+        // Resource inheritance management
+        if (form.resource) {
+          const resource = await Resource.findById(form.resource);
+          const templates = await Form.find({
+            resource: form.resource,
+            _id: { $ne: mongoose.Types.ObjectId(args.id) },
+          }).select('_id structure fields');
+          const oldFields: any[] = JSON.parse(JSON.stringify(resource.fields));
+          const usedFields = templates
+            .map((x) => x.fields)
+            .flat()
+            .concat(fields);
+          // Check fields against the resource to add new ones or edit old ones
+          for (const field of fields) {
+            // For each field in the form being saved
+            const oldField = oldFields.find((x) => x.name === field.name); // Find the equivalent field in the ressource's fields
+            if (!oldField) {
+              // If the field isn't found in the resource
+              const newField: any = Object.assign({}, field); // Create a copy of the form's field
+              newField.isRequired = form.core && field.isRequired ? true : false; // If it's a core form and the field isRequired, copy this property
+              oldFields.push(newField); // Add this field to the list of the resource's fields
+            } else {
+              // Check if field can be updated
+              if (!oldField.isCore || (oldField.isCore && form.core)) {
+                //If resource's field isn't core or if it's core but the edited form is core too, make it writable
+                if (!isEqual(oldField, field)) {
+                  // If the resource's field and the current form's field are different
+                  const index = oldFields.findIndex((x) => x.name === field.name); // Get the index of the form's field in the resources
+                  oldFields.splice(index, 1, field); // Replace resource's field by the form's field
+                  // === REFLECT UPDATE ===
+                  for (const template of templates) {
+                    // For each form that inherits from the same resource
+
+                    template.fields = template.fields.map((x) => {
+                      // For each field of the childForm
+                      return x.name === field.name // If the child field's name equals the parent field's name
+                        ? x.hasOwnProperty('defaultValue') &&
+                          !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
+                          ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
+                          : field // Else replace child's field by parent's field
+                        : x; // Else don't change the child's field
+                    });
+                    if (!field.generated) {
+                      // Update structure
+                      const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
+                      const prevStructure = JSON.parse(
+                        form.structure ? form.structure : ''
+                      ); // Get the current form's state structure
+                      replaceField(
+                        field.name,
+                        newStructure,
+                        structure,
+                        prevStructure
+                      ); // Replace the inheriting form's field by the edited form's field
+                      template.structure = JSON.stringify(newStructure); // Save the new structure
+                    }
                   }
                 }
               }
             }
           }
-        }
-        // Check if there are unused or duplicated fields in the resource
-        for (let index = 0; index < oldFields.length; index++) {
-          const field = oldFields[index]; // Store the resource's field
-          if (!field.isCalculated) {
-            // prevent calculated fields to be deleted automatically
-            const fieldToRemove =
-              ((form.core
-                ? !fields.some((x) => x.name === field.name)
-                : true) && // If edited form is core, check if resource's field is absent from form's fields
-                !usedFields.some((x) => x.name === field.name)) || // Unused -- TODO What if it's in one inherited form and not in another ?
-              oldFields.some((x, id) => field.name === x.name && id !== index); // Duplicated If there's another field with the same name but not the same ID
-            if (fieldToRemove) {
-              oldFields.splice(index, 1);
-              index--;
-            }
-          }
-        }
-        // Check if form is a core template of a resource
-        if (!form.core) {
-          // Check if a required field is missing
-          // Keep old version and move that to extract fields ?
-          let fieldExists = false;
-          for (const field of oldFields.filter((x) => x.isCore)) {
-            // For each non-core field in the resource
-            for (const x of fields) {
-              if (x.name === field.name) {
-                x.isCore = true;
-                fieldExists = true;
+          // Check if there are unused or duplicated fields in the resource
+          for (let index = 0; index < oldFields.length; index++) {
+            const field = oldFields[index]; // Store the resource's field
+            if (!field.isCalculated) {
+              // prevent calculated fields to be deleted automatically
+              const fieldToRemove =
+                ((form.core
+                  ? !fields.some((x) => x.name === field.name)
+                  : true) && // If edited form is core, check if resource's field is absent from form's fields
+                  !usedFields.some((x) => x.name === field.name)) || // Unused -- TODO What if it's in one inherited form and not in another ?
+                oldFields.some((x, id) => field.name === x.name && id !== index); // Duplicated If there's another field with the same name but not the same ID
+              if (fieldToRemove) {
+                oldFields.splice(index, 1);
+                index--;
               }
             }
-            if (!fieldExists) {
-              throw new GraphQLError(
-                i18next.t('mutations.form.edit.errors.coreFieldMissing', {
-                  name: field.name,
-                })
-              );
-            }
-            fieldExists = false;
           }
-        } else {
-          // List deleted fields
-          const deletedFields = form.fields.filter(
-            (x) => !fields.some((y) => x.name === y.name)
-          );
-          // List new fields
-          const newFields = fields.filter(
-            (x) => !form.fields.some((y) => x.name === y.name)
-          );
-          // Detect structure updates
-          const structureUpdate = {};
-          const newStructure = structure;
-          if (form.structure) {
-            const prevStructure = JSON.parse(form.structure);
+          // Check if form is a core template of a resource
+          if (!form.core) {
+            // Check if a required field is missing
+            // Keep old version and move that to extract fields ?
+            let fieldExists = false;
+            for (const field of oldFields.filter((x) => x.isCore)) {
+              // For each non-core field in the resource
+              for (const x of fields) {
+                if (x.name === field.name) {
+                  x.isCore = true;
+                  fieldExists = true;
+                }
+              }
+              if (!fieldExists) {
+                throw new GraphQLError(
+                  i18next.t('mutations.form.edit.errors.coreFieldMissing', {
+                    name: field.name,
+                  })
+                );
+              }
+              fieldExists = false;
+            }
+          } else {
+            // List deleted fields
+            const deletedFields = form.fields.filter(
+              (x) => !fields.some((y) => x.name === y.name)
+            );
+            // List new fields
+            const newFields = fields.filter(
+              (x) => !form.fields.some((y) => x.name === y.name)
+            );
+            // Detect structure updates
+            const structureUpdate = {};
+            const newStructure = structure;
+            if (form.structure) {
+              const prevStructure = JSON.parse(form.structure);
 
-            // Store the property's objects that have been removed between the new and previous versions of the form
-            for (const property of INHERITED_PROPERTIES) {
-              if (!isEqual(prevStructure[property], newStructure[property])) {
-                structureUpdate[property] = newStructure[property]
-                  ? differenceWith(
-                      prevStructure[property],
-                      newStructure[property],
+              // Store the property's objects that have been removed between the new and previous versions of the form
+              for (const property of INHERITED_PROPERTIES) {
+                if (!isEqual(prevStructure[property], newStructure[property])) {
+                  structureUpdate[property] = newStructure[property]
+                    ? differenceWith(
+                        prevStructure[property],
+                        newStructure[property],
+                        isEqual
+                      )
+                    : prevStructure[property];
+                }
+              }
+            }
+
+            // Loop on templates
+            for (const template of templates) {
+              // === REFLECT DELETION ===
+              // For each old field from core form which is not anymore in the current core form fields
+              for (const field of deletedFields) {
+                // Check if we rename or delete a field used in a child form
+                if (usedFields.some((x) => x.name === field.name)) {
+                  // If this deleted / modified field was used, reflect the deletion / edition
+                  const index = template.fields.findIndex(
+                    (x) => x.name === field.name
+                  );
+                  template.fields.splice(index, 1);
+                  if (!field.generated) {
+                    // Remove from structure
+                    const templateStructure = JSON.parse(template.structure);
+                    removeField(templateStructure, field.name);
+                    template.structure = JSON.stringify(templateStructure);
+                  }
+                }
+              }
+
+              // === REFLECT ADDITION ===
+              // For each new field from core form which were not before in the old core form fields
+              for (const field of newFields) {
+                // Add to fields and structure if needed
+                if (!template.fields.some((x) => x.name === field.name)) {
+                  template.fields.unshift(field);
+
+                  if (!field.generated) {
+                    // Add to structure
+                    const templateStructure = JSON.parse(template.structure);
+                    addField(templateStructure, field.name, structure);
+                    template.structure = JSON.stringify(templateStructure);
+                  }
+                }
+              }
+
+              // REFLECT STRUCTURE CHANGES ===
+              const templateStructure = JSON.parse(template.structure);
+              for (const objectKey in structureUpdate) {
+                // In a childForm's structure, if there are property's objects that have been deleted from the core form, delete them there too
+                if (
+                  templateStructure[objectKey] &&
+                  templateStructure[objectKey].length &&
+                  structureUpdate[objectKey] &&
+                  structureUpdate[objectKey].length
+                ) {
+                  templateStructure[objectKey] = differenceWith(
+                    templateStructure[objectKey],
+                    structureUpdate[objectKey],
+                    isEqual
+                  );
+                }
+                // Merge the new property's objects to the children
+                templateStructure[objectKey] = templateStructure[objectKey]
+                  ? unionWith(
+                      templateStructure[objectKey],
+                      newStructure[objectKey],
                       isEqual
                     )
-                  : prevStructure[property];
+                  : newStructure[objectKey];
+                // If the property is null, undefined or empty, directly remove the entry from the structure
+                if (
+                  !templateStructure[objectKey] ||
+                  !templateStructure[objectKey].length
+                ) {
+                  delete templateStructure[objectKey];
+                }
               }
+              template.structure = JSON.stringify(templateStructure);
             }
-          }
 
-          // Loop on templates
-          for (const template of templates) {
-            // === REFLECT DELETION ===
-            // For each old field from core form which is not anymore in the current core form fields
             for (const field of deletedFields) {
-              // Check if we rename or delete a field used in a child form
-              if (usedFields.some((x) => x.name === field.name)) {
-                // If this deleted / modified field was used, reflect the deletion / edition
-                const index = template.fields.findIndex(
-                  (x) => x.name === field.name
-                );
-                template.fields.splice(index, 1);
-                if (!field.generated) {
-                  // Remove from structure
-                  const templateStructure = JSON.parse(template.structure);
-                  removeField(templateStructure, field.name);
-                  template.structure = JSON.stringify(templateStructure);
-                }
+              // We remove the field from the resource
+              const index = oldFields.findIndex((x) => x.name === field.name);
+              if (index >= 0) {
+                oldFields.splice(index, 1);
               }
             }
-
-            // === REFLECT ADDITION ===
-            // For each new field from core form which were not before in the old core form fields
-            for (const field of newFields) {
-              // Add to fields and structure if needed
-              if (!template.fields.some((x) => x.name === field.name)) {
-                template.fields.unshift(field);
-
-                if (!field.generated) {
-                  // Add to structure
-                  const templateStructure = JSON.parse(template.structure);
-                  addField(templateStructure, field.name, structure);
-                  template.structure = JSON.stringify(templateStructure);
-                }
-              }
-            }
-
-            // REFLECT STRUCTURE CHANGES ===
-            const templateStructure = JSON.parse(template.structure);
-            for (const objectKey in structureUpdate) {
-              // In a childForm's structure, if there are property's objects that have been deleted from the core form, delete them there too
-              if (
-                templateStructure[objectKey] &&
-                templateStructure[objectKey].length &&
-                structureUpdate[objectKey] &&
-                structureUpdate[objectKey].length
-              ) {
-                templateStructure[objectKey] = differenceWith(
-                  templateStructure[objectKey],
-                  structureUpdate[objectKey],
-                  isEqual
-                );
-              }
-              // Merge the new property's objects to the children
-              templateStructure[objectKey] = templateStructure[objectKey]
-                ? unionWith(
-                    templateStructure[objectKey],
-                    newStructure[objectKey],
-                    isEqual
-                  )
-                : newStructure[objectKey];
-              // If the property is null, undefined or empty, directly remove the entry from the structure
-              if (
-                !templateStructure[objectKey] ||
-                !templateStructure[objectKey].length
-              ) {
-                delete templateStructure[objectKey];
-              }
-            }
-            template.structure = JSON.stringify(templateStructure);
           }
 
-          for (const field of deletedFields) {
-            // We remove the field from the resource
-            const index = oldFields.findIndex((x) => x.name === field.name);
-            if (index >= 0) {
-              oldFields.splice(index, 1);
-            }
-          }
-        }
-
-        // Build bulk update of non-core templates
-        const bulkUpdate = [];
-        for (const template of templates) {
-          bulkUpdate.push({
-            updateOne: {
-              filter: { _id: template._id },
-              update: {
-                structure: template.structure,
-                fields: template.fields,
+          // Build bulk update of non-core templates
+          const bulkUpdate = [];
+          for (const template of templates) {
+            bulkUpdate.push({
+              updateOne: {
+                filter: { _id: template._id },
+                update: {
+                  structure: template.structure,
+                  fields: template.fields,
+                },
               },
-            },
+            });
+          }
+          if (bulkUpdate.length > 0) {
+            // Update all child form for addition/deletion/structure changes
+            await Form.bulkWrite(bulkUpdate);
+          }
+
+          // Update resource fields
+          await Resource.findByIdAndUpdate(form.resource, {
+            fields: oldFields,
           });
         }
-        if (bulkUpdate.length > 0) {
-          // Update all child form for addition/deletion/structure changes
-          await Form.bulkWrite(bulkUpdate);
-        }
-
-        // Update resource fields
-        await Resource.findByIdAndUpdate(form.resource, {
-          fields: oldFields,
+        update.fields = fields;
+        // Update version
+        const version = new Version({
+          //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
+          data: form.structure,
         });
+        await version.save();
+        update.$push = { versions: version._id };
       }
-      update.fields = fields;
-      // Update version
-      const version = new Version({
-        //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
-        data: form.structure,
+      // Return updated form
+      return Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
+        // Avoid to rebuild types only if permissions changed
+        if (args.name || args.status || args.structure) {
+          buildTypes();
+        }
       });
-      await version.save();
-      update.$push = { versions: version._id };
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    // Return updated form
-    return Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
-      // Avoid to rebuild types only if permissions changed
-      if (args.name || args.status || args.structure) {
-        buildTypes();
-      }
-    });
   },
 };

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -89,6 +89,9 @@ export default {
       // Permission check
       const ability: AppAbility = user.ability;
       const form = await Form.findById(args.id);
+      if (!form){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       if (ability.cannot('update', form)) {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
@@ -119,9 +122,12 @@ export default {
         update.name = args.name;
         update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
         if (form.core) {
-          await Resource.findByIdAndUpdate(form.resource, {
+          const resource = await Resource.findByIdAndUpdate(form.resource, {
             name: args.name,
           });
+          if (!resource){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
         }
       }
 
@@ -252,7 +258,10 @@ export default {
         }
         // Resource inheritance management
         if (form.resource) {
-          const resource = await Resource.findById(form.resource);
+          let resource = await Resource.findById(form.resource);
+          if (!resource){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
           const templates = await Form.find({
             resource: form.resource,
             _id: { $ne: mongoose.Types.ObjectId(args.id) },
@@ -479,9 +488,12 @@ export default {
           }
 
           // Update resource fields
-          await Resource.findByIdAndUpdate(form.resource, {
+          resource = await Resource.findByIdAndUpdate(form.resource, {
             fields: oldFields,
           });
+          if (!resource){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
         }
         update.fields = fields;
         // Update version

--- a/src/schema/mutation/editLayout.mutation.ts
+++ b/src/schema/mutation/editLayout.mutation.ts
@@ -3,6 +3,7 @@ import { Resource, Form } from '@models';
 import { LayoutType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import LayoutInputType from '../../schema/inputs/layout.input';
+import { logger } from '@services/logger.service';
 
 /**
  * Edits an existing layout.
@@ -16,50 +17,57 @@ export default {
     form: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    if (args.form && args.resource) {
+    try{
+      if (args.form && args.resource) {
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.layout.edit.errors.invalidAddPageArguments'
+          )
+        );
+      }
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = user.ability;
+      // Edition of a resource
+      if (args.resource) {
+        const filters = Resource.accessibleBy(ability, 'update')
+          .where({ _id: args.resource })
+          .getFilter();
+        const resource: Resource = await Resource.findOne(filters);
+        if (!resource) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+        resource.layouts.id(args.id).name = args.layout.name;
+        resource.layouts.id(args.id).query = args.layout.query;
+        resource.layouts.id(args.id).display = args.layout.display;
+        await resource.save();
+        return resource.layouts.id(args.id);
+      } else {
+        // Edition of a Form
+        const filters = Form.accessibleBy(ability, 'update')
+          .where({ _id: args.form })
+          .getFilter();
+        const form: Form = await Form.findOne(filters);
+        if (!form) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+        form.layouts.id(args.id).name = args.layout.name;
+        form.layouts.id(args.id).query = args.layout.query;
+        form.layouts.id(args.id).display = args.layout.display;
+        await form.save();
+        return form.layouts.id(args.id);
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t(
-          'mutations.layout.edit.errors.invalidAddPageArguments'
-        )
+        context.i18next.t('common.errors.internalServerError')
       );
-    }
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    // Edition of a resource
-    if (args.resource) {
-      const filters = Resource.accessibleBy(ability, 'update')
-        .where({ _id: args.resource })
-        .getFilter();
-      const resource: Resource = await Resource.findOne(filters);
-      if (!resource) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      resource.layouts.id(args.id).name = args.layout.name;
-      resource.layouts.id(args.id).query = args.layout.query;
-      resource.layouts.id(args.id).display = args.layout.display;
-      await resource.save();
-      return resource.layouts.id(args.id);
-    } else {
-      // Edition of a Form
-      const filters = Form.accessibleBy(ability, 'update')
-        .where({ _id: args.form })
-        .getFilter();
-      const form: Form = await Form.findOne(filters);
-      if (!form) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      form.layouts.id(args.id).name = args.layout.name;
-      form.layouts.id(args.id).query = args.layout.query;
-      form.layouts.id(args.id).display = args.layout.display;
-      await form.save();
-      return form.layouts.id(args.id);
     }
   },
 };

--- a/src/schema/mutation/editLayout.mutation.ts
+++ b/src/schema/mutation/editLayout.mutation.ts
@@ -17,7 +17,7 @@ export default {
     form: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       if (args.form && args.resource) {
         throw new GraphQLError(
           context.i18next.t(
@@ -27,7 +27,9 @@ export default {
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       // Edition of a resource
@@ -63,7 +65,7 @@ export default {
         await form.save();
         return form.layouts.id(args.id);
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editPage.mutation.ts
+++ b/src/schema/mutation/editPage.mutation.ts
@@ -40,11 +40,13 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       // check inputs
       if (!args || (!args.name && !args.permissions))
@@ -119,7 +121,7 @@ export default {
         { new: true }
       );
 
-      if (!page){
+      if (!page) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
 
@@ -139,7 +141,7 @@ export default {
           break;
       }
       return page;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editPage.mutation.ts
+++ b/src/schema/mutation/editPage.mutation.ts
@@ -10,6 +10,7 @@ import { PageType } from '../types';
 import { Page, Workflow, Dashboard, Form } from '@models';
 import { isArray } from 'lodash';
 import extendAbilityForPage from '@security/extendAbilityForPage';
+import { logger } from '@services/logger.service';
 
 /** Simple form permission change type */
 type SimplePermissionChange =
@@ -39,99 +40,106 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    // check inputs
-    if (!args || (!args.name && !args.permissions))
-      throw new GraphQLError(
-        context.i18next.t('mutations.page.edit.errors.invalidArguments')
-      );
-    // get data
-    let page = await Page.findById(args.id);
-    if (!page) {
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
-    // check permission
-    const ability = await extendAbilityForPage(user, page);
-    if (ability.cannot('update', page)) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      // check inputs
+      if (!args || (!args.name && !args.permissions))
+        throw new GraphQLError(
+          context.i18next.t('mutations.page.edit.errors.invalidArguments')
+        );
+      // get data
+      let page = await Page.findById(args.id);
+      if (!page) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+      // check permission
+      const ability = await extendAbilityForPage(user, page);
+      if (ability.cannot('update', page)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
 
-    // update name
-    /* const update: {
-      modifiedAt?: Date;
-      name?: string;
-    } = {
-      modifiedAt: new Date(),
-    }; */
+      // update name
+      /* const update: {
+        modifiedAt?: Date;
+        name?: string;
+      } = {
+        modifiedAt: new Date(),
+      }; */
 
-    const update: {
-      name?: string;
-    } = {};
+      const update: {
+        name?: string;
+      } = {};
 
-    Object.assign(update, args.name && { name: args.name });
+      Object.assign(update, args.name && { name: args.name });
 
-    // Updating permissions
-    const permissionsUpdate: any = {};
-    if (args.permissions) {
-      const permissions: PermissionChange = args.permissions;
-      for (const [key, obj] of Object.entries(permissions)) {
-        if (isArray(obj)) {
-          // if it's an array, replace the old value with the provided list
-          permissionsUpdate['permissions.' + key] = obj;
-        } else {
-          // else it's an object with "add" and "remove" keys
-          if (obj.add && obj.add.length) {
-            const pushRoles = {
-              [`permissions.${key}`]: { $each: obj.add },
-            };
-            if (permissionsUpdate.$push) {
-              Object.assign(permissionsUpdate.$push, pushRoles);
-            } else {
-              Object.assign(permissionsUpdate, { $push: pushRoles });
+      // Updating permissions
+      const permissionsUpdate: any = {};
+      if (args.permissions) {
+        const permissions: PermissionChange = args.permissions;
+        for (const [key, obj] of Object.entries(permissions)) {
+          if (isArray(obj)) {
+            // if it's an array, replace the old value with the provided list
+            permissionsUpdate['permissions.' + key] = obj;
+          } else {
+            // else it's an object with "add" and "remove" keys
+            if (obj.add && obj.add.length) {
+              const pushRoles = {
+                [`permissions.${key}`]: { $each: obj.add },
+              };
+              if (permissionsUpdate.$push) {
+                Object.assign(permissionsUpdate.$push, pushRoles);
+              } else {
+                Object.assign(permissionsUpdate, { $push: pushRoles });
+              }
             }
-          }
-          if (obj.remove && obj.remove.length) {
-            const pullRoles = {
-              [`permissions.${key}`]: { $in: obj.remove },
-            };
-            if (permissionsUpdate.$pull) {
-              Object.assign(permissionsUpdate.$pull, pullRoles);
-            } else {
-              Object.assign(permissionsUpdate, { $pull: pullRoles });
+            if (obj.remove && obj.remove.length) {
+              const pullRoles = {
+                [`permissions.${key}`]: { $in: obj.remove },
+              };
+              if (permissionsUpdate.$pull) {
+                Object.assign(permissionsUpdate.$pull, pullRoles);
+              } else {
+                Object.assign(permissionsUpdate, { $pull: pullRoles });
+              }
             }
           }
         }
       }
-    }
 
-    // apply the update
-    page = await Page.findByIdAndUpdate(
-      page._id,
-      { ...update, ...permissionsUpdate },
-      { new: true }
-    );
+      // apply the update
+      page = await Page.findByIdAndUpdate(
+        page._id,
+        { ...update, ...permissionsUpdate },
+        { new: true }
+      );
 
-    // update the content
-    switch (page.type) {
-      case contentType.workflow:
-        await Workflow.findByIdAndUpdate(page.content, update);
-        break;
-      case contentType.dashboard:
-        await Dashboard.findByIdAndUpdate(page.content, update);
-        break;
-      case contentType.form:
-        if (update.name) delete update.name;
-        await Form.findByIdAndUpdate(page.content, update);
-        break;
-      default:
-        break;
+      // update the content
+      switch (page.type) {
+        case contentType.workflow:
+          await Workflow.findByIdAndUpdate(page.content, update);
+          break;
+        case contentType.dashboard:
+          await Dashboard.findByIdAndUpdate(page.content, update);
+          break;
+        case contentType.form:
+          if (update.name) delete update.name;
+          await Form.findByIdAndUpdate(page.content, update);
+          break;
+        default:
+          break;
+      }
+      return page;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    return page;
   },
 };

--- a/src/schema/mutation/editPage.mutation.ts
+++ b/src/schema/mutation/editPage.mutation.ts
@@ -119,6 +119,10 @@ export default {
         { new: true }
       );
 
+      if (!page){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+
       // update the content
       switch (page.type) {
         case contentType.workflow:

--- a/src/schema/mutation/editPageContext.mutation.ts
+++ b/src/schema/mutation/editPageContext.mutation.ts
@@ -17,11 +17,13 @@ export default {
     context: { type: PageContextInputType },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // only one of refData or resource can be set
@@ -31,7 +33,9 @@ export default {
 
       if (!args || !validSource)
         throw new GraphQLError(
-          context.i18next.t('mutations.page.edit.context.errors.invalidArguments')
+          context.i18next.t(
+            'mutations.page.edit.context.errors.invalidArguments'
+          )
         );
 
       // get data
@@ -71,7 +75,7 @@ export default {
       page.context = args.context;
       await page.save();
       return page;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editPageContext.mutation.ts
+++ b/src/schema/mutation/editPageContext.mutation.ts
@@ -4,6 +4,7 @@ import { Dashboard, Page, Resource, Workflow } from '@models';
 import extendAbilityForPage from '@security/extendAbilityForPage';
 import { PageContextInputType } from '@schema/inputs';
 import { Types } from 'mongoose';
+import { logger } from '@services/logger.service';
 
 /**
  *  Finds a page from its id and update it's context, if user is authorized.
@@ -16,58 +17,65 @@ export default {
     context: { type: PageContextInputType },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    // only one of refData or resource can be set
-    const validSource =
-      (!!args?.context?.refData && !args?.context?.resource) ||
-      (!args?.context?.refData && !!args?.context?.resource);
+      // only one of refData or resource can be set
+      const validSource =
+        (!!args?.context?.refData && !args?.context?.resource) ||
+        (!args?.context?.refData && !!args?.context?.resource);
 
-    if (!args || !validSource)
+      if (!args || !validSource)
+        throw new GraphQLError(
+          context.i18next.t('mutations.page.edit.context.errors.invalidArguments')
+        );
+
+      // get data
+      const page = await Page.findById(args.id);
+      if (!page) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+
+      // check permission
+      const ability = await extendAbilityForPage(user, page);
+      if (ability.cannot('update', page)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      const resourceChanged =
+        'resource' in page.context &&
+        ((page.context.resource instanceof Types.ObjectId &&
+          !page.context.resource.equals(args.context.resource)) ||
+          (page.context.resource instanceof Resource &&
+            !page.context.resource._id.equals(args.context.resource)));
+
+      const refDataChanged =
+        'refData' in page.context &&
+        page.context.refData !== args.context.refData;
+
+      // If datasource origin changes, remove all previous contentWithContext
+      if (resourceChanged || refDataChanged) {
+        const idsToDelete = page.contentWithContext.map((c) => c.content);
+        await Dashboard.deleteMany({ _id: { $in: idsToDelete } });
+        await Workflow.deleteMany({ _id: { $in: idsToDelete } });
+        page.contentWithContext = [];
+      }
+
+      // Update page context and return
+      page.context = args.context;
+      await page.save();
+      return page;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('mutations.page.edit.context.errors.invalidArguments')
-      );
-
-    // get data
-    const page = await Page.findById(args.id);
-    if (!page) {
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
-
-    // check permission
-    const ability = await extendAbilityForPage(user, page);
-    if (ability.cannot('update', page)) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-
-    const resourceChanged =
-      'resource' in page.context &&
-      ((page.context.resource instanceof Types.ObjectId &&
-        !page.context.resource.equals(args.context.resource)) ||
-        (page.context.resource instanceof Resource &&
-          !page.context.resource._id.equals(args.context.resource)));
-
-    const refDataChanged =
-      'refData' in page.context &&
-      page.context.refData !== args.context.refData;
-
-    // If datasource origin changes, remove all previous contentWithContext
-    if (resourceChanged || refDataChanged) {
-      const idsToDelete = page.contentWithContext.map((c) => c.content);
-      await Dashboard.deleteMany({ _id: { $in: idsToDelete } });
-      await Workflow.deleteMany({ _id: { $in: idsToDelete } });
-      page.contentWithContext = [];
-    }
-
-    // Update page context and return
-    page.context = args.context;
-    await page.save();
-    return page;
   },
 };

--- a/src/schema/mutation/editPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/editPositionAttributeCategory.mutation.ts
@@ -21,11 +21,13 @@ export default {
     title: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = context.user.ability;
       const application = await Application.findById(args.application);
@@ -39,16 +41,18 @@ export default {
           },
           { new: true }
         );
-        if (!position){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!position) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
-        return position;
+        return await position;
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/editPositionAttributeCategory.mutation.ts
@@ -32,13 +32,17 @@ export default {
       if (!application)
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       if (ability.can('update', application)) {
-        return PositionAttributeCategory.findByIdAndUpdate(
+        const position = PositionAttributeCategory.findByIdAndUpdate(
           args.id,
           {
             title: args.title,
           },
           { new: true }
         );
+        if (!position){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return position;
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')

--- a/src/schema/mutation/editPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/editPositionAttributeCategory.mutation.ts
@@ -7,6 +7,7 @@ import {
 import { Application, PositionAttributeCategory } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { PositionAttributeCategoryType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Edit a position attribute category.
@@ -20,26 +21,33 @@ export default {
     title: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = context.user.ability;
-    const application = await Application.findById(args.application);
-    if (!application)
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    if (ability.can('update', application)) {
-      return PositionAttributeCategory.findByIdAndUpdate(
-        args.id,
-        {
-          title: args.title,
-        },
-        { new: true }
-      );
-    } else {
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = context.user.ability;
+      const application = await Application.findById(args.application);
+      if (!application)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      if (ability.can('update', application)) {
+        return PositionAttributeCategory.findByIdAndUpdate(
+          args.id,
+          {
+            title: args.title,
+          },
+          { new: true }
+        );
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/mutation/editPullJob.mutation.ts
+++ b/src/schema/mutation/editPullJob.mutation.ts
@@ -33,63 +33,70 @@ export default {
     channel: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-
-    if (args.convertTo) {
-      const form = await Form.findById(args.convertTo);
-      if (!form)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
-
-    if (args.channel) {
-      const filters = {
-        _id: args.channel,
-      };
-      const channel = await Channel.findOne(filters);
-      if (!channel)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
-
-    const update = {};
-    Object.assign(
-      update,
-      args.name && { name: args.name },
-      args.status && { status: args.status },
-      args.apiConfiguration && { apiConfiguration: args.apiConfiguration },
-      args.url && { url: args.url },
-      args.path && { path: args.path },
-      args.schedule && { schedule: args.schedule },
-      args.convertTo && { convertTo: args.convertTo },
-      args.mapping && { mapping: args.mapping },
-      args.uniqueIdentifiers && { uniqueIdentifiers: args.uniqueIdentifiers },
-      args.channel && { channel: args.channel }
-    );
-    const filters = PullJob.accessibleBy(ability, 'update')
-      .where({ _id: args.id })
-      .getFilter();
-    try {
-      const pullJob = await PullJob.findOneAndUpdate(filters, update, {
-        new: true,
-        runValidators: true,
-      }).populate({
-        path: 'apiConfiguration',
-        model: 'ApiConfiguration',
-      });
-      if (!pullJob)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-      if (pullJob.status === status.active) {
-        scheduleJob(pullJob);
-      } else {
-        unscheduleJob(pullJob);
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-      return pullJob;
-    } catch (err) {
-      logger.error(err.message);
-      throw new GraphQLError(err.message);
+      const ability: AppAbility = user.ability;
+  
+      if (args.convertTo) {
+        const form = await Form.findById(args.convertTo);
+        if (!form)
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+  
+      if (args.channel) {
+        const filters = {
+          _id: args.channel,
+        };
+        const channel = await Channel.findOne(filters);
+        if (!channel)
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+  
+      const update = {};
+      Object.assign(
+        update,
+        args.name && { name: args.name },
+        args.status && { status: args.status },
+        args.apiConfiguration && { apiConfiguration: args.apiConfiguration },
+        args.url && { url: args.url },
+        args.path && { path: args.path },
+        args.schedule && { schedule: args.schedule },
+        args.convertTo && { convertTo: args.convertTo },
+        args.mapping && { mapping: args.mapping },
+        args.uniqueIdentifiers && { uniqueIdentifiers: args.uniqueIdentifiers },
+        args.channel && { channel: args.channel }
+      );
+      const filters = PullJob.accessibleBy(ability, 'update')
+        .where({ _id: args.id })
+        .getFilter();
+      try {
+        const pullJob = await PullJob.findOneAndUpdate(filters, update, {
+          new: true,
+          runValidators: true,
+        }).populate({
+          path: 'apiConfiguration',
+          model: 'ApiConfiguration',
+        });
+        if (!pullJob)
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (pullJob.status === status.active) {
+          scheduleJob(pullJob);
+        } else {
+          unscheduleJob(pullJob);
+        }
+        return pullJob;
+      } catch (err) {
+        logger.error(err.message);
+        throw new GraphQLError(err.message);
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
   },
 };

--- a/src/schema/mutation/editPullJob.mutation.ts
+++ b/src/schema/mutation/editPullJob.mutation.ts
@@ -33,28 +33,34 @@ export default {
     channel: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
-  
+
       if (args.convertTo) {
         const form = await Form.findById(args.convertTo);
         if (!form)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
       }
-  
+
       if (args.channel) {
         const filters = {
           _id: args.channel,
         };
         const channel = await Channel.findOne(filters);
         if (!channel)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
       }
-  
+
       const update = {};
       Object.assign(
         update,
@@ -81,7 +87,9 @@ export default {
           model: 'ApiConfiguration',
         });
         if (!pullJob)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         if (pullJob.status === status.active) {
           scheduleJob(pullJob);
         } else {
@@ -92,7 +100,7 @@ export default {
         logger.error(err.message);
         throw new GraphQLError(err.message);
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -56,19 +56,21 @@ export default {
     lang: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       if (!args.data && !args.version) {
         throw new GraphQLError(
           context.i18next.t('mutations.record.edit.errors.invalidArguments')
         );
       }
-  
+
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
-  
+
       // Get record and form
       const oldRecord: Record = await Record.findById(args.id);
       const parentForm: Form = await Form.findById(
@@ -78,7 +80,7 @@ export default {
       if (!oldRecord || !parentForm) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
-  
+
       // Check permissions with two layers
       const ability = await extendAbilityForRecords(user, parentForm);
       if (
@@ -89,7 +91,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-  
+
       // Update record
       // Put a try catch for record validation + check the structure of this form
       let validationErrors;
@@ -144,11 +146,13 @@ export default {
           ownership && { createdBy: { ...oldRecord.createdBy, ...ownership } }
         );
         const record = Record.findByIdAndUpdate(args.id, update, { new: true });
-        if (!record){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!record) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         await version.save();
-        return record;
+        return await record;
       } else {
         const oldVersion = await Version.findOne({
           $and: [
@@ -160,7 +164,7 @@ export default {
             { _id: args.version },
           ],
         });
-        if(!oldVersion){
+        if (!oldVersion) {
           throw new GraphQLError(
             context.i18next.t('common.errors.dataNotFound')
           );
@@ -171,13 +175,15 @@ export default {
           $push: { versions: version._id },
         };
         const record = Record.findByIdAndUpdate(args.id, update, { new: true });
-        if (!record){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!record) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         await version.save();
-        return record;
+        return await record;
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -56,114 +56,126 @@ export default {
     lang: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    if (!args.data && !args.version) {
-      throw new GraphQLError(
-        context.i18next.t('mutations.record.edit.errors.invalidArguments')
+    try{
+      if (!args.data && !args.version) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.record.edit.errors.invalidArguments')
+        );
+      }
+  
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+  
+      // Get record and form
+      const oldRecord: Record = await Record.findById(args.id);
+      const parentForm: Form = await Form.findById(
+        oldRecord.form,
+        'fields permissions resource structure'
       );
-    }
-
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    // Get record and form
-    const oldRecord: Record = await Record.findById(args.id);
-    const parentForm: Form = await Form.findById(
-      oldRecord.form,
-      'fields permissions resource structure'
-    );
-    if (!oldRecord || !parentForm) {
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
-
-    // Check permissions with two layers
-    const ability = await extendAbilityForRecords(user, parentForm);
-    if (
-      ability.cannot('update', oldRecord) ||
-      hasInaccessibleFields(oldRecord, args.data, ability)
-    ) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-
-    // Update record
-    // Put a try catch for record validation + check the structure of this form
-    let validationErrors;
-    try {
-      validationErrors = checkRecordValidation(
-        oldRecord,
-        args.data,
-        parentForm,
-        context,
-        args.lang
-      );
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
-    }
-    if (validationErrors && validationErrors.length) {
-      return Object.assign(oldRecord, { validationErrors });
-    }
-    const version = new Version({
-      createdAt: oldRecord.modifiedAt
-        ? oldRecord.modifiedAt
-        : oldRecord.createdAt,
-      data: oldRecord.data,
-      createdBy: user._id,
-    });
-    if (!args.version) {
-      let template: Form | Resource;
-      if (args.template && parentForm.resource) {
-        template = await Form.findById(args.template, 'fields resource');
-        if (!template.resource.equals(parentForm.resource)) {
+      if (!oldRecord || !parentForm) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+  
+      // Check permissions with two layers
+      const ability = await extendAbilityForRecords(user, parentForm);
+      if (
+        ability.cannot('update', oldRecord) ||
+        hasInaccessibleFields(oldRecord, args.data, ability)
+      ) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+  
+      // Update record
+      // Put a try catch for record validation + check the structure of this form
+      let validationErrors;
+      try {
+        validationErrors = checkRecordValidation(
+          oldRecord,
+          args.data,
+          parentForm,
+          context,
+          args.lang
+        );
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+      }
+      if (validationErrors && validationErrors.length) {
+        return Object.assign(oldRecord, { validationErrors });
+      }
+      const version = new Version({
+        createdAt: oldRecord.modifiedAt
+          ? oldRecord.modifiedAt
+          : oldRecord.createdAt,
+        data: oldRecord.data,
+        createdBy: user._id,
+      });
+      if (!args.version) {
+        let template: Form | Resource;
+        if (args.template && parentForm.resource) {
+          template = await Form.findById(args.template, 'fields resource');
+          if (!template.resource.equals(parentForm.resource)) {
+            throw new GraphQLError(
+              context.i18next.t(
+                'mutations.record.edit.errors.wrongTemplateProvided'
+              )
+            );
+          }
+        } else {
+          if (parentForm.resource) {
+            template = await Resource.findById(parentForm.resource, 'fields');
+          } else {
+            template = parentForm;
+          }
+        }
+        transformRecord(args.data, template.fields);
+        const update: any = {
+          data: { ...oldRecord.data, ...args.data },
+          //modifiedAt: new Date(),
+          $push: { versions: version._id },
+        };
+        const ownership = getOwnership(template.fields, args.data); // Update with template during merge
+        Object.assign(
+          update,
+          ownership && { createdBy: { ...oldRecord.createdBy, ...ownership } }
+        );
+        const record = Record.findByIdAndUpdate(args.id, update, { new: true });
+        await version.save();
+        return record;
+      } else {
+        const oldVersion = await Version.findOne({
+          $and: [
+            {
+              _id: {
+                $in: oldRecord.versions.map((x) => mongoose.Types.ObjectId(x)),
+              },
+            },
+            { _id: args.version },
+          ],
+        });
+        if(!oldVersion){
           throw new GraphQLError(
-            context.i18next.t(
-              'mutations.record.edit.errors.wrongTemplateProvided'
-            )
+            context.i18next.t('common.errors.dataNotFound')
           );
         }
-      } else {
-        if (parentForm.resource) {
-          template = await Resource.findById(parentForm.resource, 'fields');
-        } else {
-          template = parentForm;
-        }
+        const update: any = {
+          data: oldVersion.data,
+          //modifiedAt: new Date(),
+          $push: { versions: version._id },
+        };
+        const record = Record.findByIdAndUpdate(args.id, update, { new: true });
+        await version.save();
+        return record;
       }
-      transformRecord(args.data, template.fields);
-      const update: any = {
-        data: { ...oldRecord.data, ...args.data },
-        //modifiedAt: new Date(),
-        $push: { versions: version._id },
-      };
-      const ownership = getOwnership(template.fields, args.data); // Update with template during merge
-      Object.assign(
-        update,
-        ownership && { createdBy: { ...oldRecord.createdBy, ...ownership } }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
       );
-      const record = Record.findByIdAndUpdate(args.id, update, { new: true });
-      await version.save();
-      return record;
-    } else {
-      const oldVersion = await Version.findOne({
-        $and: [
-          {
-            _id: {
-              $in: oldRecord.versions.map((x) => mongoose.Types.ObjectId(x)),
-            },
-          },
-          { _id: args.version },
-        ],
-      });
-      const update: any = {
-        data: oldVersion.data,
-        //modifiedAt: new Date(),
-        $push: { versions: version._id },
-      };
-      const record = Record.findByIdAndUpdate(args.id, update, { new: true });
-      await version.save();
-      return record;
     }
   },
 };

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -144,6 +144,9 @@ export default {
           ownership && { createdBy: { ...oldRecord.createdBy, ...ownership } }
         );
         const record = Record.findByIdAndUpdate(args.id, update, { new: true });
+        if (!record){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
         await version.save();
         return record;
       } else {
@@ -168,6 +171,9 @@ export default {
           $push: { versions: version._id },
         };
         const record = Record.findByIdAndUpdate(args.id, update, { new: true });
+        if (!record){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
         await version.save();
         return record;
       }

--- a/src/schema/mutation/editRecords.mutation.ts
+++ b/src/schema/mutation/editRecords.mutation.ts
@@ -38,7 +38,7 @@ export default {
     lang: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       if (!args.data) {
         throw new GraphQLError(
           context.i18next.t('mutations.record.edit.errors.invalidArguments')
@@ -47,9 +47,11 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
-  
+
       // Get records and forms
       const records: RecordWithError[] = [];
       const oldRecords: Record[] = await Record.find({
@@ -94,7 +96,9 @@ export default {
             }
             transformRecord(data, fields);
             const version = new Version({
-              createdAt: record.modifiedAt ? record.modifiedAt : record.createdAt,
+              createdAt: record.modifiedAt
+                ? record.modifiedAt
+                : record.createdAt,
               data: record.data,
               createdBy: user._id,
             });
@@ -108,11 +112,17 @@ export default {
               update,
               ownership && { createdBy: { ...record.createdBy, ...ownership } }
             );
-            const newRecord = await Record.findByIdAndUpdate(record.id, update, {
-              new: true,
-            });
-            if (!newRecord){
-              throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+            const newRecord = await Record.findByIdAndUpdate(
+              record.id,
+              update,
+              {
+                new: true,
+              }
+            );
+            if (!newRecord) {
+              throw new GraphQLError(
+                context.i18next.t('common.errors.dataNotFound')
+              );
             }
             await version.save();
             records.push(newRecord);
@@ -120,7 +130,7 @@ export default {
         }
       }
       return records;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editRecords.mutation.ts
+++ b/src/schema/mutation/editRecords.mutation.ts
@@ -111,6 +111,9 @@ export default {
             const newRecord = await Record.findByIdAndUpdate(record.id, update, {
               new: true,
             });
+            if (!newRecord){
+              throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+            }
             await version.save();
             records.push(newRecord);
           }

--- a/src/schema/mutation/editRecords.mutation.ts
+++ b/src/schema/mutation/editRecords.mutation.ts
@@ -15,6 +15,7 @@ import {
 } from '@utils/form';
 import { RecordType } from '../types';
 import { hasInaccessibleFields } from './editRecord.mutation';
+import { logger } from '@services/logger.service';
 
 /** Interface for records with an error */
 interface RecordWithError extends Record {
@@ -37,83 +38,90 @@ export default {
     lang: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    if (!args.data) {
-      throw new GraphQLError(
-        context.i18next.t('mutations.record.edit.errors.invalidArguments')
-      );
-    }
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    // Get records and forms
-    const records: RecordWithError[] = [];
-    const oldRecords: Record[] = await Record.find({
-      _id: { $in: args.ids },
-    }).populate({
-      path: 'form',
-      model: 'Form',
-    });
-    for (const record of oldRecords) {
-      const ability = await extendAbilityForRecords(user, record.form);
-      if (
-        ability.can('update', record) &&
-        !hasInaccessibleFields(record, args.data, ability)
-      ) {
-        const validationErrors = checkRecordValidation(
-          record,
-          args.data,
-          record.form,
-          context,
-          args.lang
+    try{
+      if (!args.data) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.record.edit.errors.invalidArguments')
         );
-        if (validationErrors.length) {
-          records.push(
-            Object.assign(record, { validationErrors: validationErrors })
+      }
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+  
+      // Get records and forms
+      const records: RecordWithError[] = [];
+      const oldRecords: Record[] = await Record.find({
+        _id: { $in: args.ids },
+      }).populate({
+        path: 'form',
+        model: 'Form',
+      });
+      for (const record of oldRecords) {
+        const ability = await extendAbilityForRecords(user, record.form);
+        if (
+          ability.can('update', record) &&
+          !hasInaccessibleFields(record, args.data, ability)
+        ) {
+          const validationErrors = checkRecordValidation(
+            record,
+            args.data,
+            record.form,
+            context,
+            args.lang
           );
-        } else {
-          const data = { ...args.data };
-          let fields = record.form.fields;
-          if (args.template && record.form.resource) {
-            const template = await Form.findById(
-              args.template,
-              'fields resource'
+          if (validationErrors.length) {
+            records.push(
+              Object.assign(record, { validationErrors: validationErrors })
             );
-            if (!template.resource.equals(record.form.resource)) {
-              throw new GraphQLError(
-                context.i18next.t(
-                  'mutations.record.edit.errors.wrongTemplateProvided'
-                )
+          } else {
+            const data = { ...args.data };
+            let fields = record.form.fields;
+            if (args.template && record.form.resource) {
+              const template = await Form.findById(
+                args.template,
+                'fields resource'
               );
+              if (!template.resource.equals(record.form.resource)) {
+                throw new GraphQLError(
+                  context.i18next.t(
+                    'mutations.record.edit.errors.wrongTemplateProvided'
+                  )
+                );
+              }
+              fields = template.fields;
             }
-            fields = template.fields;
+            transformRecord(data, fields);
+            const version = new Version({
+              createdAt: record.modifiedAt ? record.modifiedAt : record.createdAt,
+              data: record.data,
+              createdBy: user._id,
+            });
+            const update: any = {
+              data: { ...record.data, ...data },
+              //modifiedAt: new Date(),
+              $push: { versions: version._id },
+            };
+            const ownership = getOwnership(record.form.fields, args.data); // Update with template during merge
+            Object.assign(
+              update,
+              ownership && { createdBy: { ...record.createdBy, ...ownership } }
+            );
+            const newRecord = await Record.findByIdAndUpdate(record.id, update, {
+              new: true,
+            });
+            await version.save();
+            records.push(newRecord);
           }
-          transformRecord(data, fields);
-          const version = new Version({
-            createdAt: record.modifiedAt ? record.modifiedAt : record.createdAt,
-            data: record.data,
-            createdBy: user._id,
-          });
-          const update: any = {
-            data: { ...record.data, ...data },
-            //modifiedAt: new Date(),
-            $push: { versions: version._id },
-          };
-          const ownership = getOwnership(record.form.fields, args.data); // Update with template during merge
-          Object.assign(
-            update,
-            ownership && { createdBy: { ...record.createdBy, ...ownership } }
-          );
-          const newRecord = await Record.findByIdAndUpdate(record.id, update, {
-            new: true,
-          });
-          await version.save();
-          records.push(newRecord);
         }
       }
+      return records;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    return records;
   },
 };

--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -36,10 +36,12 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = user.ability;
       // Build update
@@ -58,7 +60,9 @@ export default {
           (await ReferenceData.hasDuplicate(graphQLTypeName, args.id))
         ) {
           throw new GraphQLError(
-            context.i18next.t('mutations.reference.edit.errors.formResDuplicated')
+            context.i18next.t(
+              'mutations.reference.edit.errors.formResDuplicated'
+            )
           );
         }
         update.graphQLTypeName = ReferenceData.getGraphQLTypeName(args.name);
@@ -66,7 +70,9 @@ export default {
       if (update.fields) {
         // Generate graphql field names
         for (const field of update.fields) {
-          field.graphQLFieldName = ReferenceData.getGraphQLFieldName(field.name);
+          field.graphQLFieldName = ReferenceData.getGraphQLFieldName(
+            field.name
+          );
         }
         // Check fields
         for (const field of update.fields) {
@@ -95,7 +101,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -11,6 +11,7 @@ import { Resource } from '@models';
 import { buildTypes } from '@utils/schema';
 import { AppAbility } from '@security/defineUserAbility';
 import { get, has, isArray, isEqual } from 'lodash';
+import { logger } from '@services/logger.service';
 
 /** Simple resource permission change type */
 type SimplePermissionChange =
@@ -546,229 +547,236 @@ export default {
     calculatedField: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    if (
-      !args ||
-      (!args.fields &&
-        !args.permissions &&
-        !args.calculatedField &&
-        !args.fieldsPermissions)
-    ) {
-      throw new GraphQLError(
-        context.i18next.t('mutations.resource.edit.errors.invalidArguments')
-      );
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      if (
+        !args ||
+        (!args.fields &&
+          !args.permissions &&
+          !args.calculatedField &&
+          !args.fieldsPermissions)
+      ) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.resource.edit.errors.invalidArguments')
+        );
+      }
 
-    // check ability
-    const ability: AppAbility = user.ability;
-    const resource = await Resource.findById(args.id);
-    if (ability.cannot('update', resource)) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
+      // check ability
+      const ability: AppAbility = user.ability;
+      const resource = await Resource.findById(args.id);
+      if (ability.cannot('update', resource)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
 
-    // Create the update object
-    const update: any = {
-      modifiedAt: new Date(),
-    };
-    // Tell if it is required to build types
-    let updateGraphQL = (args.fields && true) || false;
-    Object.assign(update, args.fields && { fields: args.fields });
+      // Create the update object
+      const update: any = {
+        modifiedAt: new Date(),
+      };
+      // Tell if it is required to build types
+      let updateGraphQL = (args.fields && true) || false;
+      Object.assign(update, args.fields && { fields: args.fields });
 
-    const allResourceFields = resource.fields;
+      const allResourceFields = resource.fields;
 
-    // Update permissions
-    if (args.permissions) {
-      const permissions: PermissionChange = args.permissions;
-      for (const permission in permissions) {
-        if (isArray(permissions[permission])) {
-          // if it's an array, replace the old value with the provided list
-          update['permissions.' + permission] = permissions[permission];
-        } else {
+      // Update permissions
+      if (args.permissions) {
+        const permissions: PermissionChange = args.permissions;
+        for (const permission in permissions) {
+          if (isArray(permissions[permission])) {
+            // if it's an array, replace the old value with the provided list
+            update['permissions.' + permission] = permissions[permission];
+          } else {
+            const obj = permissions[permission];
+            // Add new permissions on resource
+            if (obj.add && obj.add.length) {
+              // Add permission
+              addResourcePermission(update, obj.add, permission);
+              /**
+               * 'Common sense' rules, that apply if no existing permission for the role is set on this resource
+               */
+              obj.add.forEach((x) => {
+                if (x.role) {
+                  // Ensure that the permissions make 'common sense'
+                  checkPermission(
+                    context,
+                    get(resource, 'permissions'),
+                    x,
+                    permission,
+                    permissions
+                  );
+                  // Apply common sense rules on fields
+                  automateFieldsPermission(
+                    update,
+                    get(resource, 'permissions'),
+                    allResourceFields,
+                    x,
+                    permission
+                  );
+                }
+              });
+            }
+            // Remove permissions on resource
+            if (obj.remove && obj.remove.length) {
+              // Remove permission
+              removeResourcePermission(update, obj.remove, permission);
+              // Remove permission for all fields, if role does not have any other access
+              obj.remove.forEach((x) => {
+                if (x.role) {
+                  // Apply common sense rules on fields
+                  clearFieldsPermission(
+                    update,
+                    get(resource, 'permissions'),
+                    allResourceFields,
+                    x,
+                    permission
+                  );
+                }
+              });
+            }
+          }
+        }
+      }
+
+      // Updating field permissions
+      if (args.fieldsPermissions) {
+        const permissions: FieldPermissionChange = args.fieldsPermissions;
+        for (const permission in permissions) {
           const obj = permissions[permission];
-          // Add new permissions on resource
-          if (obj.add && obj.add.length) {
-            // Add permission
-            addResourcePermission(update, obj.add, permission);
-            /**
-             * 'Common sense' rules, that apply if no existing permission for the role is set on this resource
-             */
-            obj.add.forEach((x) => {
-              if (x.role) {
-                // Ensure that the permissions make 'common sense'
-                checkPermission(
-                  context,
-                  get(resource, 'permissions'),
-                  x,
-                  permission,
-                  permissions
-                );
-                // Apply common sense rules on fields
-                automateFieldsPermission(
-                  update,
-                  get(resource, 'permissions'),
-                  allResourceFields,
-                  x,
-                  permission
-                );
-              }
-            });
+          // Add permission on target field
+          if (obj.add) {
+            checkFieldPermission(
+              context,
+              get(resource, 'permissions'),
+              allResourceFields,
+              obj.add.field,
+              obj.add.role,
+              permission
+            );
+            addFieldPermission(
+              update,
+              allResourceFields,
+              obj.add.field,
+              obj.add.role,
+              permission
+            );
           }
-          // Remove permissions on resource
-          if (obj.remove && obj.remove.length) {
-            // Remove permission
-            removeResourcePermission(update, obj.remove, permission);
-            // Remove permission for all fields, if role does not have any other access
-            obj.remove.forEach((x) => {
-              if (x.role) {
-                // Apply common sense rules on fields
-                clearFieldsPermission(
-                  update,
-                  get(resource, 'permissions'),
-                  allResourceFields,
-                  x,
-                  permission
-                );
-              }
-            });
+          // Remove permission on target field
+          if (obj.remove) {
+            removeFieldPermission(
+              update,
+              allResourceFields,
+              obj.remove.field,
+              obj.remove.role,
+              permission
+            );
           }
         }
       }
-    }
 
-    // Updating field permissions
-    if (args.fieldsPermissions) {
-      const permissions: FieldPermissionChange = args.fieldsPermissions;
-      for (const permission in permissions) {
-        const obj = permissions[permission];
-        // Add permission on target field
-        if (obj.add) {
-          checkFieldPermission(
-            context,
-            get(resource, 'permissions'),
-            allResourceFields,
-            obj.add.field,
-            obj.add.role,
-            permission
+      // Update calculated fields
+      if (args.calculatedField) {
+        const calculatedField: CalculatedFieldChange = args.calculatedField;
+        // Add new calculated field
+        if (calculatedField.add) {
+          const expression = getExpressionFromString(
+            calculatedField.add.expression
           );
-          addFieldPermission(
-            update,
-            allResourceFields,
-            obj.add.field,
-            obj.add.role,
-            permission
-          );
-        }
-        // Remove permission on target field
-        if (obj.remove) {
-          removeFieldPermission(
-            update,
-            allResourceFields,
-            obj.remove.field,
-            obj.remove.role,
-            permission
-          );
-        }
-      }
-    }
+          const pushCalculatedField = {
+            fields: {
+              isCalculated: true,
+              name: calculatedField.add.name,
+              expression: calculatedField.add.expression,
+              type: OperationTypeMap[expression.operation] ?? 'text',
+            },
+          };
 
-    // Update calculated fields
-    if (args.calculatedField) {
-      const calculatedField: CalculatedFieldChange = args.calculatedField;
-      // Add new calculated field
-      if (calculatedField.add) {
-        const expression = getExpressionFromString(
-          calculatedField.add.expression
-        );
-        const pushCalculatedField = {
-          fields: {
-            isCalculated: true,
-            name: calculatedField.add.name,
-            expression: calculatedField.add.expression,
-            type: OperationTypeMap[expression.operation] ?? 'text',
-          },
-        };
-
-        findDuplicateFields([
-          ...allResourceFields,
-          { name: calculatedField.add.name },
-        ]);
-
-        if (update.$addToSet)
-          Object.assign(update.$addToSet, pushCalculatedField);
-        else Object.assign(update, { $addToSet: pushCalculatedField });
-      }
-      // Remove existing field
-      if (calculatedField.remove) {
-        const pullCalculatedField = {
-          fields: {
-            name: calculatedField.remove.name,
-          },
-        };
-
-        if (update.$pull) Object.assign(update.$pull, pullCalculatedField);
-        else Object.assign(update, { $pull: pullCalculatedField });
-      }
-      // Update existing field
-      if (calculatedField.update) {
-        //First remove the old field
-        const pullCalculatedField = {
-          fields: {
-            name: calculatedField.update.oldName,
-          },
-        };
-        if (update.$pull) Object.assign(update.$pull, pullCalculatedField);
-        else Object.assign(update, { $pull: pullCalculatedField });
-        const expression = getExpressionFromString(
-          calculatedField.update.expression
-        );
-
-        const oldField = allResourceFields.find(
-          (field) => field.name === calculatedField.update.oldName
-        );
-
-        //Then add the updated one
-        const pushCalculatedField = {
-          fields: {
-            isCalculated: true,
-            name: calculatedField.update.name,
-            expression: calculatedField.update.expression,
-            type: OperationTypeMap[expression.operation] ?? 'text',
-            permissions: oldField.permissions,
-          },
-        };
-
-        if (calculatedField.update.oldName !== calculatedField.update.name)
           findDuplicateFields([
             ...allResourceFields,
-            { name: calculatedField.update.name },
+            { name: calculatedField.add.name },
           ]);
 
-        if (update.$addToSet)
-          Object.assign(update.$addToSet, pushCalculatedField);
-        else Object.assign(update, { $addToSet: pushCalculatedField });
-      }
-      updateGraphQL = true;
-    }
+          if (update.$addToSet)
+            Object.assign(update.$addToSet, pushCalculatedField);
+          else Object.assign(update, { $addToSet: pushCalculatedField });
+        }
+        // Remove existing field
+        if (calculatedField.remove) {
+          const pullCalculatedField = {
+            fields: {
+              name: calculatedField.remove.name,
+            },
+          };
 
-    // Split the request in two parts, to avoid conflict
-    if (!!update.$pull) {
-      await Resource.findByIdAndUpdate(
+          if (update.$pull) Object.assign(update.$pull, pullCalculatedField);
+          else Object.assign(update, { $pull: pullCalculatedField });
+        }
+        // Update existing field
+        if (calculatedField.update) {
+          //First remove the old field
+          const pullCalculatedField = {
+            fields: {
+              name: calculatedField.update.oldName,
+            },
+          };
+          if (update.$pull) Object.assign(update.$pull, pullCalculatedField);
+          else Object.assign(update, { $pull: pullCalculatedField });
+          const expression = getExpressionFromString(
+            calculatedField.update.expression
+          );
+
+          const oldField = allResourceFields.find(
+            (field) => field.name === calculatedField.update.oldName
+          );
+
+          //Then add the updated one
+          const pushCalculatedField = {
+            fields: {
+              isCalculated: true,
+              name: calculatedField.update.name,
+              expression: calculatedField.update.expression,
+              type: OperationTypeMap[expression.operation] ?? 'text',
+              permissions: oldField.permissions,
+            },
+          };
+
+          if (calculatedField.update.oldName !== calculatedField.update.name)
+            findDuplicateFields([
+              ...allResourceFields,
+              { name: calculatedField.update.name },
+            ]);
+
+          if (update.$addToSet)
+            Object.assign(update.$addToSet, pushCalculatedField);
+          else Object.assign(update, { $addToSet: pushCalculatedField });
+        }
+        updateGraphQL = true;
+      }
+
+      // Split the request in two parts, to avoid conflict
+      if (!!update.$pull) {
+        await Resource.findByIdAndUpdate(
+          args.id,
+          { $pull: update.$pull },
+          () => updateGraphQL && buildTypes()
+        );
+      }
+      return Resource.findByIdAndUpdate(
         args.id,
-        { $pull: update.$pull },
+        { $addToSet: update.$addToSet },
+        { new: true },
         () => updateGraphQL && buildTypes()
       );
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    return Resource.findByIdAndUpdate(
-      args.id,
-      { $addToSet: update.$addToSet },
-      { new: true },
-      () => updateGraphQL && buildTypes()
-    );
   },
 };

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -547,11 +547,13 @@ export default {
     calculatedField: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       if (
         !args ||
@@ -568,7 +570,7 @@ export default {
       // check ability
       const ability: AppAbility = user.ability;
       const resource = await Resource.findById(args.id);
-      if (!resource){
+      if (!resource) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       if (ability.cannot('update', resource)) {
@@ -769,13 +771,13 @@ export default {
           () => updateGraphQL && buildTypes()
         );
       }
-      return Resource.findByIdAndUpdate(
+      return await Resource.findByIdAndUpdate(
         args.id,
         { $addToSet: update.$addToSet },
         { new: true },
         () => updateGraphQL && buildTypes()
       );
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -568,6 +568,9 @@ export default {
       // check ability
       const ability: AppAbility = user.ability;
       const resource = await Resource.findById(args.id);
+      if (!resource){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       if (ability.cannot('update', resource)) {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')

--- a/src/schema/mutation/editRole.mutation.ts
+++ b/src/schema/mutation/editRole.mutation.ts
@@ -10,6 +10,7 @@ import { get, has } from 'lodash';
 import { Role } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { RoleType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Edit a role's admin permissions, providing its id and the list of admin permissions.
@@ -28,64 +29,71 @@ export default {
     },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const autoAssignmentUpdate: any = {};
-    if (args.autoAssignment) {
-      if (has(args.autoAssignment, 'add')) {
-        Object.assign(autoAssignmentUpdate, {
-          $addToSet: {
-            autoAssignment: get(args.autoAssignment, 'add'),
-          },
+      const autoAssignmentUpdate: any = {};
+      if (args.autoAssignment) {
+        if (has(args.autoAssignment, 'add')) {
+          Object.assign(autoAssignmentUpdate, {
+            $addToSet: {
+              autoAssignment: get(args.autoAssignment, 'add'),
+            },
+          });
+        }
+        if (has(args.autoAssignment, 'remove')) {
+          Object.assign(autoAssignmentUpdate, {
+            $pull: {
+              autoAssignment: get(args.autoAssignment, 'remove'),
+            },
+          });
+        }
+      }
+
+      const ability: AppAbility = context.user.ability;
+      const update = {};
+      Object.assign(
+        update,
+        args.permissions && { permissions: args.permissions },
+        args.channels && { channels: args.channels },
+        args.title && { title: args.title },
+        args.description && { description: args.description },
+        autoAssignmentUpdate.$pull && { $pull: autoAssignmentUpdate.$pull }
+      );
+
+      const filters = Role.accessibleBy(ability, 'update')
+        .where({ _id: args.id })
+        .getFilter();
+
+      // doing a separate update to avoid the following error:
+      // Updating the path 'x' would create a conflict at 'x'
+      if (autoAssignmentUpdate.$addToSet) {
+        await Role.findOneAndUpdate(filters, {
+          $addToSet: autoAssignmentUpdate.$addToSet,
         });
       }
-      if (has(args.autoAssignment, 'remove')) {
-        Object.assign(autoAssignmentUpdate, {
-          $pull: {
-            autoAssignment: get(args.autoAssignment, 'remove'),
-          },
-        });
+
+      await Role.findOneAndUpdate(filters, update, { new: true });
+      const role = await Role.findOneAndUpdate(
+        filters,
+        { $pull: { autoAssignment: null } },
+        { new: true }
+      );
+      if (!role) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
       }
-    }
-
-    const ability: AppAbility = context.user.ability;
-    const update = {};
-    Object.assign(
-      update,
-      args.permissions && { permissions: args.permissions },
-      args.channels && { channels: args.channels },
-      args.title && { title: args.title },
-      args.description && { description: args.description },
-      autoAssignmentUpdate.$pull && { $pull: autoAssignmentUpdate.$pull }
-    );
-
-    const filters = Role.accessibleBy(ability, 'update')
-      .where({ _id: args.id })
-      .getFilter();
-
-    // doing a separate update to avoid the following error:
-    // Updating the path 'x' would create a conflict at 'x'
-    if (autoAssignmentUpdate.$addToSet) {
-      await Role.findOneAndUpdate(filters, {
-        $addToSet: autoAssignmentUpdate.$addToSet,
-      });
-    }
-
-    await Role.findOneAndUpdate(filters, update, { new: true });
-    const role = await Role.findOneAndUpdate(
-      filters,
-      { $pull: { autoAssignment: null } },
-      { new: true }
-    );
-    if (!role) {
+      return role;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    return role;
   },
 };

--- a/src/schema/mutation/editRole.mutation.ts
+++ b/src/schema/mutation/editRole.mutation.ts
@@ -29,11 +29,13 @@ export default {
     },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const autoAssignmentUpdate: any = {};
@@ -89,7 +91,7 @@ export default {
         );
       }
       return role;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -41,11 +41,13 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       // check inputs
       if (
@@ -58,7 +60,7 @@ export default {
       }
       // get data and check permissions
       let step = await Step.findById(args.id);
-      if (!step){
+      if (!step) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const ability = await extendAbilityForStep(user, step);
@@ -81,7 +83,9 @@ export default {
             break;
         }
         if (!content)
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
       }
 
       // defining what to update
@@ -131,7 +135,7 @@ export default {
         { ...update, ...permissionsUpdate },
         { new: true }
       );
-      if (!step){
+      if (!step) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       // update the dashboard if needed
@@ -143,7 +147,7 @@ export default {
         await Dashboard.findByIdAndUpdate(step.content, dashboardUpdate);
       }
       return step;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -10,6 +10,7 @@ import { contentType } from '@const/enumTypes';
 import { StepType } from '../types';
 import { Dashboard, Form, Step } from '@models';
 import extendAbilityForStep from '@security/extendAbilityForStep';
+import { logger } from '@services/logger.service';
 
 /** Simple form permission change type */
 type SimplePermissionChange =
@@ -40,100 +41,107 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    // check inputs
-    if (
-      !args ||
-      (!args.name && !args.type && !args.content && !args.permissions)
-    ) {
-      throw new GraphQLError(
-        context.i18next.t('mutations.step.edit.errors.invalidArguments')
-      );
-    }
-    // get data and check permissions
-    let step = await Step.findById(args.id);
-    const ability = await extendAbilityForStep(user, step);
-    if (ability.cannot('update', step)) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-    // check the new content exists
-    if (args.content) {
-      let content: Form | Dashboard;
-      switch (args.type) {
-        case contentType.dashboard:
-          content = await Dashboard.findById(args.content);
-          break;
-        case contentType.form:
-          content = await Form.findById(args.content);
-          break;
-        default:
-          break;
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-      if (!content)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
+      // check inputs
+      if (
+        !args ||
+        (!args.name && !args.type && !args.content && !args.permissions)
+      ) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.step.edit.errors.invalidArguments')
+        );
+      }
+      // get data and check permissions
+      let step = await Step.findById(args.id);
+      const ability = await extendAbilityForStep(user, step);
+      if (ability.cannot('update', step)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      // check the new content exists
+      if (args.content) {
+        let content: Form | Dashboard;
+        switch (args.type) {
+          case contentType.dashboard:
+            content = await Dashboard.findById(args.content);
+            break;
+          case contentType.form:
+            content = await Form.findById(args.content);
+            break;
+          default:
+            break;
+        }
+        if (!content)
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
 
-    // defining what to update
-    const update = {
-      //modifiedAt: new Date(),
-    };
-    Object.assign(
-      update,
-      args.name && { name: args.name },
-      args.type && { type: args.type },
-      args.content && { content: args.content }
-    );
+      // defining what to update
+      const update = {
+        //modifiedAt: new Date(),
+      };
+      Object.assign(
+        update,
+        args.name && { name: args.name },
+        args.type && { type: args.type },
+        args.content && { content: args.content }
+      );
 
-    // Updating permissions
-    const permissionsUpdate: any = {};
-    if (args.permissions) {
-      const permissions: PermissionChange = args.permissions;
-      for (const [key, obj] of Object.entries(permissions)) {
-        if (isArray(obj)) {
-          // if it's an array, replace the old value with the provided list
-          permissionsUpdate['permissions.' + key] = obj;
-        } else {
-          if (obj.add && obj.add.length) {
-            const pushRoles = {
-              [`permissions.${key}`]: { $each: obj.add },
-            };
+      // Updating permissions
+      const permissionsUpdate: any = {};
+      if (args.permissions) {
+        const permissions: PermissionChange = args.permissions;
+        for (const [key, obj] of Object.entries(permissions)) {
+          if (isArray(obj)) {
+            // if it's an array, replace the old value with the provided list
+            permissionsUpdate['permissions.' + key] = obj;
+          } else {
+            if (obj.add && obj.add.length) {
+              const pushRoles = {
+                [`permissions.${key}`]: { $each: obj.add },
+              };
 
-            if (permissionsUpdate.$push)
-              Object.assign(permissionsUpdate.$push, pushRoles);
-            else Object.assign(permissionsUpdate, { $push: pushRoles });
-          }
-          if (obj.remove && obj.remove.length) {
-            const pullRoles = {
-              [`permissions.${key}`]: { $in: obj.remove },
-            };
+              if (permissionsUpdate.$push)
+                Object.assign(permissionsUpdate.$push, pushRoles);
+              else Object.assign(permissionsUpdate, { $push: pushRoles });
+            }
+            if (obj.remove && obj.remove.length) {
+              const pullRoles = {
+                [`permissions.${key}`]: { $in: obj.remove },
+              };
 
-            if (permissionsUpdate.$pull)
-              Object.assign(permissionsUpdate.$pull, pullRoles);
-            else Object.assign(permissionsUpdate, { $pull: pullRoles });
+              if (permissionsUpdate.$pull)
+                Object.assign(permissionsUpdate.$pull, pullRoles);
+              else Object.assign(permissionsUpdate, { $pull: pullRoles });
+            }
           }
         }
       }
+      // update the step
+      step = await Step.findByIdAndUpdate(
+        args.id,
+        { ...update, ...permissionsUpdate },
+        { new: true }
+      );
+      // update the dashboard if needed
+      if (step.type === contentType.dashboard) {
+        const dashboardUpdate = {
+          //modifiedAt: new Date(),
+        };
+        Object.assign(dashboardUpdate, args.name && { name: args.name });
+        await Dashboard.findByIdAndUpdate(step.content, dashboardUpdate);
+      }
+      return step;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    // update the step
-    step = await Step.findByIdAndUpdate(
-      args.id,
-      { ...update, ...permissionsUpdate },
-      { new: true }
-    );
-    // update the dashboard if needed
-    if (step.type === contentType.dashboard) {
-      const dashboardUpdate = {
-        //modifiedAt: new Date(),
-      };
-      Object.assign(dashboardUpdate, args.name && { name: args.name });
-      await Dashboard.findByIdAndUpdate(step.content, dashboardUpdate);
-    }
-    return step;
   },
 };

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -58,6 +58,9 @@ export default {
       }
       // get data and check permissions
       let step = await Step.findById(args.id);
+      if (!step){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const ability = await extendAbilityForStep(user, step);
       if (ability.cannot('update', step)) {
         throw new GraphQLError(
@@ -128,6 +131,9 @@ export default {
         { ...update, ...permissionsUpdate },
         { new: true }
       );
+      if (!step){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       // update the dashboard if needed
       if (step.type === contentType.dashboard) {
         const dashboardUpdate = {

--- a/src/schema/mutation/editSubscription.mutation.ts
+++ b/src/schema/mutation/editSubscription.mutation.ts
@@ -28,11 +28,13 @@ export default {
     previousSubscription: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -70,7 +72,7 @@ export default {
         deleteQueue(args.previousSubscription);
       }
       return subscription;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editSubscription.mutation.ts
+++ b/src/schema/mutation/editSubscription.mutation.ts
@@ -11,6 +11,7 @@ import {
   createAndConsumeQueue,
   deleteQueue,
 } from '../../server/subscriberSafe';
+import { logger } from '@services/logger.service';
 
 /**
  * Edit a subscription.
@@ -27,46 +28,53 @@ export default {
     previousSubscription: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability: AppAbility = context.user.ability;
-    const filters = Application.accessibleBy(ability, 'update')
-      .where({ _id: args.applicationId })
-      .getFilter();
-    const application = await Application.findOne(filters);
-    if (!application) {
+      const ability: AppAbility = context.user.ability;
+      const filters = Application.accessibleBy(ability, 'update')
+        .where({ _id: args.applicationId })
+        .getFilter();
+      const application = await Application.findOne(filters);
+      if (!application) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      const subscription = {
+        routingKey: args.routingKey,
+        title: args.title,
+      };
+      Object.assign(
+        subscription,
+        args.convertTo && { convertTo: args.convertTo },
+        args.channel && { channel: args.channel }
+      );
+
+      application.subscriptions = application.subscriptions.map((sub) => {
+        if (sub.routingKey === args.previousSubscription) {
+          sub = subscription;
+        }
+        return sub;
+      });
+
+      await Application.findByIdAndUpdate(args.applicationId, application, {
+        new: true,
+      });
+      if (args.routingKey !== args.previousSubscription) {
+        createAndConsumeQueue(args.routingKey);
+        deleteQueue(args.previousSubscription);
+      }
+      return subscription;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    const subscription = {
-      routingKey: args.routingKey,
-      title: args.title,
-    };
-    Object.assign(
-      subscription,
-      args.convertTo && { convertTo: args.convertTo },
-      args.channel && { channel: args.channel }
-    );
-
-    application.subscriptions = application.subscriptions.map((sub) => {
-      if (sub.routingKey === args.previousSubscription) {
-        sub = subscription;
-      }
-      return sub;
-    });
-
-    await Application.findByIdAndUpdate(args.applicationId, application, {
-      new: true,
-    });
-    if (args.routingKey !== args.previousSubscription) {
-      createAndConsumeQueue(args.routingKey);
-      deleteQueue(args.previousSubscription);
-    }
-    return subscription;
   },
 };

--- a/src/schema/mutation/editTemplate.mutation.ts
+++ b/src/schema/mutation/editTemplate.mutation.ts
@@ -42,9 +42,15 @@ export default {
       update,
       { new: true }
     );
-
-    return application.templates.find(
-      (template) => template.id.toString() === args.id
-    );
+    
+    if(!application){
+      throw new GraphQLError(
+        context.i18next.t('common.errors.dataNotFound')
+      );
+    }else{
+      return application.templates.find(
+        (template) => template.id.toString() === args.id
+      );
+    }
   },
 };

--- a/src/schema/mutation/editTemplate.mutation.ts
+++ b/src/schema/mutation/editTemplate.mutation.ts
@@ -42,12 +42,10 @@ export default {
       update,
       { new: true }
     );
-    
-    if(!application){
-      throw new GraphQLError(
-        context.i18next.t('common.errors.dataNotFound')
-      );
-    }else{
+
+    if (!application) {
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    } else {
       return application.templates.find(
         (template) => template.id.toString() === args.id
       );

--- a/src/schema/mutation/editUser.mutation.ts
+++ b/src/schema/mutation/editUser.mutation.ts
@@ -20,11 +20,13 @@ export default {
     positionAttributes: { type: new GraphQLList(PositionAttributeInputType) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -50,8 +52,10 @@ export default {
           path: 'roles',
           match: { application: { $ne: args.application } }, // Only returns roles not attached to the application
         });
-        if (!nonAppRoles){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!nonAppRoles) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         roles = nonAppRoles.roles.map((x) => x._id).concat(roles);
         const update = {
@@ -70,7 +74,9 @@ export default {
             context.i18next.t('mutations.user.edit.errors.invalidArguments')
           );
         }
-        return User.findByIdAndUpdate(args.id, update, { new: true }).populate({
+        return await User.findByIdAndUpdate(args.id, update, {
+          new: true,
+        }).populate({
           path: 'roles',
           match: { application: args.application }, // Only returns roles attached to the application
         });
@@ -86,8 +92,10 @@ export default {
             path: 'roles',
             match: { application: { $ne: null } }, // Returns roles attached to any application
           });
-          if (!appRoles){
-            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          if (!appRoles) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
           }
           roles = appRoles.roles.map((x) => x._id).concat(roles);
           Object.assign(update, { roles: roles });
@@ -100,9 +108,9 @@ export default {
             context.i18next.t('mutations.user.edit.errors.invalidArguments')
           );
         }
-        return User.findByIdAndUpdate(args.id, update, { new: true });
+        return await User.findByIdAndUpdate(args.id, update, { new: true });
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editUser.mutation.ts
+++ b/src/schema/mutation/editUser.mutation.ts
@@ -4,6 +4,7 @@ import { User } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { UserType } from '../types';
 import { PositionAttributeInputType } from '../inputs';
+import { logger } from '@services/logger.service';
 
 /**
  * Edits an user's roles and groups, providing its id and the list of roles/groups.
@@ -19,80 +20,87 @@ export default {
     positionAttributes: { type: new GraphQLList(PositionAttributeInputType) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability: AppAbility = context.user.ability;
-    let roles = args.roles;
-    if (args.application) {
-      if (ability.cannot('update', 'User')) {
-        // Check applications permissions if we don't have the global one
-        const canUpdate = user.roles.some(
-          (x) =>
-            x.application &&
-            x.application.equals(args.application) &&
-            x.permissions.some(
-              (y) => y.type === permissions.canSeeUsers && !y.global
-            )
-        );
-        if (!canUpdate) {
+      const ability: AppAbility = context.user.ability;
+      let roles = args.roles;
+      if (args.application) {
+        if (ability.cannot('update', 'User')) {
+          // Check applications permissions if we don't have the global one
+          const canUpdate = user.roles.some(
+            (x) =>
+              x.application &&
+              x.application.equals(args.application) &&
+              x.permissions.some(
+                (y) => y.type === permissions.canSeeUsers && !y.global
+              )
+          );
+          if (!canUpdate) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.permissionNotGranted')
+            );
+          }
+        }
+        const nonAppRoles = await User.findById(args.id).populate({
+          path: 'roles',
+          match: { application: { $ne: args.application } }, // Only returns roles not attached to the application
+        });
+        roles = nonAppRoles.roles.map((x) => x._id).concat(roles);
+        const update = {
+          roles,
+        };
+        if (args.positionAttributes) {
+          const positionAttributes = args.positionAttributes.filter(
+            (element) => element.value.length > 0
+          );
+          Object.assign(update, {
+            positionAttributes,
+          });
+        }
+        if (Object.keys(update).length < 1) {
+          throw new GraphQLError(
+            context.i18next.t('mutations.user.edit.errors.invalidArguments')
+          );
+        }
+        return User.findByIdAndUpdate(args.id, update, { new: true }).populate({
+          path: 'roles',
+          match: { application: args.application }, // Only returns roles attached to the application
+        });
+      } else {
+        if (ability.cannot('update', 'User')) {
           throw new GraphQLError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
+        const update = {};
+        if (args.roles) {
+          const appRoles = await User.findById(args.id).populate({
+            path: 'roles',
+            match: { application: { $ne: null } }, // Returns roles attached to any application
+          });
+          roles = appRoles.roles.map((x) => x._id).concat(roles);
+          Object.assign(update, { roles: roles });
+        }
+        if (args.groups) {
+          Object.assign(update, { groups: args.groups });
+        }
+        if (Object.keys(update).length < 1) {
+          throw new GraphQLError(
+            context.i18next.t('mutations.user.edit.errors.invalidArguments')
+          );
+        }
+        return User.findByIdAndUpdate(args.id, update, { new: true });
       }
-      const nonAppRoles = await User.findById(args.id).populate({
-        path: 'roles',
-        match: { application: { $ne: args.application } }, // Only returns roles not attached to the application
-      });
-      roles = nonAppRoles.roles.map((x) => x._id).concat(roles);
-      const update = {
-        roles,
-      };
-      if (args.positionAttributes) {
-        const positionAttributes = args.positionAttributes.filter(
-          (element) => element.value.length > 0
-        );
-        Object.assign(update, {
-          positionAttributes,
-        });
-      }
-      if (Object.keys(update).length < 1) {
-        throw new GraphQLError(
-          context.i18next.t('mutations.user.edit.errors.invalidArguments')
-        );
-      }
-      return User.findByIdAndUpdate(args.id, update, { new: true }).populate({
-        path: 'roles',
-        match: { application: args.application }, // Only returns roles attached to the application
-      });
-    } else {
-      if (ability.cannot('update', 'User')) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      const update = {};
-      if (args.roles) {
-        const appRoles = await User.findById(args.id).populate({
-          path: 'roles',
-          match: { application: { $ne: null } }, // Returns roles attached to any application
-        });
-        roles = appRoles.roles.map((x) => x._id).concat(roles);
-        Object.assign(update, { roles: roles });
-      }
-      if (args.groups) {
-        Object.assign(update, { groups: args.groups });
-      }
-      if (Object.keys(update).length < 1) {
-        throw new GraphQLError(
-          context.i18next.t('mutations.user.edit.errors.invalidArguments')
-        );
-      }
-      return User.findByIdAndUpdate(args.id, update, { new: true });
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
   },
 };

--- a/src/schema/mutation/editUser.mutation.ts
+++ b/src/schema/mutation/editUser.mutation.ts
@@ -50,6 +50,9 @@ export default {
           path: 'roles',
           match: { application: { $ne: args.application } }, // Only returns roles not attached to the application
         });
+        if (!nonAppRoles){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
         roles = nonAppRoles.roles.map((x) => x._id).concat(roles);
         const update = {
           roles,
@@ -83,6 +86,9 @@ export default {
             path: 'roles',
             match: { application: { $ne: null } }, // Returns roles attached to any application
           });
+          if (!appRoles){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
           roles = appRoles.roles.map((x) => x._id).concat(roles);
           Object.assign(update, { roles: roles });
         }

--- a/src/schema/mutation/editUserProfile.mutation.ts
+++ b/src/schema/mutation/editUserProfile.mutation.ts
@@ -5,6 +5,7 @@ import { UserType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import config from 'config';
 import { isEmpty, get } from 'lodash';
+import { logger } from '@services/logger.service';
 
 /**
  * Edit User profile.
@@ -18,58 +19,65 @@ export default {
     id: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const availableAttributes: { value: string; text: string }[] =
-      config.get('user.attributes.list') || [];
+      const availableAttributes: { value: string; text: string }[] =
+        config.get('user.attributes.list') || [];
 
-    // Create base update
-    const update = {};
-    Object.assign(
-      update,
-      args.profile.favoriteApp && { favoriteApp: args.profile.favoriteApp },
-      args.profile.name && { name: args.profile.name },
-      args.profile.firstName && { firstName: args.profile.firstName },
-      args.profile.lastName && { lastName: args.profile.lastName }
-    );
+      // Create base update
+      const update = {};
+      Object.assign(
+        update,
+        args.profile.favoriteApp && { favoriteApp: args.profile.favoriteApp },
+        args.profile.name && { name: args.profile.name },
+        args.profile.firstName && { firstName: args.profile.firstName },
+        args.profile.lastName && { lastName: args.profile.lastName }
+      );
 
-    // Create attribute update
-    const attributes = {};
-    if (args.profile.attributes) {
-      for (const attribute in args.profile.attributes) {
-        if (availableAttributes.find((x) => x.value === attribute)) {
-          Object.assign(attributes, {
-            [attribute]: get(args.profile.attributes, attribute, null),
-          });
+      // Create attribute update
+      const attributes = {};
+      if (args.profile.attributes) {
+        for (const attribute in args.profile.attributes) {
+          if (availableAttributes.find((x) => x.value === attribute)) {
+            Object.assign(attributes, {
+              [attribute]: get(args.profile.attributes, attribute, null),
+            });
+          }
         }
       }
-    }
 
-    if (!isEmpty(attributes)) {
-      Object.assign(update, { attributes });
-    }
+      if (!isEmpty(attributes)) {
+        Object.assign(update, { attributes });
+      }
 
-    if (args.id) {
-      const ability: AppAbility = context.user.ability;
-      if (ability.can('update', 'User')) {
-        try {
-          return await User.findByIdAndUpdate(args.id, update, { new: true });
-        } catch {
+      if (args.id) {
+        const ability: AppAbility = context.user.ability;
+        if (ability.can('update', 'User')) {
+          try {
+            return await User.findByIdAndUpdate(args.id, update, { new: true });
+          } catch {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
+          }
+        } else {
           throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
+            context.i18next.t('common.errors.permissionNotGranted')
           );
         }
       } else {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
+        return User.findByIdAndUpdate(user._id, update, { new: true });
       }
-    } else {
-      return User.findByIdAndUpdate(user._id, update, { new: true });
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
   },
 };

--- a/src/schema/mutation/editUserProfile.mutation.ts
+++ b/src/schema/mutation/editUserProfile.mutation.ts
@@ -19,11 +19,13 @@ export default {
     id: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const availableAttributes: { value: string; text: string }[] =
@@ -71,9 +73,9 @@ export default {
           );
         }
       } else {
-        return User.findByIdAndUpdate(user._id, update, { new: true });
+        return await User.findByIdAndUpdate(user._id, update, { new: true });
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editWorkflow.mutation.ts
+++ b/src/schema/mutation/editWorkflow.mutation.ts
@@ -22,42 +22,59 @@ export default {
     steps: { type: new GraphQLList(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    // check inputs
-    if (!args || (!args.name && !args.steps)) {
+      // check inputs
+      if (!args || (!args.name && !args.steps)) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.workflow.edit.errors.invalidArguments')
+        );
+      }
+
+      // get data and check permissions
+      let workflow = await Workflow.findById(args.id);
+      const ability = await extendAbilityForContent(user, workflow);
+      if (ability.cannot('update', workflow)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      // do the update
+      const update = Object.assign(
+        {},
+        args.name && { name: args.name },
+        args.steps && { steps: args.steps }
+      );
+      logger.info('update ==>> ', update);
+      workflow = await Workflow.findByIdAndUpdate(args.id, update, { new: true });
+
+      // update the page or step
+      if (update.steps) delete update.steps;
+      const page = await Page.findOneAndUpdate({ content: args.id }, update);
+      if(!page){
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+      const step = await Step.findOneAndUpdate({ content: args.id }, update);
+      if(!step){
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+
+      return workflow;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('mutations.workflow.edit.errors.invalidArguments')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-
-    // get data and check permissions
-    let workflow = await Workflow.findById(args.id);
-    const ability = await extendAbilityForContent(user, workflow);
-    if (ability.cannot('update', workflow)) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-
-    // do the update
-    const update = Object.assign(
-      {},
-      args.name && { name: args.name },
-      args.steps && { steps: args.steps }
-    );
-    logger.info('update ==>> ', update);
-    workflow = await Workflow.findByIdAndUpdate(args.id, update, { new: true });
-
-    // update the page or step
-    if (update.steps) delete update.steps;
-    await Page.findOneAndUpdate({ content: args.id }, update);
-    await Step.findOneAndUpdate({ content: args.id }, update);
-
-    return workflow;
   },
 };

--- a/src/schema/mutation/editWorkflow.mutation.ts
+++ b/src/schema/mutation/editWorkflow.mutation.ts
@@ -22,11 +22,13 @@ export default {
     steps: { type: new GraphQLList(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // check inputs
@@ -38,7 +40,7 @@ export default {
 
       // get data and check permissions
       let workflow = await Workflow.findById(args.id);
-      if (!workflow){
+      if (!workflow) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const ability = await extendAbilityForContent(user, workflow);
@@ -55,27 +57,25 @@ export default {
         args.steps && { steps: args.steps }
       );
       logger.info('update ==>> ', update);
-      workflow = await Workflow.findByIdAndUpdate(args.id, update, { new: true });
-      if (!workflow){
+      workflow = await Workflow.findByIdAndUpdate(args.id, update, {
+        new: true,
+      });
+      if (!workflow) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       // update the page or step
       if (update.steps) delete update.steps;
       const page = await Page.findOneAndUpdate({ content: args.id }, update);
-      if(!page){
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+      if (!page) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const step = await Step.findOneAndUpdate({ content: args.id }, update);
-      if(!step){
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+      if (!step) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
 
       return workflow;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editWorkflow.mutation.ts
+++ b/src/schema/mutation/editWorkflow.mutation.ts
@@ -38,6 +38,9 @@ export default {
 
       // get data and check permissions
       let workflow = await Workflow.findById(args.id);
+      if (!workflow){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const ability = await extendAbilityForContent(user, workflow);
       if (ability.cannot('update', workflow)) {
         throw new GraphQLError(
@@ -53,7 +56,9 @@ export default {
       );
       logger.info('update ==>> ', update);
       workflow = await Workflow.findByIdAndUpdate(args.id, update, { new: true });
-
+      if (!workflow){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       // update the page or step
       if (update.steps) delete update.steps;
       const page = await Page.findOneAndUpdate({ content: args.id }, update);

--- a/src/schema/mutation/fetchGroups.mutation.ts
+++ b/src/schema/mutation/fetchGroups.mutation.ts
@@ -13,7 +13,7 @@ import { logger } from '@services/logger.service';
 export default {
   type: new GraphQLList(GroupType),
   async resolve(parent, args, context) {
-    try{
+    try {
       const canFetch = !config.get('user.groups.local');
       if (!canFetch) {
         throw new GraphQLError(
@@ -22,11 +22,13 @@ export default {
           )
         );
       }
-  
+
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = context.user.ability;
       if (!ability.can('create', 'Group')) {
@@ -34,7 +36,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-  
+
       const groups = await fetchGroups();
       const bulkOps: any[] = [];
       groups.forEach((group) => {
@@ -54,10 +56,10 @@ export default {
         bulkOps.push(upsertGroup);
       });
       await Group.collection.bulkWrite(bulkOps);
-  
+
       const filter = Group.accessibleBy(ability, 'read').getFilter();
-      return Group.find(filter);
-    }catch (err){
+      return await Group.find(filter);
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/fetchGroups.mutation.ts
+++ b/src/schema/mutation/fetchGroups.mutation.ts
@@ -4,6 +4,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import { GroupType } from '../types';
 import config from 'config';
 import { fetchGroups } from '@utils/user';
+import { logger } from '@services/logger.service';
 
 /**
  * Fetches groups from service
@@ -12,48 +13,55 @@ import { fetchGroups } from '@utils/user';
 export default {
   type: new GraphQLList(GroupType),
   async resolve(parent, args, context) {
-    const canFetch = !config.get('user.groups.local');
-    if (!canFetch) {
-      throw new GraphQLError(
-        context.i18next.t(
-          'mutations.group.fetch.errors.groupsFromServiceDisabled'
-        )
-      );
-    }
-
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = context.user.ability;
-    if (!ability.can('create', 'Group')) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-
-    const groups = await fetchGroups();
-    const bulkOps: any[] = [];
-    groups.forEach((group) => {
-      const upsertGroup = {
-        updateOne: {
-          filter: { oid: group.oid },
-          update: {
-            $set: {
-              oid: group.oid,
-              title: group.title,
-              description: group.description,
+    try{
+      const canFetch = !config.get('user.groups.local');
+      if (!canFetch) {
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.group.fetch.errors.groupsFromServiceDisabled'
+          )
+        );
+      }
+  
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = context.user.ability;
+      if (!ability.can('create', 'Group')) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+  
+      const groups = await fetchGroups();
+      const bulkOps: any[] = [];
+      groups.forEach((group) => {
+        const upsertGroup = {
+          updateOne: {
+            filter: { oid: group.oid },
+            update: {
+              $set: {
+                oid: group.oid,
+                title: group.title,
+                description: group.description,
+              },
             },
+            upsert: true,
           },
-          upsert: true,
-        },
-      };
-      bulkOps.push(upsertGroup);
-    });
-    await Group.collection.bulkWrite(bulkOps);
-
-    const filter = Group.accessibleBy(ability, 'read').getFilter();
-    return Group.find(filter);
+        };
+        bulkOps.push(upsertGroup);
+      });
+      await Group.collection.bulkWrite(bulkOps);
+  
+      const filter = Group.accessibleBy(ability, 'read').getFilter();
+      return Group.find(filter);
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
+    }
   },
 };

--- a/src/schema/mutation/publish.mutation.ts
+++ b/src/schema/mutation/publish.mutation.ts
@@ -21,11 +21,13 @@ export default {
     channel: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -54,7 +56,7 @@ export default {
         records
       );
       return true;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/publish.mutation.ts
+++ b/src/schema/mutation/publish.mutation.ts
@@ -9,6 +9,7 @@ import { Channel, Record } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import pubsubSafe from '../../server/pubsubSafe';
 import config from 'config';
+import { logger } from '@services/logger.service';
 
 /**
  * Publish records in a notification.
@@ -20,37 +21,44 @@ export default {
     channel: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability: AppAbility = context.user.ability;
-    const channel = await Channel.findById(args.channel).populate(
-      'application'
-    );
-    if (!channel || !channel.application) {
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
-    if (ability.cannot('read', channel.application)) {
+      const ability: AppAbility = context.user.ability;
+      const channel = await Channel.findById(args.channel).populate(
+        'application'
+      );
+      if (!channel || !channel.application) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+      if (ability.cannot('read', channel.application)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      const records = await Record.find({})
+        .where('_id')
+        .in(args.ids)
+        .select('data');
+
+      const publisher = await pubsubSafe();
+      publisher.publish(
+        `${config.get('rabbitMQ.application')}.${channel.application._id}.${
+          args.channel
+        }`,
+        records
+      );
+      return true;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-
-    const records = await Record.find({})
-      .where('_id')
-      .in(args.ids)
-      .select('data');
-
-    const publisher = await pubsubSafe();
-    publisher.publish(
-      `${config.get('rabbitMQ.application')}.${channel.application._id}.${
-        args.channel
-      }`,
-      records
-    );
-    return true;
   },
 };

--- a/src/schema/mutation/publishNotification.mutation.ts
+++ b/src/schema/mutation/publishNotification.mutation.ts
@@ -23,16 +23,18 @@ export default {
     channel: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       if (!args || !args.action || !args.content || !args.channel)
-      throw new GraphQLError(
-        context.i18next.t(
-          'mutations.notification.publish.errors.invalidArguments'
-        )
-      );
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.notification.publish.errors.invalidArguments'
+          )
+        );
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const notification = new Notification({
         action: args.action,
@@ -45,7 +47,7 @@ export default {
       const publisher = await pubsub();
       publisher.publish(args.channel, { notification });
       return notification;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/publishNotification.mutation.ts
+++ b/src/schema/mutation/publishNotification.mutation.ts
@@ -8,6 +8,7 @@ import GraphQLJSON from 'graphql-type-json';
 import { NotificationType } from '../types';
 import { Notification } from '@models';
 import pubsub from '../../server/pubsub';
+import { logger } from '@services/logger.service';
 
 /**
  * Create a notification and store it in the database.
@@ -22,26 +23,33 @@ export default {
     channel: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    if (!args || !args.action || !args.content || !args.channel)
+    try{
+      if (!args || !args.action || !args.content || !args.channel)
       throw new GraphQLError(
         context.i18next.t(
           'mutations.notification.publish.errors.invalidArguments'
         )
       );
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const notification = new Notification({
+        action: args.action,
+        content: args.content,
+        //createdAt: new Date(),
+        channel: args.channel,
+        seenBy: [],
+      });
+      await notification.save();
+      const publisher = await pubsub();
+      publisher.publish(args.channel, { notification });
+      return notification;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    const notification = new Notification({
-      action: args.action,
-      content: args.content,
-      //createdAt: new Date(),
-      channel: args.channel,
-      seenBy: [],
-    });
-    await notification.save();
-    const publisher = await pubsub();
-    publisher.publish(args.channel, { notification });
-    return notification;
   },
 };

--- a/src/schema/mutation/restoreRecord.mutation.ts
+++ b/src/schema/mutation/restoreRecord.mutation.ts
@@ -25,6 +25,9 @@ export default {
         path: 'form',
         model: 'Form',
       });
+      if (!record){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       // Check ability
       const ability = await extendAbilityForRecords(user, record.form);
       if (ability.cannot('update', record)) {

--- a/src/schema/mutation/restoreRecord.mutation.ts
+++ b/src/schema/mutation/restoreRecord.mutation.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { Record } from '@models';
 import { RecordType } from '../types';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
+import { logger } from '@services/logger.service';
 
 /**
  * Restore, if user has permission to update associated form / resource.
@@ -13,28 +14,35 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    // Get the record
-    const record = await Record.findById(args.id).populate({
-      path: 'form',
-      model: 'Form',
-    });
-    // Check ability
-    const ability = await extendAbilityForRecords(user, record.form);
-    if (ability.cannot('update', record)) {
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      // Get the record
+      const record = await Record.findById(args.id).populate({
+        path: 'form',
+        model: 'Form',
+      });
+      // Check ability
+      const ability = await extendAbilityForRecords(user, record.form);
+      if (ability.cannot('update', record)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      // Update the record
+      return Record.findByIdAndUpdate(
+        record._id,
+        { archived: false },
+        { new: true }
+      );
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    // Update the record
-    return Record.findByIdAndUpdate(
-      record._id,
-      { archived: false },
-      { new: true }
-    );
   },
 };

--- a/src/schema/mutation/restoreRecord.mutation.ts
+++ b/src/schema/mutation/restoreRecord.mutation.ts
@@ -14,18 +14,20 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       // Get the record
       const record = await Record.findById(args.id).populate({
         path: 'form',
         model: 'Form',
       });
-      if (!record){
+      if (!record) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       // Check ability
@@ -36,12 +38,12 @@ export default {
         );
       }
       // Update the record
-      return Record.findByIdAndUpdate(
+      return await Record.findByIdAndUpdate(
         record._id,
         { archived: false },
         { new: true }
       );
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/seeNotification.mutation.ts
+++ b/src/schema/mutation/seeNotification.mutation.ts
@@ -14,11 +14,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -28,14 +30,12 @@ export default {
       const notification = Notification.findOneAndUpdate(filters, {
         $push: { seenBy: user._id },
       });
-      if(notification){
-        return notification
-      }else{
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+      if (notification) {
+        return await notification;
+      } else {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/seeNotification.mutation.ts
+++ b/src/schema/mutation/seeNotification.mutation.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { NotificationType } from '../types';
 import { Notification } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Find notification from its id and update it.
@@ -13,18 +14,32 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability: AppAbility = context.user.ability;
-    const filters = Notification.accessibleBy(ability, 'update')
-      .where({ _id: args.id })
-      .getFilter();
-    return Notification.findOneAndUpdate(filters, {
-      $push: { seenBy: user._id },
-    });
+      const ability: AppAbility = context.user.ability;
+      const filters = Notification.accessibleBy(ability, 'update')
+        .where({ _id: args.id })
+        .getFilter();
+      const notification = Notification.findOneAndUpdate(filters, {
+        $push: { seenBy: user._id },
+      });
+      if(notification){
+        return notification
+      }else{
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
+    }
   },
 };

--- a/src/schema/mutation/seeNotifications.mutation.ts
+++ b/src/schema/mutation/seeNotifications.mutation.ts
@@ -19,17 +19,21 @@ export default {
     ids: { type: new GraphQLNonNull(GraphQLList(GraphQLID)) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
       if (!args) {
         throw new GraphQLError(
-          context.i18next.t('mutations.notification.see.errors.invalidArguments')
+          context.i18next.t(
+            'mutations.notification.see.errors.invalidArguments'
+          )
         );
       }
       const filters = Notification.accessibleBy(ability, 'update')
@@ -39,7 +43,7 @@ export default {
         $push: { seenBy: user._id },
       });
       return result.ok === 1;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/seeNotifications.mutation.ts
+++ b/src/schema/mutation/seeNotifications.mutation.ts
@@ -7,6 +7,7 @@ import {
 } from 'graphql';
 import { Notification } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Find multiple notifications and mark them as read.
@@ -18,24 +19,31 @@ export default {
     ids: { type: new GraphQLNonNull(GraphQLList(GraphQLID)) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability: AppAbility = context.user.ability;
-    if (!args) {
+      const ability: AppAbility = context.user.ability;
+      if (!args) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.notification.see.errors.invalidArguments')
+        );
+      }
+      const filters = Notification.accessibleBy(ability, 'update')
+        .where({ _id: { $in: args.ids } })
+        .getFilter();
+      const result = await Notification.updateMany(filters, {
+        $push: { seenBy: user._id },
+      });
+      return result.ok === 1;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('mutations.notification.see.errors.invalidArguments')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    const filters = Notification.accessibleBy(ability, 'update')
-      .where({ _id: { $in: args.ids } })
-      .getFilter();
-    const result = await Notification.updateMany(filters, {
-      $push: { seenBy: user._id },
-    });
-    return result.ok === 1;
   },
 };

--- a/src/schema/mutation/toggleApplicationLock.mutation.ts
+++ b/src/schema/mutation/toggleApplicationLock.mutation.ts
@@ -8,6 +8,7 @@ import { ApplicationType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import pubsub from '../../server/pubsub';
 import { Application } from '@models';
+import { logger } from '@services/logger.service';
 
 /**
  * Toggle application lock, to prevent other users to edit the application at the same time.
@@ -19,32 +20,44 @@ export default {
     lock: { type: new GraphQLNonNull(GraphQLBoolean) },
   },
   async resolve(parent, args, context) {
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = context.user.ability;
-    const filters = Application.accessibleBy(ability, 'update')
-      .where({ _id: args.id })
-      .getFilter();
-    let application = await Application.findOne(filters);
-    if (!application) {
+    try{
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = context.user.ability;
+      const filters = Application.accessibleBy(ability, 'update')
+        .where({ _id: args.id })
+        .getFilter();
+      let application = await Application.findOne(filters);
+      if (!application) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      const update = {
+        lockedBy: args.lock ? user._id : null,
+        locked: args.lock,
+      };
+      application = await Application.findOneAndUpdate(filters, update, {
+        new: true,
+      });
+      if(!application){
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+      const publisher = await pubsub();
+      publisher.publish('app_lock', {
+        application,
+        user: user._id,
+      });
+      return application;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    const update = {
-      lockedBy: args.lock ? user._id : null,
-      locked: args.lock,
-    };
-    application = await Application.findOneAndUpdate(filters, update, {
-      new: true,
-    });
-    const publisher = await pubsub();
-    publisher.publish('app_lock', {
-      application,
-      user: user._id,
-    });
-    return application;
   },
 };

--- a/src/schema/mutation/toggleApplicationLock.mutation.ts
+++ b/src/schema/mutation/toggleApplicationLock.mutation.ts
@@ -20,10 +20,12 @@ export default {
     lock: { type: new GraphQLNonNull(GraphQLBoolean) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = context.user.ability;
       const filters = Application.accessibleBy(ability, 'update')
@@ -42,10 +44,8 @@ export default {
       application = await Application.findOneAndUpdate(filters, update, {
         new: true,
       });
-      if(!application){
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+      if (!application) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const publisher = await pubsub();
       publisher.publish('app_lock', {
@@ -53,7 +53,7 @@ export default {
         user: user._id,
       });
       return application;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/uploadApplicationStyle.ts
+++ b/src/schema/mutation/uploadApplicationStyle.ts
@@ -20,11 +20,13 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = context.user.ability;
       const filters = Application.accessibleBy(ability, 'update')
@@ -37,10 +39,15 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-      const path = await uploadFile('applications', args.application, file.file, {
-        filename: application.cssFilename,
-        allowedExtensions: ['css', 'scss'],
-      });
+      const path = await uploadFile(
+        'applications',
+        args.application,
+        file.file,
+        {
+          filename: application.cssFilename,
+          allowedExtensions: ['css', 'scss'],
+        }
+      );
 
       await Application.updateOne(
         { _id: args.application },
@@ -48,7 +55,7 @@ export default {
       );
 
       return path;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/uploadApplicationStyle.ts
+++ b/src/schema/mutation/uploadApplicationStyle.ts
@@ -8,6 +8,7 @@ import {
 import { Application } from '@models';
 import { uploadFile } from '@utils/files';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Upload application style File.
@@ -19,32 +20,39 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = context.user.ability;
-    const filters = Application.accessibleBy(ability, 'update')
-      .where({ _id: args.application })
-      .getFilter();
-    const file = await args.file;
-    const application = await Application.findOne(filters);
-    if (!application) {
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = context.user.ability;
+      const filters = Application.accessibleBy(ability, 'update')
+        .where({ _id: args.application })
+        .getFilter();
+      const file = await args.file;
+      const application = await Application.findOne(filters);
+      if (!application) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      const path = await uploadFile('applications', args.application, file.file, {
+        filename: application.cssFilename,
+        allowedExtensions: ['css', 'scss'],
+      });
+
+      await Application.updateOne(
+        { _id: args.application },
+        { cssFilename: path }
+      );
+
+      return path;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    const path = await uploadFile('applications', args.application, file.file, {
-      filename: application.cssFilename,
-      allowedExtensions: ['css', 'scss'],
-    });
-
-    await Application.updateOne(
-      { _id: args.application },
-      { cssFilename: path }
-    );
-
-    return path;
   },
 };

--- a/src/schema/query/apiConfiguration.query.ts
+++ b/src/schema/query/apiConfiguration.query.ts
@@ -13,26 +13,30 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability = context.user.ability;
       if (ability.can('read', 'ApiConfiguration')) {
         const apiConfiguration = ApiConfiguration.findById(args.id);
-        if (!apiConfiguration){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!apiConfiguration) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
-        return apiConfiguration;
+        return await apiConfiguration;
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/apiConfiguration.query.ts
+++ b/src/schema/query/apiConfiguration.query.ts
@@ -1,6 +1,7 @@
 import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { ApiConfigurationType } from '../types';
 import { ApiConfiguration } from '@models';
+import { logger } from '@services/logger.service';
 
 /**
  * Return api configuration from id if available for the logged user.
@@ -12,18 +13,25 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability = context.user.ability;
-    if (ability.can('read', 'ApiConfiguration')) {
-      return ApiConfiguration.findById(args.id);
-    } else {
+      const ability = context.user.ability;
+      if (ability.can('read', 'ApiConfiguration')) {
+        return ApiConfiguration.findById(args.id);
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/query/apiConfiguration.query.ts
+++ b/src/schema/query/apiConfiguration.query.ts
@@ -22,7 +22,11 @@ export default {
 
       const ability = context.user.ability;
       if (ability.can('read', 'ApiConfiguration')) {
-        return ApiConfiguration.findById(args.id);
+        const apiConfiguration = ApiConfiguration.findById(args.id);
+        if (!apiConfiguration){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return apiConfiguration;
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')

--- a/src/schema/query/apiConfigurations.query.ts
+++ b/src/schema/query/apiConfigurations.query.ts
@@ -22,11 +22,13 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -68,7 +70,7 @@ export default {
         edges,
         totalCount: await ApiConfiguration.countDocuments({ $and: filters }),
       };
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/apiConfigurations.query.ts
+++ b/src/schema/query/apiConfigurations.query.ts
@@ -6,6 +6,7 @@ import {
 } from '../types';
 import { ApiConfiguration } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -21,50 +22,57 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+
+      const ability: AppAbility = context.user.ability;
+
+      const abilityFilters = ApiConfiguration.accessibleBy(
+        ability,
+        'read'
+      ).getFilter();
+      const filters: any[] = [abilityFilters];
+
+      const first = args.first || DEFAULT_FIRST;
+      const afterCursor = args.afterCursor;
+      const cursorFilters = afterCursor
+        ? {
+            _id: {
+              $gt: decodeCursor(afterCursor),
+            },
+          }
+        : {};
+
+      let items: any[] = await ApiConfiguration.find({
+        $and: [cursorFilters, ...filters],
+      }).limit(first + 1);
+
+      const hasNextPage = items.length > first;
+      if (hasNextPage) {
+        items = items.slice(0, items.length - 1);
+      }
+      const edges = items.map((r) => ({
+        cursor: encodeCursor(r.id.toString()),
+        node: r,
+      }));
+      return {
+        pageInfo: {
+          hasNextPage,
+          startCursor: edges.length > 0 ? edges[0].cursor : null,
+          endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+        },
+        edges,
+        totalCount: await ApiConfiguration.countDocuments({ $and: filters }),
+      };
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-
-    const ability: AppAbility = context.user.ability;
-
-    const abilityFilters = ApiConfiguration.accessibleBy(
-      ability,
-      'read'
-    ).getFilter();
-    const filters: any[] = [abilityFilters];
-
-    const first = args.first || DEFAULT_FIRST;
-    const afterCursor = args.afterCursor;
-    const cursorFilters = afterCursor
-      ? {
-          _id: {
-            $gt: decodeCursor(afterCursor),
-          },
-        }
-      : {};
-
-    let items: any[] = await ApiConfiguration.find({
-      $and: [cursorFilters, ...filters],
-    }).limit(first + 1);
-
-    const hasNextPage = items.length > first;
-    if (hasNextPage) {
-      items = items.slice(0, items.length - 1);
-    }
-    const edges = items.map((r) => ({
-      cursor: encodeCursor(r.id.toString()),
-      node: r,
-    }));
-    return {
-      pageInfo: {
-        hasNextPage,
-        startCursor: edges.length > 0 ? edges[0].cursor : null,
-        endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
-      },
-      edges,
-      totalCount: await ApiConfiguration.countDocuments({ $and: filters }),
-    };
   },
 };

--- a/src/schema/query/application.query.ts
+++ b/src/schema/query/application.query.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { ApplicationType } from '../types';
 import mongoose from 'mongoose';
 import { Application, Page } from '@models';
+import { logger } from '@services/logger.service';
 
 /**
  * Returns application from id if available for the logged user.
@@ -15,41 +16,48 @@ export default {
     asRole: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability = context.user.ability;
-    const filters = Application.accessibleBy(ability)
-      .where({ _id: args.id })
-      .getFilter();
-    const application = await Application.findOne(filters);
-    if (application && args.asRole) {
-      const pages: Page[] = await Page.aggregate([
-        {
-          $match: {
-            'permissions.canSee': {
-              $elemMatch: { $eq: mongoose.Types.ObjectId(args.asRole) },
+      const ability = context.user.ability;
+      const filters = Application.accessibleBy(ability)
+        .where({ _id: args.id })
+        .getFilter();
+      const application = await Application.findOne(filters);
+      if (application && args.asRole) {
+        const pages: Page[] = await Page.aggregate([
+          {
+            $match: {
+              'permissions.canSee': {
+                $elemMatch: { $eq: mongoose.Types.ObjectId(args.asRole) },
+              },
+              _id: { $in: application.pages },
             },
-            _id: { $in: application.pages },
           },
-        },
-        {
-          $addFields: {
-            __order: { $indexOfArray: [application.pages, '$_id'] },
+          {
+            $addFields: {
+              __order: { $indexOfArray: [application.pages, '$_id'] },
+            },
           },
-        },
-        { $sort: { __order: 1 } },
-      ]);
-      application.pages = pages.map((x) => x._id);
-    }
-    if (!application) {
+          { $sort: { __order: 1 } },
+        ]);
+        application.pages = pages.map((x) => x._id);
+      }
+      if (!application) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      return application;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    return application;
   },
 };

--- a/src/schema/query/application.query.ts
+++ b/src/schema/query/application.query.ts
@@ -16,11 +16,13 @@ export default {
     asRole: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability = context.user.ability;
@@ -53,7 +55,7 @@ export default {
         );
       }
       return application;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/applications.query.ts
+++ b/src/schema/query/applications.query.ts
@@ -101,11 +101,13 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       // Inputs check
       if (args.sortField) {
@@ -167,7 +169,7 @@ export default {
         edges,
         totalCount: await Application.countDocuments({ $and: filters }),
       };
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/applications.query.ts
+++ b/src/schema/query/applications.query.ts
@@ -9,6 +9,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import GraphQLJSON from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
+import { logger } from '@services/logger.service';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -100,70 +101,77 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    // Inputs check
-    if (args.sortField) {
-      if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
-        throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-    }
-
-    const ability: AppAbility = context.user.ability;
-
-    // Inputs check
-    if (args.sortField) {
-      if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
-        throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
+      // Inputs check
+      if (args.sortField) {
+        if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
+          throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
+        }
       }
+
+      const ability: AppAbility = context.user.ability;
+
+      // Inputs check
+      if (args.sortField) {
+        if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
+          throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
+        }
+      }
+
+      const abilityFilters = Application.accessibleBy(
+        ability,
+        'read'
+      ).getFilter();
+      const queryFilters = getFilter(args.filter, FILTER_FIELDS);
+      const filters: any[] = [queryFilters, abilityFilters];
+
+      const first = args.first || DEFAULT_FIRST;
+      const afterCursor = args.afterCursor;
+
+      const sortField =
+        SORT_FIELDS.find((x) => x.name === args.sortField) ||
+        SORT_FIELDS.find((x) => x.name === 'createdAt');
+      const sortOrder = args.sortOrder || 'asc';
+
+      const cursorFilters = afterCursor
+        ? sortField.cursorFilter(afterCursor, sortOrder)
+        : {};
+
+      let items: any[] = await Application.find({
+        $and: [cursorFilters, ...filters],
+      })
+        .sort(sortField.sort(sortOrder))
+        .limit(first + 1);
+
+      const hasNextPage = items.length > first;
+      if (hasNextPage) {
+        items = items.slice(0, items.length - 1);
+      }
+
+      const edges = items.map((r) => ({
+        cursor: encodeCursor(sortField.cursorId(r)),
+        node: r,
+      }));
+
+      return {
+        pageInfo: {
+          hasNextPage,
+          startCursor: edges.length > 0 ? edges[0].cursor : null,
+          endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+        },
+        edges,
+        totalCount: await Application.countDocuments({ $and: filters }),
+      };
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-
-    const abilityFilters = Application.accessibleBy(
-      ability,
-      'read'
-    ).getFilter();
-    const queryFilters = getFilter(args.filter, FILTER_FIELDS);
-    const filters: any[] = [queryFilters, abilityFilters];
-
-    const first = args.first || DEFAULT_FIRST;
-    const afterCursor = args.afterCursor;
-
-    const sortField =
-      SORT_FIELDS.find((x) => x.name === args.sortField) ||
-      SORT_FIELDS.find((x) => x.name === 'createdAt');
-    const sortOrder = args.sortOrder || 'asc';
-
-    const cursorFilters = afterCursor
-      ? sortField.cursorFilter(afterCursor, sortOrder)
-      : {};
-
-    let items: any[] = await Application.find({
-      $and: [cursorFilters, ...filters],
-    })
-      .sort(sortField.sort(sortOrder))
-      .limit(first + 1);
-
-    const hasNextPage = items.length > first;
-    if (hasNextPage) {
-      items = items.slice(0, items.length - 1);
-    }
-
-    const edges = items.map((r) => ({
-      cursor: encodeCursor(sortField.cursorId(r)),
-      node: r,
-    }));
-
-    return {
-      pageInfo: {
-        hasNextPage,
-        startCursor: edges.length > 0 ? edges[0].cursor : null,
-        endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
-      },
-      edges,
-      totalCount: await Application.countDocuments({ $and: filters }),
-    };
   },
 };

--- a/src/schema/query/dashboard.query.ts
+++ b/src/schema/query/dashboard.query.ts
@@ -10,6 +10,7 @@ import {
 import extendAbilityForContent from '@security/extendAbilityForContent';
 import { CustomAPI } from '@server/apollo/dataSources';
 import { Types } from 'mongoose';
+import { logger } from '@services/logger.service';
 
 /**
  * Return dashboard from id if available for the logged user.
@@ -21,69 +22,80 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    // get data and check permissions
-    const dashboard = await Dashboard.findById(args.id);
-    const ability = await extendAbilityForContent(user, dashboard);
-    if (ability.cannot('read', dashboard)) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-    // Check if dashboard has context linked to it
-    const page = await Page.findOne({
-      contentWithContext: { $elemMatch: { content: args.id } },
-    });
-
-    // If a page was found, means the dashboard has context
-    if (page && page.context) {
-      // get the id of the resource or refData
-      const contentWithContext = page.contentWithContext.find((c) =>
-        (c.content as Types.ObjectId).equals(args.id)
-      );
-      const id =
-        'element' in contentWithContext && contentWithContext.element
-          ? contentWithContext.element
-          : 'record' in contentWithContext && contentWithContext.record
-          ? contentWithContext.record
-          : null;
-
-      const ctx = page.context;
-      let data: any;
-
-      if ('resource' in ctx && ctx.resource) {
-        const record = await Record.findById(id);
-        data = record.data;
-      } else if ('refData' in ctx && ctx.refData) {
-        // get refData from page
-        const referenceData = await ReferenceData.findById(ctx.refData);
-        const apiConfiguration = await ApiConfiguration.findById(
-          referenceData.apiConfiguration
-        );
-        const items = apiConfiguration
-          ? await (
-              context.dataSources[apiConfiguration.name] as CustomAPI
-            ).getReferenceDataItems(referenceData, apiConfiguration)
-          : referenceData.data;
-        data = items.find((x) => x[referenceData.valueField] === id);
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
 
-      const stringifiedStructure = JSON.stringify(dashboard.structure);
-      const regex = /{{context\.(.*?)}}/g;
+      // get data and check permissions
+      const dashboard = await Dashboard.findById(args.id);
+      const ability = await extendAbilityForContent(user, dashboard);
+      if (ability.cannot('read', dashboard)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      // Check if dashboard has context linked to it
+      const page = await Page.findOne({
+        contentWithContext: { $elemMatch: { content: args.id } },
+      });
 
-      // replace all {{context.<field>}} with the value from the data
-      dashboard.structure = JSON.parse(
-        stringifiedStructure.replace(regex, (match) => {
-          const field = match.replace('{{context.', '').replace('}}', '');
-          return data[field] || match;
-        })
+      // If a page was found, means the dashboard has context
+      if (page && page.context) {
+        // get the id of the resource or refData
+        const contentWithContext = page.contentWithContext.find((c) =>
+          (c.content as Types.ObjectId).equals(args.id)
+        );
+        const id =
+          'element' in contentWithContext && contentWithContext.element
+            ? contentWithContext.element
+            : 'record' in contentWithContext && contentWithContext.record
+            ? contentWithContext.record
+            : null;
+
+        const ctx = page.context;
+        let data: any;
+
+        if ('resource' in ctx && ctx.resource) {
+          const record = await Record.findById(id);
+          data = record.data;
+        } else if ('refData' in ctx && ctx.refData) {
+          // get refData from page
+          const referenceData = await ReferenceData.findById(ctx.refData);
+          const apiConfiguration = await ApiConfiguration.findById(
+            referenceData.apiConfiguration
+          );
+          const items = apiConfiguration
+            ? await (
+                context.dataSources[apiConfiguration.name] as CustomAPI
+              ).getReferenceDataItems(referenceData, apiConfiguration)
+            : referenceData.data;
+          data = items.find((x) => x[referenceData.valueField] === id);
+        }
+
+        const stringifiedStructure = JSON.stringify(dashboard.structure);
+        const regex = /{{context\.(.*?)}}/g;
+
+        // replace all {{context.<field>}} with the value from the data
+        dashboard.structure = JSON.parse(
+          stringifiedStructure.replace(regex, (match) => {
+            const field = match.replace('{{context.', '').replace('}}', '');
+            return data[field] || match;
+          })
+        );
+      }else{
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+      return dashboard;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    return dashboard;
   },
 };

--- a/src/schema/query/dashboard.query.ts
+++ b/src/schema/query/dashboard.query.ts
@@ -22,16 +22,18 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // get data and check permissions
       const dashboard = await Dashboard.findById(args.id);
-      if (!dashboard){
+      if (!dashboard) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const ability = await extendAbilityForContent(user, dashboard);
@@ -63,21 +65,27 @@ export default {
 
         if ('resource' in ctx && ctx.resource) {
           const record = await Record.findById(id);
-          if (!record){
-            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          if (!record) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
           }
           data = record.data;
         } else if ('refData' in ctx && ctx.refData) {
           // get refData from page
           const referenceData = await ReferenceData.findById(ctx.refData);
-          if (!referenceData){
-            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          if (!referenceData) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
           }
           const apiConfiguration = await ApiConfiguration.findById(
             referenceData.apiConfiguration
           );
-          if (!apiConfiguration){
-            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          if (!apiConfiguration) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
           }
           const items = apiConfiguration
             ? await (
@@ -97,13 +105,11 @@ export default {
             return data[field] || match;
           })
         );
-      }else{
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+      } else {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       return dashboard;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/dashboard.query.ts
+++ b/src/schema/query/dashboard.query.ts
@@ -31,6 +31,9 @@ export default {
 
       // get data and check permissions
       const dashboard = await Dashboard.findById(args.id);
+      if (!dashboard){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const ability = await extendAbilityForContent(user, dashboard);
       if (ability.cannot('read', dashboard)) {
         throw new GraphQLError(
@@ -60,13 +63,22 @@ export default {
 
         if ('resource' in ctx && ctx.resource) {
           const record = await Record.findById(id);
+          if (!record){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
           data = record.data;
         } else if ('refData' in ctx && ctx.refData) {
           // get refData from page
           const referenceData = await ReferenceData.findById(ctx.refData);
+          if (!referenceData){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
           const apiConfiguration = await ApiConfiguration.findById(
             referenceData.apiConfiguration
           );
+          if (!apiConfiguration){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
           const items = apiConfiguration
             ? await (
                 context.dataSources[apiConfiguration.name] as CustomAPI

--- a/src/schema/query/dashboards.query.ts
+++ b/src/schema/query/dashboards.query.ts
@@ -14,11 +14,13 @@ export default {
     all: { type: GraphQLBoolean },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability = context.user.ability;
@@ -35,9 +37,9 @@ export default {
         Object.assign(filters, { _id: { $nin: contentIds.concat(stepIds) } });
       }
       if (ability.can('read', 'Dashboard')) {
-        return Dashboard.find(filters);
+        return await Dashboard.find(filters);
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/dashboards.query.ts
+++ b/src/schema/query/dashboards.query.ts
@@ -2,6 +2,7 @@ import { GraphQLList, GraphQLBoolean, GraphQLError } from 'graphql';
 import { contentType } from '@const/enumTypes';
 import { Page, Step, Dashboard } from '@models';
 import { DashboardType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * List all dashboards available for the logged user.
@@ -13,27 +14,34 @@ export default {
     all: { type: GraphQLBoolean },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability = context.user.ability;
-    const filters = {};
-    if (!args.all) {
-      const contentIds = await Page.find({
-        type: { $eq: contentType.dashboard },
-        content: { $ne: null },
-      }).distinct('content');
-      const stepIds = await Step.find({
-        type: { $eq: contentType.dashboard },
-        content: { $ne: null },
-      }).distinct('content');
-      Object.assign(filters, { _id: { $nin: contentIds.concat(stepIds) } });
-    }
-    if (ability.can('read', 'Dashboard')) {
-      return Dashboard.find(filters);
+      const ability = context.user.ability;
+      const filters = {};
+      if (!args.all) {
+        const contentIds = await Page.find({
+          type: { $eq: contentType.dashboard },
+          content: { $ne: null },
+        }).distinct('content');
+        const stepIds = await Step.find({
+          type: { $eq: contentType.dashboard },
+          content: { $ne: null },
+        }).distinct('content');
+        Object.assign(filters, { _id: { $nin: contentIds.concat(stepIds) } });
+      }
+      if (ability.can('read', 'Dashboard')) {
+        return Dashboard.find(filters);
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
   },
 };

--- a/src/schema/query/form.query.ts
+++ b/src/schema/query/form.query.ts
@@ -15,11 +15,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // get data and permissions
@@ -39,7 +41,7 @@ export default {
       }
 
       return form;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/forms.query.ts
+++ b/src/schema/query/forms.query.ts
@@ -101,11 +101,13 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       // Inputs check
       if (args.sortField) {
@@ -155,7 +157,7 @@ export default {
         edges,
         totalCount: await Form.countDocuments({ $and: filters }),
       };
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/group.query.ts
+++ b/src/schema/query/group.query.ts
@@ -14,11 +14,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -34,14 +36,16 @@ export default {
           }
           return group;
         } catch {
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/group.query.ts
+++ b/src/schema/query/group.query.ts
@@ -2,6 +2,7 @@ import { GraphQLID, GraphQLError, GraphQLNonNull } from 'graphql';
 import { Group } from '@models';
 import { GroupType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Get Query by ID.
@@ -13,30 +14,37 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    const ability: AppAbility = context.user.ability;
-    if (ability.can('read', 'Group')) {
-      try {
-        const group = await Group.accessibleBy(ability, 'read').findOne({
-          _id: args.id,
-        });
-        if (!group) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
-        }
-        return group;
-      } catch {
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-    } else {
+
+      const ability: AppAbility = context.user.ability;
+      if (ability.can('read', 'Group')) {
+        try {
+          const group = await Group.accessibleBy(ability, 'read').findOne({
+            _id: args.id,
+          });
+          if (!group) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
+          }
+          return group;
+        } catch {
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/query/notifications.query.ts
+++ b/src/schema/query/notifications.query.ts
@@ -22,11 +22,13 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -70,7 +72,7 @@ export default {
         edges,
         totalCount: await Notification.countDocuments({ $and: filters }),
       };
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/notifications.query.ts
+++ b/src/schema/query/notifications.query.ts
@@ -6,6 +6,7 @@ import {
 } from '../types';
 import { Notification } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -21,52 +22,59 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+
+      const ability: AppAbility = context.user.ability;
+
+      const abilityFilters = Notification.accessibleBy(
+        ability,
+        'read'
+      ).getFilter();
+      const filters: any[] = [abilityFilters];
+
+      const first = args.first || DEFAULT_FIRST;
+      const afterCursor = args.afterCursor;
+      const cursorFilters = afterCursor
+        ? {
+            _id: {
+              $lt: decodeCursor(afterCursor),
+            },
+          }
+        : {};
+
+      let items: any[] = await Notification.find({
+        $and: [cursorFilters, ...filters],
+      })
+        .sort({ createdAt: -1 })
+        .limit(first + 1);
+
+      const hasNextPage = items.length > first;
+      if (hasNextPage) {
+        items = items.slice(0, items.length - 1);
+      }
+      const edges = items.map((r) => ({
+        cursor: encodeCursor(r.id.toString()),
+        node: r,
+      }));
+      return {
+        pageInfo: {
+          hasNextPage,
+          startCursor: edges.length > 0 ? edges[0].cursor : null,
+          endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+        },
+        edges,
+        totalCount: await Notification.countDocuments({ $and: filters }),
+      };
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-
-    const ability: AppAbility = context.user.ability;
-
-    const abilityFilters = Notification.accessibleBy(
-      ability,
-      'read'
-    ).getFilter();
-    const filters: any[] = [abilityFilters];
-
-    const first = args.first || DEFAULT_FIRST;
-    const afterCursor = args.afterCursor;
-    const cursorFilters = afterCursor
-      ? {
-          _id: {
-            $lt: decodeCursor(afterCursor),
-          },
-        }
-      : {};
-
-    let items: any[] = await Notification.find({
-      $and: [cursorFilters, ...filters],
-    })
-      .sort({ createdAt: -1 })
-      .limit(first + 1);
-
-    const hasNextPage = items.length > first;
-    if (hasNextPage) {
-      items = items.slice(0, items.length - 1);
-    }
-    const edges = items.map((r) => ({
-      cursor: encodeCursor(r.id.toString()),
-      node: r,
-    }));
-    return {
-      pageInfo: {
-        hasNextPage,
-        startCursor: edges.length > 0 ? edges[0].cursor : null,
-        endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
-      },
-      edges,
-      totalCount: await Notification.countDocuments({ $and: filters }),
-    };
   },
 };

--- a/src/schema/query/page.query.ts
+++ b/src/schema/query/page.query.ts
@@ -14,16 +14,18 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // get data
       const page = await Page.findById(args.id);
-      if (!page){
+      if (!page) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
 
@@ -36,7 +38,7 @@ export default {
       }
 
       return page;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/page.query.ts
+++ b/src/schema/query/page.query.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { PageType } from '../types';
 import { Page } from '@models';
 import extendAbilityForPage from '@security/extendAbilityForPage';
+import { logger } from '@services/logger.service';
 
 /**
  * Return page from id if available for the logged user.
@@ -13,23 +14,30 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    // get data
-    const page = await Page.findById(args.id);
+      // get data
+      const page = await Page.findById(args.id);
 
-    // check ability
-    const ability = await extendAbilityForPage(user, page);
-    if (ability.cannot('read', page)) {
+      // check ability
+      const ability = await extendAbilityForPage(user, page);
+      if (ability.cannot('read', page)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      return page;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-
-    return page;
   },
 };

--- a/src/schema/query/page.query.ts
+++ b/src/schema/query/page.query.ts
@@ -23,6 +23,9 @@ export default {
 
       // get data
       const page = await Page.findById(args.id);
+      if (!page){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
 
       // check ability
       const ability = await extendAbilityForPage(user, page);

--- a/src/schema/query/pages.query.ts
+++ b/src/schema/query/pages.query.ts
@@ -12,23 +12,28 @@ import { logger } from '@services/logger.service';
 export default {
   type: new GraphQLList(PageType),
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // create ability object for all pages
       let ability: AppAbility = user.ability;
-      const applications = await Application.accessibleBy(ability, 'read').find();
+      const applications = await Application.accessibleBy(
+        ability,
+        'read'
+      ).find();
       for (const application of applications) {
         ability = await extendAbilityForPage(user, application, ability);
       }
 
       // return the pages
-      return Page.accessibleBy(ability, 'read').find();
-    }catch (err){
+      return await Page.accessibleBy(ability, 'read').find();
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/pages.query.ts
+++ b/src/schema/query/pages.query.ts
@@ -3,6 +3,7 @@ import { PageType } from '../types';
 import { Application, Page } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import extendAbilityForPage from '@security/extendAbilityForPage';
+import { logger } from '@services/logger.service';
 
 /**
  * List all pages available for the logged user.
@@ -11,20 +12,27 @@ import extendAbilityForPage from '@security/extendAbilityForPage';
 export default {
   type: new GraphQLList(PageType),
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    // create ability object for all pages
-    let ability: AppAbility = user.ability;
-    const applications = await Application.accessibleBy(ability, 'read').find();
-    for (const application of applications) {
-      ability = await extendAbilityForPage(user, application, ability);
-    }
+      // create ability object for all pages
+      let ability: AppAbility = user.ability;
+      const applications = await Application.accessibleBy(ability, 'read').find();
+      for (const application of applications) {
+        ability = await extendAbilityForPage(user, application, ability);
+      }
 
-    // return the pages
-    return Page.accessibleBy(ability, 'read').find();
+      // return the pages
+      return Page.accessibleBy(ability, 'read').find();
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
+    }
   },
 };

--- a/src/schema/query/positionAttributes.query.ts
+++ b/src/schema/query/positionAttributes.query.ts
@@ -2,6 +2,7 @@ import { GraphQLError, GraphQLID, GraphQLList, GraphQLNonNull } from 'graphql';
 import { User } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { PositionAttributeType } from '../types';
+import { logger } from '@services/logger.service';
 
 /**
  * Return position attributes from category id.
@@ -13,39 +14,46 @@ export default {
     category: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = context.user.ability;
-    if (ability.cannot('read', 'User')) {
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      const ability: AppAbility = context.user.ability;
+      if (ability.cannot('read', 'User')) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      const positionAttributes = [];
+      const lastAttributeValue = [];
+      const users = await User.find(
+        { 'positionAttributes.category': args.category },
+        { positionAttributes: true }
+      );
+      if (users) {
+        users.forEach((x) => {
+          x.positionAttributes.forEach((attribute) => {
+            if (
+              !lastAttributeValue.includes(attribute.value) &&
+              attribute.category.toString() === args.category
+            ) {
+              positionAttributes.push({
+                value: attribute.value,
+                category: attribute.category,
+              });
+              lastAttributeValue.push(attribute.value);
+            }
+          });
+        });
+      }
+      return positionAttributes;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    const positionAttributes = [];
-    const lastAttributeValue = [];
-    const users = await User.find(
-      { 'positionAttributes.category': args.category },
-      { positionAttributes: true }
-    );
-    if (users) {
-      users.forEach((x) => {
-        x.positionAttributes.forEach((attribute) => {
-          if (
-            !lastAttributeValue.includes(attribute.value) &&
-            attribute.category.toString() === args.category
-          ) {
-            positionAttributes.push({
-              value: attribute.value,
-              category: attribute.category,
-            });
-            lastAttributeValue.push(attribute.value);
-          }
-        });
-      });
-    }
-    return positionAttributes;
   },
 };

--- a/src/schema/query/positionAttributes.query.ts
+++ b/src/schema/query/positionAttributes.query.ts
@@ -14,11 +14,13 @@ export default {
     category: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const ability: AppAbility = context.user.ability;
       if (ability.cannot('read', 'User')) {
@@ -49,7 +51,7 @@ export default {
         });
       }
       return positionAttributes;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/pullJobs.query.ts
+++ b/src/schema/query/pullJobs.query.ts
@@ -18,11 +18,13 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -60,7 +62,7 @@ export default {
         edges,
         totalCount: await PullJob.countDocuments({ $and: filters }),
       };
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/pullJobs.query.ts
+++ b/src/schema/query/pullJobs.query.ts
@@ -2,6 +2,7 @@ import { GraphQLError, GraphQLID, GraphQLInt } from 'graphql';
 import { PullJobConnectionType, encodeCursor, decodeCursor } from '../types';
 import { PullJob } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -17,46 +18,53 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+
+      const ability: AppAbility = context.user.ability;
+      const abilityFilters = PullJob.accessibleBy(ability, 'read').getFilter();
+      const filters: any[] = [abilityFilters];
+
+      const first = args.first || DEFAULT_FIRST;
+      const afterCursor = args.afterCursor;
+      const cursorFilters = afterCursor
+        ? {
+            _id: {
+              $gt: decodeCursor(afterCursor),
+            },
+          }
+        : {};
+
+      let items: any[] = await PullJob.find({
+        $and: [cursorFilters, ...filters],
+      }).limit(first + 1);
+
+      const hasNextPage = items.length > first;
+      if (hasNextPage) {
+        items = items.slice(0, items.length - 1);
+      }
+      const edges = items.map((r) => ({
+        cursor: encodeCursor(r.id.toString()),
+        node: r,
+      }));
+      return {
+        pageInfo: {
+          hasNextPage,
+          startCursor: edges.length > 0 ? edges[0].cursor : null,
+          endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+        },
+        edges,
+        totalCount: await PullJob.countDocuments({ $and: filters }),
+      };
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-
-    const ability: AppAbility = context.user.ability;
-    const abilityFilters = PullJob.accessibleBy(ability, 'read').getFilter();
-    const filters: any[] = [abilityFilters];
-
-    const first = args.first || DEFAULT_FIRST;
-    const afterCursor = args.afterCursor;
-    const cursorFilters = afterCursor
-      ? {
-          _id: {
-            $gt: decodeCursor(afterCursor),
-          },
-        }
-      : {};
-
-    let items: any[] = await PullJob.find({
-      $and: [cursorFilters, ...filters],
-    }).limit(first + 1);
-
-    const hasNextPage = items.length > first;
-    if (hasNextPage) {
-      items = items.slice(0, items.length - 1);
-    }
-    const edges = items.map((r) => ({
-      cursor: encodeCursor(r.id.toString()),
-      node: r,
-    }));
-    return {
-      pageInfo: {
-        hasNextPage,
-        startCursor: edges.length > 0 ? edges[0].cursor : null,
-        endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
-      },
-      edges,
-      totalCount: await PullJob.countDocuments({ $and: filters }),
-    };
   },
 };

--- a/src/schema/query/record.query.ts
+++ b/src/schema/query/record.query.ts
@@ -24,7 +24,13 @@ export default {
 
       // Get the form and the record
       const record = await Record.findById(args.id);
+      if (!record){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const form = await Form.findById(record.form);
+      if (!form){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
 
       // Check ability
       const ability = await extendAbilityForRecords(user, form);

--- a/src/schema/query/record.query.ts
+++ b/src/schema/query/record.query.ts
@@ -3,6 +3,7 @@ import { Form, Record } from '@models';
 import { RecordType } from '../types';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import { getAccessibleFields } from '@utils/form';
+import { logger } from '@services/logger.service';
 
 /**
  * Return record from id if available for the logged user.
@@ -14,25 +15,32 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    // Get the form and the record
-    const record = await Record.findById(args.id);
-    const form = await Form.findById(record.form);
+      // Get the form and the record
+      const record = await Record.findById(args.id);
+      const form = await Form.findById(record.form);
 
-    // Check ability
-    const ability = await extendAbilityForRecords(user, form);
-    if (ability.cannot('read', record)) {
+      // Check ability
+      const ability = await extendAbilityForRecords(user, form);
+      if (ability.cannot('read', record)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      // Return the record
+      return getAccessibleFields(record, ability);
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-
-    // Return the record
-    return getAccessibleFields(record, ability);
   },
 };

--- a/src/schema/query/record.query.ts
+++ b/src/schema/query/record.query.ts
@@ -15,20 +15,22 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // Get the form and the record
       const record = await Record.findById(args.id);
-      if (!record){
+      if (!record) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const form = await Form.findById(record.form);
-      if (!form){
+      if (!form) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
 
@@ -42,7 +44,7 @@ export default {
 
       // Return the record
       return getAccessibleFields(record, ability);
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -22,7 +22,7 @@ export default {
     lang: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Setting language, if provided
       if (args.lang) {
         await context.i18next.i18n.changeLanguage(args.lang);
@@ -57,13 +57,16 @@ export default {
             model: 'Resource',
           },
         });
-      
-      if (!record){
+
+      if (!record) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       // Check ability
       const ability = await extendAbilityForRecords(user, record.form);
-      if (ability.cannot('read', record) || ability.cannot('read', record.form)) {
+      if (
+        ability.cannot('read', record) ||
+        ability.cannot('read', record.form)
+      ) {
         throw new GraphQLError(
           context.i18next.i18n.t('common.errors.permissionNotGranted')
         );
@@ -82,7 +85,7 @@ export default {
         }
       }
       return history;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -57,7 +57,10 @@ export default {
             model: 'Resource',
           },
         });
-
+      
+      if (!record){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       // Check ability
       const ability = await extendAbilityForRecords(user, record.form);
       if (ability.cannot('read', record) || ability.cannot('read', record.form)) {

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -9,6 +9,7 @@ import { HistoryVersionType } from '../types';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import { RecordHistory } from '@utils/history';
 import { Record } from '@models';
+import { logger } from '@services/logger.service';
 
 /**
  * Gets the record history for a record.
@@ -21,61 +22,68 @@ export default {
     lang: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    // Setting language, if provided
-    if (args.lang) {
-      await context.i18next.i18n.changeLanguage(args.lang);
-    }
-
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(
-        context.i18next.i18n.t('common.errors.userNotLogged')
-      );
-    }
-
-    // Get data
-    const record: Record = await Record.findById(args.id)
-      .populate({
-        path: 'versions',
-        populate: {
-          path: 'createdBy',
-          model: 'User',
-        },
-      })
-      .populate({
-        path: 'createdBy.user',
-        model: 'User',
-      })
-      .populate({
-        path: 'form',
-        model: 'Form',
-        populate: {
-          path: 'resource',
-          model: 'Resource',
-        },
-      });
-
-    // Check ability
-    const ability = await extendAbilityForRecords(user, record.form);
-    if (ability.cannot('read', record) || ability.cannot('read', record.form)) {
-      throw new GraphQLError(
-        context.i18next.i18n.t('common.errors.permissionNotGranted')
-      );
-    }
-
-    // Create the history and return it
-    const history = await new RecordHistory(record, {
-      translate: context.i18next.i18n.t,
-      ability,
-      context,
-    }).getHistory();
-    for (const version of history) {
-      for (const change of version.changes) {
-        if (change.new) change.new = JSON.stringify(change.new);
-        if (change.old) change.old = JSON.stringify(change.old);
+    try{
+      // Setting language, if provided
+      if (args.lang) {
+        await context.i18next.i18n.changeLanguage(args.lang);
       }
+
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(
+          context.i18next.i18n.t('common.errors.userNotLogged')
+        );
+      }
+
+      // Get data
+      const record: Record = await Record.findById(args.id)
+        .populate({
+          path: 'versions',
+          populate: {
+            path: 'createdBy',
+            model: 'User',
+          },
+        })
+        .populate({
+          path: 'createdBy.user',
+          model: 'User',
+        })
+        .populate({
+          path: 'form',
+          model: 'Form',
+          populate: {
+            path: 'resource',
+            model: 'Resource',
+          },
+        });
+
+      // Check ability
+      const ability = await extendAbilityForRecords(user, record.form);
+      if (ability.cannot('read', record) || ability.cannot('read', record.form)) {
+        throw new GraphQLError(
+          context.i18next.i18n.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      // Create the history and return it
+      const history = await new RecordHistory(record, {
+        translate: context.i18next.i18n.t,
+        ability,
+        context,
+      }).getHistory();
+      for (const version of history) {
+        for (const change of version.changes) {
+          if (change.new) change.new = JSON.stringify(change.new);
+          if (change.old) change.old = JSON.stringify(change.old);
+        }
+      }
+      return history;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    return history;
   },
 };

--- a/src/schema/query/records.query.ts
+++ b/src/schema/query/records.query.ts
@@ -12,18 +12,20 @@ import { logger } from '@services/logger.service';
 export default {
   type: new GraphQLList(RecordType),
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability = await extendAbilityForRecords(user);
       // Return the records
       const records = await Record.accessibleBy(ability, 'read').find();
       return getAccessibleFields(records, ability);
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/records.query.ts
+++ b/src/schema/query/records.query.ts
@@ -3,6 +3,7 @@ import { RecordType } from '../types';
 import { Record } from '@models';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import { getAccessibleFields } from '@utils/form';
+import { logger } from '@services/logger.service';
 
 /**
  * List all records available for the logged user.
@@ -11,15 +12,22 @@ import { getAccessibleFields } from '@utils/form';
 export default {
   type: new GraphQLList(RecordType),
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability = await extendAbilityForRecords(user);
-    // Return the records
-    const records = await Record.accessibleBy(ability, 'read').find();
-    return getAccessibleFields(records, ability);
+      const ability = await extendAbilityForRecords(user);
+      // Return the records
+      const records = await Record.accessibleBy(ability, 'read').find();
+      return getAccessibleFields(records, ability);
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
+    }
   },
 };

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -49,394 +49,401 @@ export default {
     skip: { type: GraphQLInt },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    // global variables
-    let pipeline: any[] = [];
-    const first: number = get(args, 'first', 10);
-    const skip: number = get(args, 'skip', 0);
-
-    // Build data source step
-    // TODO: enhance if switching from azure cosmos to mongo
-    const resource = await Resource.findById(args.resource, {
-      name: 1,
-      fields: 1,
-      aggregations: 1,
-    });
-
-    // Check abilities
-    const ability = await extendAbilityForRecords(user);
-    const permissionFilters = Record.accessibleBy(ability, 'read').getFilter();
-
-    // As we only queried one aggregation
-    const aggregation = resource.aggregations.find((x) =>
-      isEqual(x.id, args.aggregation)
-    );
-    const mongooseFilter = {};
-    // Check if resource exists and aggregation exists
-    if (resource && aggregation) {
-      Object.assign(
-        mongooseFilter,
-        { resource: mongoose.Types.ObjectId(args.resource) },
-        { archived: { $ne: true } }
-      );
-    } else {
-      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-    }
-
-    pipeline.push({
-      $match: {
-        $and: [mongooseFilter, permissionFilters],
-      },
-    });
-
-    // Build the source fields step
-    if (aggregation.sourceFields && aggregation.sourceFields.length) {
-      // If we have user fields
-      if (
-        aggregation.sourceFields.some((x) =>
-          defaultRecordFields.some(
-            (y) => (x === y.field && y.type === UserType) || y.field === 'form'
-          )
-        )
-      ) {
-        // Form
-        if (aggregation.sourceFields.includes('form')) {
-          const relatedForms = await Form.find({
-            resource: args.resource,
-          }).select('id name');
-          resource.fields.push({
-            name: 'form',
-            choices: relatedForms.map((x) => {
-              return { value: x.id, text: x.name };
-            }),
-          });
-        }
-        // Created By
-        if (aggregation.sourceFields.includes('createdBy')) {
-          pipeline = pipeline.concat(CREATED_BY_STAGES);
-        }
-        // Last updated by
-        if (aggregation.sourceFields.includes('lastUpdatedBy')) {
-          if (!aggregation.sourceFields.includes('createdBy')) {
-            pipeline = pipeline.concat(CREATED_BY_STAGES);
-          }
-          pipeline = pipeline.concat([
-            {
-              $addFields: {
-                lastVersion: {
-                  $last: '$versions',
-                },
-              },
-            },
-            {
-              $lookup: {
-                from: 'versions',
-                localField: 'lastVersion',
-                foreignField: '_id',
-                as: 'lastVersion',
-              },
-            },
-            {
-              $lookup: {
-                from: 'users',
-                localField: 'lastVersion.createdBy',
-                foreignField: '_id',
-                as: 'lastUpdatedBy',
-              },
-            },
-            {
-              $addFields: {
-                lastUpdatedBy: {
-                  $last: '$lastUpdatedBy',
-                },
-              },
-            },
-            {
-              $addFields: {
-                lastUpdatedBy: {
-                  $ifNull: ['$lastUpdatedBy', '$createdBy'],
-                },
-              },
-            },
-          ]);
-        }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-      // Fetch related fields from other forms
-      const relatedFields: any[] = await Form.aggregate([
-        {
-          $match: {
-            fields: {
-              $elemMatch: {
-                resource: String(args.resource),
-                $or: [
-                  {
-                    type: 'resource',
-                  },
-                  {
-                    type: 'resources',
-                  },
-                ],
-              },
-            },
-          },
-        },
-        {
-          $unwind: '$fields',
-        },
-        {
-          $match: {
-            'fields.resource': String(args.resource),
-            $or: [
-              {
-                'fields.type': 'resource',
-              },
-              {
-                'fields.type': 'resources',
-              },
-            ],
-          },
-        },
-        {
-          $addFields: {
-            'fields.form': '$_id',
-          },
-        },
-        {
-          $replaceRoot: {
-            newRoot: '$fields',
-          },
-        },
-      ]);
+
+      // global variables
+      let pipeline: any[] = [];
+      const first: number = get(args, 'first', 10);
+      const skip: number = get(args, 'skip', 0);
+
+      // Build data source step
+      // TODO: enhance if switching from azure cosmos to mongo
+      const resource = await Resource.findById(args.resource, {
+        name: 1,
+        fields: 1,
+        aggregations: 1,
+      });
+
+      // Check abilities
+      const ability = await extendAbilityForRecords(user);
+      const permissionFilters = Record.accessibleBy(ability, 'read').getFilter();
+
+      // As we only queried one aggregation
+      const aggregation = resource.aggregations.find((x) =>
+        isEqual(x.id, args.aggregation)
+      );
+      const mongooseFilter = {};
+      // Check if resource exists and aggregation exists
+      if (resource && aggregation) {
+        Object.assign(
+          mongooseFilter,
+          { resource: mongoose.Types.ObjectId(args.resource) },
+          { archived: { $ne: true } }
+        );
+      } else {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+
       pipeline.push({
-        $addFields: {
-          record_id: {
-            $toString: '$_id',
-          },
+        $match: {
+          $and: [mongooseFilter, permissionFilters],
         },
       });
-      // Loop on fields to apply lookups for special fields
-      for (const fieldName of aggregation.sourceFields) {
-        const field = resource.fields.find((x) => x.name === fieldName);
-        // If field is a calculated field
-        if (field && field.isCalculated) {
-          pipeline.unshift(
-            ...buildCalculatedFieldPipeline(field.expression, field.name)
-          );
-        }
 
-        // If we have resource(s) questions
+      // Build the source fields step
+      if (aggregation.sourceFields && aggregation.sourceFields.length) {
+        // If we have user fields
         if (
-          field &&
-          (field.type === 'resource' || field.type === 'resources')
+          aggregation.sourceFields.some((x) =>
+            defaultRecordFields.some(
+              (y) => (x === y.field && y.type === UserType) || y.field === 'form'
+            )
+          )
         ) {
-          if (field.type === 'resource') {
-            pipeline.push({
-              $addFields: {
-                [`data.${fieldName}`]: { $toObjectId: `$data.${fieldName}` },
-              },
-            });
-          } else {
-            pipeline.push({
-              $addFields: {
-                [`data.${fieldName}`]: {
-                  $map: {
-                    input: `$data.${fieldName}`,
-                    in: { $toObjectId: '$$this' },
-                  },
-                },
-              },
+          // Form
+          if (aggregation.sourceFields.includes('form')) {
+            const relatedForms = await Form.find({
+              resource: args.resource,
+            }).select('id name');
+            resource.fields.push({
+              name: 'form',
+              choices: relatedForms.map((x) => {
+                return { value: x.id, text: x.name };
+              }),
             });
           }
-          pipeline.push({
-            $lookup: {
-              from: 'records',
-              localField: `data.${fieldName}`,
-              foreignField: '_id',
-              as: `data.${fieldName}`,
-            },
-          });
-          if (field.type === 'resource') {
-            pipeline.push({
-              $unwind: `$data.${fieldName}`,
-            });
+          // Created By
+          if (aggregation.sourceFields.includes('createdBy')) {
+            pipeline = pipeline.concat(CREATED_BY_STAGES);
           }
-          pipeline.push({
-            $addFields: selectableDefaultRecordFieldsFlat.reduce(
-              (fields, selectableField) => {
-                if (!selectableField.includes('By')) {
-                  return Object.assign(fields, {
-                    [`data.${fieldName}.data.${selectableField}`]: `$data.${fieldName}.${selectableField}`,
-                  });
-                }
-                return fields;
-              },
-              {}
-            ),
-          });
-          pipeline.push({
-            $addFields: {
-              [`data.${fieldName}`]: `$data.${fieldName}.data`,
-            },
-          });
-        }
-        // If we have a field referring to another form with a question targeting our source
-        if (!field) {
-          const relatedField = relatedFields.find(
-            (x: any) => x.relatedName === fieldName
-          );
-          if (relatedField) {
+          // Last updated by
+          if (aggregation.sourceFields.includes('lastUpdatedBy')) {
+            if (!aggregation.sourceFields.includes('createdBy')) {
+              pipeline = pipeline.concat(CREATED_BY_STAGES);
+            }
             pipeline = pipeline.concat([
               {
+                $addFields: {
+                  lastVersion: {
+                    $last: '$versions',
+                  },
+                },
+              },
+              {
                 $lookup: {
-                  from: 'records',
-                  localField: 'record_id',
-                  foreignField: `data.${relatedField.name}`,
-                  as: `data.${fieldName}`,
+                  from: 'versions',
+                  localField: 'lastVersion',
+                  foreignField: '_id',
+                  as: 'lastVersion',
+                },
+              },
+              {
+                $lookup: {
+                  from: 'users',
+                  localField: 'lastVersion.createdBy',
+                  foreignField: '_id',
+                  as: 'lastUpdatedBy',
                 },
               },
               {
                 $addFields: {
-                  [`data.${fieldName}`]: {
-                    $filter: {
-                      input: `$data.${fieldName}`,
-                      cond: {
-                        $eq: ['$$this.form', relatedField.form],
-                      },
-                    },
+                  lastUpdatedBy: {
+                    $last: '$lastUpdatedBy',
                   },
                 },
               },
               {
-                $addFields: selectableDefaultRecordFieldsFlat.reduce(
-                  (fields, selectableField) => {
-                    if (!selectableField.includes('By')) {
-                      return Object.assign(fields, {
-                        [`data.${fieldName}.data.${selectableField}`]: `$data.${fieldName}.${selectableField}`,
-                      });
-                    }
-                    return fields;
-                  },
-                  {}
-                ),
-              },
-              {
                 $addFields: {
-                  [`data.${fieldName}`]: `$data.${fieldName}.data`,
+                  lastUpdatedBy: {
+                    $ifNull: ['$lastUpdatedBy', '$createdBy'],
+                  },
                 },
               },
             ]);
           }
         }
-        // If we have referenceData fields
-        if (field && field.referenceData && field.referenceData.id) {
-          const referenceData = await ReferenceData.findById(
-            field.referenceData.id
-          ).populate({
-            path: 'apiConfiguration',
-            model: 'ApiConfiguration',
-            select: { name: 1, endpoint: 1, graphQLEndpoint: 1 },
-          });
-          const referenceDataAggregation: any[] =
-            await buildReferenceDataAggregation(referenceData, field, context);
-          pipeline.push(...referenceDataAggregation);
-        }
-      }
-      pipeline.push({
-        $project: {
-          ...(aggregation.sourceFields as any[]).reduce(
-            (o, field) =>
-              Object.assign(o, {
-                [field]: selectableDefaultRecordFieldsFlat.includes(field)
-                  ? 1
-                  : `$data.${field}`,
-              }),
-            {}
-          ),
-        },
-      });
-    } else {
-      throw new GraphQLError(
-        context.i18next.t('query.records.aggregation.errors.invalidAggregation')
-      );
-    }
-    // Build pipeline stages
-    if (aggregation.pipeline && aggregation.pipeline.length) {
-      buildPipeline(pipeline, aggregation.pipeline, resource, context);
-    }
-    // Build mapping step
-    if (args.mapping) {
-      pipeline.push({
-        $project: {
-          category: `$${args.mapping.category}`,
-          field: `$${args.mapping.field}`,
-          id: '$_id',
-          ...(args.mapping.series && {
-            series: `$${args.mapping.series}`,
-          }),
-        },
-      });
-    } else {
-      // Only sending some examples of the queried data
-      pipeline.push({
-        $addFields: {
-          id: '$_id',
-        },
-      });
-      pipeline.push({
-        $facet: {
-          items: [{ $skip: skip }, { $limit: first }],
-          totalCount: [
-            {
-              $count: 'count',
+        // Fetch related fields from other forms
+        const relatedFields: any[] = await Form.aggregate([
+          {
+            $match: {
+              fields: {
+                $elemMatch: {
+                  resource: String(args.resource),
+                  $or: [
+                    {
+                      type: 'resource',
+                    },
+                    {
+                      type: 'resources',
+                    },
+                  ],
+                },
+              },
             },
-          ],
-        },
-      });
-    }
-    // Get aggregated data
-    const recordAggregation = await Record.aggregate(pipeline);
-    let items;
-    let totalCount;
-    if (args.mapping) {
-      items = recordAggregation;
-      totalCount = recordAggregation.length;
-    } else {
-      items = recordAggregation[0].items;
-      totalCount = recordAggregation[0]?.totalCount[0]?.count || 0;
-    }
-    const copiedItems = cloneDeep(items);
+          },
+          {
+            $unwind: '$fields',
+          },
+          {
+            $match: {
+              'fields.resource': String(args.resource),
+              $or: [
+                {
+                  'fields.type': 'resource',
+                },
+                {
+                  'fields.type': 'resources',
+                },
+              ],
+            },
+          },
+          {
+            $addFields: {
+              'fields.form': '$_id',
+            },
+          },
+          {
+            $replaceRoot: {
+              newRoot: '$fields',
+            },
+          },
+        ]);
+        pipeline.push({
+          $addFields: {
+            record_id: {
+              $toString: '$_id',
+            },
+          },
+        });
+        // Loop on fields to apply lookups for special fields
+        for (const fieldName of aggregation.sourceFields) {
+          const field = resource.fields.find((x) => x.name === fieldName);
+          // If field is a calculated field
+          if (field && field.isCalculated) {
+            pipeline.unshift(
+              ...buildCalculatedFieldPipeline(field.expression, field.name)
+            );
+          }
 
-    // For each detected field with choices, set the value of each entry to be display text value and then return
-    try {
-      if (args.mapping && args.mapping.category && args.mapping.field) {
-        const mappedFields = [
-          { key: 'category', value: args.mapping.category },
-          { key: 'field', value: args.mapping.field },
-        ];
-        if (args.mapping.series) {
-          mappedFields.push({
-            key: 'series',
-            value: args.mapping.series,
-          });
+          // If we have resource(s) questions
+          if (
+            field &&
+            (field.type === 'resource' || field.type === 'resources')
+          ) {
+            if (field.type === 'resource') {
+              pipeline.push({
+                $addFields: {
+                  [`data.${fieldName}`]: { $toObjectId: `$data.${fieldName}` },
+                },
+              });
+            } else {
+              pipeline.push({
+                $addFields: {
+                  [`data.${fieldName}`]: {
+                    $map: {
+                      input: `$data.${fieldName}`,
+                      in: { $toObjectId: '$$this' },
+                    },
+                  },
+                },
+              });
+            }
+            pipeline.push({
+              $lookup: {
+                from: 'records',
+                localField: `data.${fieldName}`,
+                foreignField: '_id',
+                as: `data.${fieldName}`,
+              },
+            });
+            if (field.type === 'resource') {
+              pipeline.push({
+                $unwind: `$data.${fieldName}`,
+              });
+            }
+            pipeline.push({
+              $addFields: selectableDefaultRecordFieldsFlat.reduce(
+                (fields, selectableField) => {
+                  if (!selectableField.includes('By')) {
+                    return Object.assign(fields, {
+                      [`data.${fieldName}.data.${selectableField}`]: `$data.${fieldName}.${selectableField}`,
+                    });
+                  }
+                  return fields;
+                },
+                {}
+              ),
+            });
+            pipeline.push({
+              $addFields: {
+                [`data.${fieldName}`]: `$data.${fieldName}.data`,
+              },
+            });
+          }
+          // If we have a field referring to another form with a question targeting our source
+          if (!field) {
+            const relatedField = relatedFields.find(
+              (x: any) => x.relatedName === fieldName
+            );
+            if (relatedField) {
+              pipeline = pipeline.concat([
+                {
+                  $lookup: {
+                    from: 'records',
+                    localField: 'record_id',
+                    foreignField: `data.${relatedField.name}`,
+                    as: `data.${fieldName}`,
+                  },
+                },
+                {
+                  $addFields: {
+                    [`data.${fieldName}`]: {
+                      $filter: {
+                        input: `$data.${fieldName}`,
+                        cond: {
+                          $eq: ['$$this.form', relatedField.form],
+                        },
+                      },
+                    },
+                  },
+                },
+                {
+                  $addFields: selectableDefaultRecordFieldsFlat.reduce(
+                    (fields, selectableField) => {
+                      if (!selectableField.includes('By')) {
+                        return Object.assign(fields, {
+                          [`data.${fieldName}.data.${selectableField}`]: `$data.${fieldName}.${selectableField}`,
+                        });
+                      }
+                      return fields;
+                    },
+                    {}
+                  ),
+                },
+                {
+                  $addFields: {
+                    [`data.${fieldName}`]: `$data.${fieldName}.data`,
+                  },
+                },
+              ]);
+            }
+          }
+          // If we have referenceData fields
+          if (field && field.referenceData && field.referenceData.id) {
+            const referenceData = await ReferenceData.findById(
+              field.referenceData.id
+            ).populate({
+              path: 'apiConfiguration',
+              model: 'ApiConfiguration',
+              select: { name: 1, endpoint: 1, graphQLEndpoint: 1 },
+            });
+            const referenceDataAggregation: any[] =
+              await buildReferenceDataAggregation(referenceData, field, context);
+            pipeline.push(...referenceDataAggregation);
+          }
         }
-        await setDisplayText(mappedFields, copiedItems, resource, context);
-        return copiedItems;
+        pipeline.push({
+          $project: {
+            ...(aggregation.sourceFields as any[]).reduce(
+              (o, field) =>
+                Object.assign(o, {
+                  [field]: selectableDefaultRecordFieldsFlat.includes(field)
+                    ? 1
+                    : `$data.${field}`,
+                }),
+              {}
+            ),
+          },
+        });
       } else {
-        const mappedFields = Object.keys(items[0]).map((key) => ({
-          key,
-          value: key,
-        }));
-        await setDisplayText(mappedFields, copiedItems, resource, context);
-        return { items: copiedItems, totalCount };
+        throw new GraphQLError(
+          context.i18next.t('query.records.aggregation.errors.invalidAggregation')
+        );
       }
-    } catch (err) {
+      // Build pipeline stages
+      if (aggregation.pipeline && aggregation.pipeline.length) {
+        buildPipeline(pipeline, aggregation.pipeline, resource, context);
+      }
+      // Build mapping step
+      if (args.mapping) {
+        pipeline.push({
+          $project: {
+            category: `$${args.mapping.category}`,
+            field: `$${args.mapping.field}`,
+            id: '$_id',
+            ...(args.mapping.series && {
+              series: `$${args.mapping.series}`,
+            }),
+          },
+        });
+      } else {
+        // Only sending some examples of the queried data
+        pipeline.push({
+          $addFields: {
+            id: '$_id',
+          },
+        });
+        pipeline.push({
+          $facet: {
+            items: [{ $skip: skip }, { $limit: first }],
+            totalCount: [
+              {
+                $count: 'count',
+              },
+            ],
+          },
+        });
+      }
+      // Get aggregated data
+      const recordAggregation = await Record.aggregate(pipeline);
+      let items;
+      let totalCount;
+      if (args.mapping) {
+        items = recordAggregation;
+        totalCount = recordAggregation.length;
+      } else {
+        items = recordAggregation[0].items;
+        totalCount = recordAggregation[0]?.totalCount[0]?.count || 0;
+      }
+      const copiedItems = cloneDeep(items);
+
+      // For each detected field with choices, set the value of each entry to be display text value and then return
+      try {
+        if (args.mapping && args.mapping.category && args.mapping.field) {
+          const mappedFields = [
+            { key: 'category', value: args.mapping.category },
+            { key: 'field', value: args.mapping.field },
+          ];
+          if (args.mapping.series) {
+            mappedFields.push({
+              key: 'series',
+              value: args.mapping.series,
+            });
+          }
+          await setDisplayText(mappedFields, copiedItems, resource, context);
+          return copiedItems;
+        } else {
+          const mappedFields = Object.keys(items[0]).map((key) => ({
+            key,
+            value: key,
+          }));
+          await setDisplayText(mappedFields, copiedItems, resource, context);
+          return { items: copiedItems, totalCount };
+        }
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+        return args.mapping ? items : { items, totalCount };
+      }
+    }catch (err){
       logger.error(err.message, { stack: err.stack });
-      return args.mapping ? items : { items, totalCount };
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
   },
 };

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -68,7 +68,9 @@ export default {
         fields: 1,
         aggregations: 1,
       });
-
+      if (!resource){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       // Check abilities
       const ability = await extendAbilityForRecords(user);
       const permissionFilters = Record.accessibleBy(ability, 'read').getFilter();
@@ -342,6 +344,9 @@ export default {
               model: 'ApiConfiguration',
               select: { name: 1, endpoint: 1, graphQLEndpoint: 1 },
             });
+            if (!referenceData){
+              throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+            }
             const referenceDataAggregation: any[] =
               await buildReferenceDataAggregation(referenceData, field, context);
             pipeline.push(...referenceDataAggregation);

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -49,11 +49,13 @@ export default {
     skip: { type: GraphQLInt },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // global variables
@@ -68,12 +70,15 @@ export default {
         fields: 1,
         aggregations: 1,
       });
-      if (!resource){
+      if (!resource) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       // Check abilities
       const ability = await extendAbilityForRecords(user);
-      const permissionFilters = Record.accessibleBy(ability, 'read').getFilter();
+      const permissionFilters = Record.accessibleBy(
+        ability,
+        'read'
+      ).getFilter();
 
       // As we only queried one aggregation
       const aggregation = resource.aggregations.find((x) =>
@@ -103,7 +108,8 @@ export default {
         if (
           aggregation.sourceFields.some((x) =>
             defaultRecordFields.some(
-              (y) => (x === y.field && y.type === UserType) || y.field === 'form'
+              (y) =>
+                (x === y.field && y.type === UserType) || y.field === 'form'
             )
           )
         ) {
@@ -344,11 +350,17 @@ export default {
               model: 'ApiConfiguration',
               select: { name: 1, endpoint: 1, graphQLEndpoint: 1 },
             });
-            if (!referenceData){
-              throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+            if (!referenceData) {
+              throw new GraphQLError(
+                context.i18next.t('common.errors.dataNotFound')
+              );
             }
             const referenceDataAggregation: any[] =
-              await buildReferenceDataAggregation(referenceData, field, context);
+              await buildReferenceDataAggregation(
+                referenceData,
+                field,
+                context
+              );
             pipeline.push(...referenceDataAggregation);
           }
         }
@@ -367,7 +379,9 @@ export default {
         });
       } else {
         throw new GraphQLError(
-          context.i18next.t('query.records.aggregation.errors.invalidAggregation')
+          context.i18next.t(
+            'query.records.aggregation.errors.invalidAggregation'
+          )
         );
       }
       // Build pipeline stages
@@ -444,7 +458,7 @@ export default {
         logger.error(err.message, { stack: err.stack });
         return args.mapping ? items : { items, totalCount };
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/referenceData.query.ts
+++ b/src/schema/query/referenceData.query.ts
@@ -13,18 +13,20 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
       const referenceData = ReferenceData.findById(args.id);
-      if (!referenceData){
+      if (!referenceData) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
-      return referenceData;
-    }catch (err){
+      return await referenceData;
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/referenceData.query.ts
+++ b/src/schema/query/referenceData.query.ts
@@ -19,7 +19,11 @@ export default {
       if (!user) {
         throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-      return ReferenceData.findById(args.id);
+      const referenceData = ReferenceData.findById(args.id);
+      if (!referenceData){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+      return referenceData;
     }catch (err){
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(

--- a/src/schema/query/referenceData.query.ts
+++ b/src/schema/query/referenceData.query.ts
@@ -1,6 +1,7 @@
 import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { ReferenceDataType } from '../types';
 import { ReferenceData } from '@models';
+import { logger } from '@services/logger.service';
 
 /**
  * Return Reference Data from id if available for the logged user.
@@ -12,11 +13,18 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+      return ReferenceData.findById(args.id);
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    return ReferenceData.findById(args.id);
   },
 };

--- a/src/schema/query/referenceDatas.query.ts
+++ b/src/schema/query/referenceDatas.query.ts
@@ -22,11 +22,13 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -68,7 +70,7 @@ export default {
         edges,
         totalCount: await ReferenceData.countDocuments({ $and: filters }),
       };
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/referenceDatas.query.ts
+++ b/src/schema/query/referenceDatas.query.ts
@@ -6,6 +6,7 @@ import {
 } from '../types';
 import { ReferenceData } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /** Pagination default items per query */
 const DEFAULT_FIRST = 10;
@@ -21,50 +22,57 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
+
+      const ability: AppAbility = context.user.ability;
+
+      const abilityFilters = ReferenceData.accessibleBy(
+        ability,
+        'read'
+      ).getFilter();
+      const filters: any[] = [abilityFilters];
+
+      const first = args.first || DEFAULT_FIRST;
+      const afterCursor = args.afterCursor;
+      const cursorFilters = afterCursor
+        ? {
+            _id: {
+              $gt: decodeCursor(afterCursor),
+            },
+          }
+        : {};
+
+      let items: any[] = await ReferenceData.find({
+        $and: [cursorFilters, ...filters],
+      }).limit(first + 1);
+
+      const hasNextPage = items.length > first;
+      if (hasNextPage) {
+        items = items.slice(0, items.length - 1);
+      }
+      const edges = items.map((r) => ({
+        cursor: encodeCursor(r.id.toString()),
+        node: r,
+      }));
+      return {
+        pageInfo: {
+          hasNextPage,
+          startCursor: edges.length > 0 ? edges[0].cursor : null,
+          endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+        },
+        edges,
+        totalCount: await ReferenceData.countDocuments({ $and: filters }),
+      };
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-
-    const ability: AppAbility = context.user.ability;
-
-    const abilityFilters = ReferenceData.accessibleBy(
-      ability,
-      'read'
-    ).getFilter();
-    const filters: any[] = [abilityFilters];
-
-    const first = args.first || DEFAULT_FIRST;
-    const afterCursor = args.afterCursor;
-    const cursorFilters = afterCursor
-      ? {
-          _id: {
-            $gt: decodeCursor(afterCursor),
-          },
-        }
-      : {};
-
-    let items: any[] = await ReferenceData.find({
-      $and: [cursorFilters, ...filters],
-    }).limit(first + 1);
-
-    const hasNextPage = items.length > first;
-    if (hasNextPage) {
-      items = items.slice(0, items.length - 1);
-    }
-    const edges = items.map((r) => ({
-      cursor: encodeCursor(r.id.toString()),
-      node: r,
-    }));
-    return {
-      pageInfo: {
-        hasNextPage,
-        startCursor: edges.length > 0 ? edges[0].cursor : null,
-        endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
-      },
-      edges,
-      totalCount: await ReferenceData.countDocuments({ $and: filters }),
-    };
   },
 };

--- a/src/schema/query/resource.query.ts
+++ b/src/schema/query/resource.query.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { ResourceType } from '../types';
 import { Resource } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Return resource from id if available for the logged user.
@@ -13,20 +14,33 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    const ability: AppAbility = user.ability;
-    const resource = await Resource.findOne({ _id: args.id });
+      const ability: AppAbility = user.ability;
+      const resource = await Resource.findOne({ _id: args.id });
 
-    if (ability.cannot('read', resource)) {
+      if(!resource){
+        throw new GraphQLError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
+      }
+
+      if (ability.cannot('read', resource)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      return resource;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-    return resource;
   },
 };

--- a/src/schema/query/resource.query.ts
+++ b/src/schema/query/resource.query.ts
@@ -14,20 +14,20 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = user.ability;
       const resource = await Resource.findOne({ _id: args.id });
 
-      if(!resource){
-        throw new GraphQLError(
-          context.i18next.t('common.errors.dataNotFound')
-        );
+      if (!resource) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
 
       if (ability.cannot('read', resource)) {
@@ -36,7 +36,7 @@ export default {
         );
       }
       return resource;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/resources.query.ts
+++ b/src/schema/query/resources.query.ts
@@ -5,6 +5,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import GraphQLJSON from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
+import { logger } from '@services/logger.service';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -73,61 +74,68 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    const ability: AppAbility = user.ability;
-
-    // Inputs check
-    if (args.sortField) {
-      if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
-        throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
+
+      const ability: AppAbility = user.ability;
+
+      // Inputs check
+      if (args.sortField) {
+        if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
+          throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
+        }
+      }
+
+      const abilityFilters = Resource.accessibleBy(ability, 'read').getFilter();
+      const queryFilters = getFilter(args.filter, FILTER_FIELDS);
+      const filters: any[] = [queryFilters, abilityFilters];
+
+      const first = args.first || DEFAULT_FIRST;
+      const afterCursor = args.afterCursor;
+
+      const sortField =
+        SORT_FIELDS.find((x) => x.name === args.sortField) ||
+        SORT_FIELDS.find((x) => x.name === 'createdAt');
+      const sortOrder = args.sortOrder || 'asc';
+
+      const cursorFilters = afterCursor
+        ? sortField.cursorFilter(afterCursor, sortOrder)
+        : {};
+
+      let items: any[] = await Resource.find({
+        $and: [cursorFilters, ...filters],
+      })
+        .sort(sortField.sort(sortOrder))
+        .limit(first + 1);
+
+      const hasNextPage = items.length > first;
+      if (hasNextPage) {
+        items = items.slice(0, items.length - 1);
+      }
+
+      const edges = items.map((r) => ({
+        cursor: encodeCursor(sortField.cursorId(r)),
+        node: r,
+      }));
+
+      return {
+        pageInfo: {
+          hasNextPage,
+          startCursor: edges.length > 0 ? edges[0].cursor : null,
+          endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+        },
+        edges,
+        totalCount: await Resource.countDocuments({ $and: filters }),
+      };
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-
-    const abilityFilters = Resource.accessibleBy(ability, 'read').getFilter();
-    const queryFilters = getFilter(args.filter, FILTER_FIELDS);
-    const filters: any[] = [queryFilters, abilityFilters];
-
-    const first = args.first || DEFAULT_FIRST;
-    const afterCursor = args.afterCursor;
-
-    const sortField =
-      SORT_FIELDS.find((x) => x.name === args.sortField) ||
-      SORT_FIELDS.find((x) => x.name === 'createdAt');
-    const sortOrder = args.sortOrder || 'asc';
-
-    const cursorFilters = afterCursor
-      ? sortField.cursorFilter(afterCursor, sortOrder)
-      : {};
-
-    let items: any[] = await Resource.find({
-      $and: [cursorFilters, ...filters],
-    })
-      .sort(sortField.sort(sortOrder))
-      .limit(first + 1);
-
-    const hasNextPage = items.length > first;
-    if (hasNextPage) {
-      items = items.slice(0, items.length - 1);
-    }
-
-    const edges = items.map((r) => ({
-      cursor: encodeCursor(sortField.cursorId(r)),
-      node: r,
-    }));
-
-    return {
-      pageInfo: {
-        hasNextPage,
-        startCursor: edges.length > 0 ? edges[0].cursor : null,
-        endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
-      },
-      edges,
-      totalCount: await Resource.countDocuments({ $and: filters }),
-    };
   },
 };

--- a/src/schema/query/resources.query.ts
+++ b/src/schema/query/resources.query.ts
@@ -74,11 +74,13 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = user.ability;
@@ -131,7 +133,7 @@ export default {
         edges,
         totalCount: await Resource.countDocuments({ $and: filters }),
       };
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/role.query.ts
+++ b/src/schema/query/role.query.ts
@@ -2,6 +2,7 @@ import { GraphQLID, GraphQLError, GraphQLNonNull } from 'graphql';
 import { Role } from '@models';
 import { RoleType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
+import { logger } from '@services/logger.service';
 
 /**
  * Get Query by ID.
@@ -13,30 +14,37 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    const ability: AppAbility = context.user.ability;
-    if (ability.can('read', 'Role')) {
-      try {
-        const role = await Role.accessibleBy(ability, 'read').findOne({
-          _id: args.id,
-        });
-        if (!role) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
-        }
-        return role;
-      } catch {
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
       }
-    } else {
+
+      const ability: AppAbility = context.user.ability;
+      if (ability.can('read', 'Role')) {
+        try {
+          const role = await Role.accessibleBy(ability, 'read').findOne({
+            _id: args.id,
+          });
+          if (!role) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
+          }
+          return role;
+        } catch {
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+      } else {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
   },

--- a/src/schema/query/role.query.ts
+++ b/src/schema/query/role.query.ts
@@ -14,11 +14,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       const ability: AppAbility = context.user.ability;
@@ -34,14 +36,16 @@ export default {
           }
           return role;
         } catch {
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/step.query.ts
+++ b/src/schema/query/step.query.ts
@@ -14,16 +14,18 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // get data and check permissions
       const step = await Step.findById(args.id);
-      if (!step){
+      if (!step) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const ability = await extendAbilityForStep(user, step);
@@ -34,7 +36,7 @@ export default {
       }
 
       return step;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/step.query.ts
+++ b/src/schema/query/step.query.ts
@@ -23,6 +23,9 @@ export default {
 
       // get data and check permissions
       const step = await Step.findById(args.id);
+      if (!step){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const ability = await extendAbilityForStep(user, step);
       if (ability.cannot('read', step)) {
         throw new GraphQLError(

--- a/src/schema/query/workflow.query.ts
+++ b/src/schema/query/workflow.query.ts
@@ -3,6 +3,7 @@ import { WorkflowType } from '../types';
 import mongoose from 'mongoose';
 import { Workflow, Step } from '@models';
 import extendAbilityForContent from '@security/extendAbilityForContent';
+import { logger } from '@services/logger.service';
 
 /**
  * Returns workflow from id if available for the logged user.
@@ -15,41 +16,48 @@ export default {
     asRole: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
+    try{
+      // Authentication check
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+      }
 
-    // get data and check permissions
-    const workflow = await Workflow.findById(args.id);
-    const ability = await extendAbilityForContent(user, workflow);
-    if (ability.cannot('read', workflow)) {
+      // get data and check permissions
+      const workflow = await Workflow.findById(args.id);
+      const ability = await extendAbilityForContent(user, workflow);
+      if (ability.cannot('read', workflow)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      if (args.asRole) {
+        const steps = await Step.aggregate([
+          {
+            $match: {
+              'permissions.canSee': {
+                $elemMatch: { $eq: mongoose.Types.ObjectId(args.asRole) },
+              },
+              _id: { $in: workflow.steps },
+            },
+          },
+          {
+            $addFields: {
+              __order: { $indexOfArray: [workflow.steps, '$_id'] },
+            },
+          },
+          { $sort: { __order: 1 } },
+        ]);
+        workflow.steps = steps.map((x) => x._id);
+      }
+
+      return workflow;
+    }catch (err){
+      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
+        context.i18next.t('common.errors.internalServerError')
       );
     }
-
-    if (args.asRole) {
-      const steps = await Step.aggregate([
-        {
-          $match: {
-            'permissions.canSee': {
-              $elemMatch: { $eq: mongoose.Types.ObjectId(args.asRole) },
-            },
-            _id: { $in: workflow.steps },
-          },
-        },
-        {
-          $addFields: {
-            __order: { $indexOfArray: [workflow.steps, '$_id'] },
-          },
-        },
-        { $sort: { __order: 1 } },
-      ]);
-      workflow.steps = steps.map((x) => x._id);
-    }
-
-    return workflow;
   },
 };

--- a/src/schema/query/workflow.query.ts
+++ b/src/schema/query/workflow.query.ts
@@ -25,6 +25,9 @@ export default {
 
       // get data and check permissions
       const workflow = await Workflow.findById(args.id);
+      if (!workflow){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const ability = await extendAbilityForContent(user, workflow);
       if (ability.cannot('read', workflow)) {
         throw new GraphQLError(

--- a/src/schema/query/workflow.query.ts
+++ b/src/schema/query/workflow.query.ts
@@ -16,16 +16,18 @@ export default {
     asRole: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try{
+    try {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
       // get data and check permissions
       const workflow = await Workflow.findById(args.id);
-      if (!workflow){
+      if (!workflow) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const ability = await extendAbilityForContent(user, workflow);
@@ -56,7 +58,7 @@ export default {
       }
 
       return workflow;
-    }catch (err){
+    } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/types/application.type.ts
+++ b/src/schema/types/application.type.ts
@@ -5,7 +5,7 @@ import {
   GraphQLList,
   GraphQLInt,
   GraphQLBoolean,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import {
@@ -66,9 +66,14 @@ export const ApplicationType = new GraphQLObjectType({
       type: UserType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const user = User.findById(parent.isLockedBy).accessibleBy(ability, 'read');
-        if (!user){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const user = User.findById(parent.isLockedBy).accessibleBy(
+          ability,
+          'read'
+        );
+        if (!user) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return user;
       },
@@ -84,14 +89,19 @@ export const ApplicationType = new GraphQLObjectType({
     createdBy: {
       type: UserType,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability: AppAbility = context.user.ability;
-          const user = User.findById(parent.createdBy).accessibleBy(ability, 'read');
-          if (!user){
-            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          const user = User.findById(parent.createdBy).accessibleBy(
+            ability,
+            'read'
+          );
+          if (!user) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
           }
-          return user;
-        }catch (err){
+          return await user;
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -131,21 +141,21 @@ export const ApplicationType = new GraphQLObjectType({
     userRoles: {
       type: new GraphQLList(RoleType),
       async resolve(parent, args, context) {
-        try{
+        try {
           const user = context.user;
           // First get roles manually assigned to user
           const manualRoles: Role[] = user.roles.filter(
             (x) => x.application && x.application.equals(parent.id)
           );
-  
+
           // Then get roles automatically assigned to user
           const autoRoles = (await getAutoAssignedRoles(user)).filter(
             (x) => x.application && x.application.equals(parent.id)
           );
-  
+
           // Filter out roles that are already assigned manually
           return uniqBy([...manualRoles, ...autoRoles], '_id');
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')

--- a/src/schema/types/application.type.ts
+++ b/src/schema/types/application.type.ts
@@ -66,7 +66,11 @@ export const ApplicationType = new GraphQLObjectType({
       type: UserType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return User.findById(parent.isLockedBy).accessibleBy(ability, 'read');
+        const user = User.findById(parent.isLockedBy).accessibleBy(ability, 'read');
+        if (!user){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return user;
       },
     },
     lockedByUser: {
@@ -82,7 +86,11 @@ export const ApplicationType = new GraphQLObjectType({
       async resolve(parent, args, context) {
         try{
           const ability: AppAbility = context.user.ability;
-          return User.findById(parent.createdBy).accessibleBy(ability, 'read');
+          const user = User.findById(parent.createdBy).accessibleBy(ability, 'read');
+          if (!user){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
+          return user;
         }catch (err){
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(

--- a/src/schema/types/channel.type.ts
+++ b/src/schema/types/channel.type.ts
@@ -3,7 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLList,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import { Application, Role, Form } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
@@ -22,14 +22,15 @@ export const ChannelType = new GraphQLObjectType({
       type: ApplicationType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const application = Application.findById(parent.application).accessibleBy(
-          ability,
-          'read'
-        );
-        if (!application){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const application = Application.findById(
+          parent.application
+        ).accessibleBy(ability, 'read');
+        if (!application) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
-        return application
+        return application;
       },
     },
     subscribedRoles: {
@@ -46,8 +47,10 @@ export const ChannelType = new GraphQLObjectType({
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
         const form = Form.findById(parent._id).accessibleBy(ability, 'read');
-        if (!form){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!form) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return form;
       },

--- a/src/schema/types/channel.type.ts
+++ b/src/schema/types/channel.type.ts
@@ -3,6 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLList,
+  GraphQLError
 } from 'graphql';
 import { Application, Role, Form } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
@@ -21,10 +22,14 @@ export const ChannelType = new GraphQLObjectType({
       type: ApplicationType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return Application.findById(parent.application).accessibleBy(
+        const application = Application.findById(parent.application).accessibleBy(
           ability,
           'read'
         );
+        if (!application){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return application
       },
     },
     subscribedRoles: {
@@ -40,7 +45,11 @@ export const ChannelType = new GraphQLObjectType({
       type: FormType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return Form.findById(parent._id).accessibleBy(ability, 'read');
+        const form = Form.findById(parent._id).accessibleBy(ability, 'read');
+        if (!form){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return form;
       },
     },
     routingKey: {

--- a/src/schema/types/dashboard.type.ts
+++ b/src/schema/types/dashboard.type.ts
@@ -3,7 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLBoolean,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import { AccessType, PageType, StepType } from '.';
@@ -25,7 +25,7 @@ export const DashboardType = new GraphQLObjectType({
     permissions: {
       type: AccessType,
       async resolve(parent, args, context) {
-        try{
+        try {
           const parentId = parent.id || parent._id;
           const ability = await extendAbilityForContent(context.user, parent);
           if (ability.can('update', parent)) {
@@ -35,21 +35,21 @@ export const DashboardType = new GraphQLObjectType({
                 { contentWithContext: { $elemMatch: { content: parentId } } },
               ],
             });
-            if (page){
-              return page.permissions
-            }else{
+            if (page) {
+              return page.permissions;
+            } else {
               const step = await Step.findOne({ content: parentId });
-              if(!step){
+              if (!step) {
                 throw new GraphQLError(
                   context.i18next.t('common.errors.dataNotFound')
                 );
-              }else{
+              } else {
                 return step.permissions;
               }
             }
           }
           return null;
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -60,7 +60,7 @@ export const DashboardType = new GraphQLObjectType({
     page: {
       type: PageType,
       async resolve(parent, args, context) {
-        try{
+        try {
           const parentId = parent.id || parent._id;
           const page = await Page.findOne({
             $or: [
@@ -68,17 +68,17 @@ export const DashboardType = new GraphQLObjectType({
               { contentWithContext: { $elemMatch: { content: parentId } } },
             ],
           });
-          if(!page){
+          if (!page) {
             throw new GraphQLError(
               context.i18next.t('common.errors.dataNotFound')
             );
-          }else{
+          } else {
             const ability = await extendAbilityForPage(context.user, page);
             if (ability.can('read', page)) {
               return page;
             }
           }
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -89,19 +89,19 @@ export const DashboardType = new GraphQLObjectType({
     step: {
       type: StepType,
       async resolve(parent, args, context) {
-        try{
+        try {
           const step = await Step.findOne({ content: parent.id || parent._id });
-          if(!step){
+          if (!step) {
             throw new GraphQLError(
               context.i18next.t('common.errors.dataNotFound')
             );
-          }else{
+          } else {
             const ability = await extendAbilityForStep(context.user, step);
             if (ability.can('read', step)) {
               return step;
             }
           }
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -112,10 +112,10 @@ export const DashboardType = new GraphQLObjectType({
     canSee: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForContent(context.user, parent);
           return ability.can('read', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -126,10 +126,10 @@ export const DashboardType = new GraphQLObjectType({
     canUpdate: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForContent(context.user, parent);
           return ability.can('update', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -140,10 +140,10 @@ export const DashboardType = new GraphQLObjectType({
     canDelete: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForContent(context.user, parent);
           return ability.can('delete', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')

--- a/src/schema/types/dashboard.type.ts
+++ b/src/schema/types/dashboard.type.ts
@@ -3,6 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLBoolean,
+  GraphQLError
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import { AccessType, PageType, StepType } from '.';
@@ -10,6 +11,7 @@ import { Page, Step } from '@models';
 import extendAbilityForContent from '@security/extendAbilityForContent';
 import extendAbilityForPage from '@security/extendAbilityForPage';
 import extendAbilityForStep from '@security/extendAbilityForStep';
+import { logger } from '@services/logger.service';
 
 /** GraphQL dashboard type definition */
 export const DashboardType = new GraphQLObjectType({
@@ -23,67 +25,130 @@ export const DashboardType = new GraphQLObjectType({
     permissions: {
       type: AccessType,
       async resolve(parent, args, context) {
-        const parentId = parent.id || parent._id;
-        const ability = await extendAbilityForContent(context.user, parent);
-        if (ability.can('update', parent)) {
+        try{
+          const parentId = parent.id || parent._id;
+          const ability = await extendAbilityForContent(context.user, parent);
+          if (ability.can('update', parent)) {
+            const page = await Page.findOne({
+              $or: [
+                { content: parentId },
+                { contentWithContext: { $elemMatch: { content: parentId } } },
+              ],
+            });
+            if (page){
+              return page.permissions
+            }else{
+              const step = await Step.findOne({ content: parentId });
+              if(!step){
+                throw new GraphQLError(
+                  context.i18next.t('common.errors.dataNotFound')
+                );
+              }else{
+                return step.permissions;
+              }
+            }
+          }
+          return null;
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
+      },
+    },
+    page: {
+      type: PageType,
+      async resolve(parent, args, context) {
+        try{
+          const parentId = parent.id || parent._id;
           const page = await Page.findOne({
             $or: [
               { content: parentId },
               { contentWithContext: { $elemMatch: { content: parentId } } },
             ],
           });
-          if (page) return page.permissions;
-          const step = await Step.findOne({ content: parentId });
-          return step.permissions;
-        }
-        return null;
-      },
-    },
-    page: {
-      type: PageType,
-      async resolve(parent, args, context) {
-        const parentId = parent.id || parent._id;
-        const page = await Page.findOne({
-          $or: [
-            { content: parentId },
-            { contentWithContext: { $elemMatch: { content: parentId } } },
-          ],
-        });
-        const ability = await extendAbilityForPage(context.user, page);
-        if (ability.can('read', page)) {
-          return page;
+          if(!page){
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
+          }else{
+            const ability = await extendAbilityForPage(context.user, page);
+            if (ability.can('read', page)) {
+              return page;
+            }
+          }
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
         }
       },
     },
     step: {
       type: StepType,
       async resolve(parent, args, context) {
-        const step = await Step.findOne({ content: parent.id || parent._id });
-        const ability = await extendAbilityForStep(context.user, step);
-        if (ability.can('read', step)) {
-          return step;
+        try{
+          const step = await Step.findOne({ content: parent.id || parent._id });
+          if(!step){
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
+          }else{
+            const ability = await extendAbilityForStep(context.user, step);
+            if (ability.can('read', step)) {
+              return step;
+            }
+          }
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
         }
       },
     },
     canSee: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        const ability = await extendAbilityForContent(context.user, parent);
-        return ability.can('read', parent);
+        try{
+          const ability = await extendAbilityForContent(context.user, parent);
+          return ability.can('read', parent);
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
       },
     },
     canUpdate: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        const ability = await extendAbilityForContent(context.user, parent);
-        return ability.can('update', parent);
+        try{
+          const ability = await extendAbilityForContent(context.user, parent);
+          return ability.can('update', parent);
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
       },
     },
     canDelete: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        const ability = await extendAbilityForContent(context.user, parent);
-        return ability.can('delete', parent);
+        try{
+          const ability = await extendAbilityForContent(context.user, parent);
+          return ability.can('delete', parent);
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
       },
     },
   }),

--- a/src/schema/types/form.type.ts
+++ b/src/schema/types/form.type.ts
@@ -67,7 +67,11 @@ export const FormType = new GraphQLObjectType({
       type: ResourceType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return Resource.findById(parent.resource).accessibleBy(ability, 'read');
+        const resource = Resource.findById(parent.resource).accessibleBy(ability, 'read');
+        if (!resource){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return resource;
       },
     },
     core: {

--- a/src/schema/types/form.type.ts
+++ b/src/schema/types/form.type.ts
@@ -5,7 +5,7 @@ import {
   GraphQLBoolean,
   GraphQLList,
   GraphQLInt,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import {
@@ -52,10 +52,10 @@ export const FormType = new GraphQLObjectType({
     permissions: {
       type: AccessType,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForContent(context.user, parent);
           return ability.can('update', parent) ? parent.permissions : null;
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -67,9 +67,14 @@ export const FormType = new GraphQLObjectType({
       type: ResourceType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const resource = Resource.findById(parent.resource).accessibleBy(ability, 'read');
-        if (!resource){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const resource = Resource.findById(parent.resource).accessibleBy(
+          ability,
+          'read'
+        );
+        if (!resource) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return resource;
       },
@@ -89,7 +94,7 @@ export const FormType = new GraphQLObjectType({
         archived: { type: GraphQLBoolean },
       },
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForRecords(context.user, parent);
           let mongooseFilter: any = {
             form: parent.id,
@@ -136,14 +141,16 @@ export const FormType = new GraphQLObjectType({
             pageInfo: {
               hasNextPage,
               startCursor: edges.length > 0 ? edges[0].cursor : null,
-              endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+              endCursor:
+                edges.length > 0 ? edges[edges.length - 1].cursor : null,
             },
             edges,
-            totalCount: await Record.accessibleBy(ability, 'read').countDocuments(
-              { $and: [mongooseFilter, permissionFilters] }
-            ),
+            totalCount: await Record.accessibleBy(
+              ability,
+              'read'
+            ).countDocuments({ $and: [mongooseFilter, permissionFilters] }),
           };
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -154,12 +161,12 @@ export const FormType = new GraphQLObjectType({
     recordsCount: {
       type: GraphQLInt,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForRecords(context.user, parent);
-          return Record.accessibleBy(ability, 'read')
+          return await Record.accessibleBy(ability, 'read')
             .find({ form: parent.id, archived: { $ne: true } })
             .count();
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -190,10 +197,10 @@ export const FormType = new GraphQLObjectType({
     canUpdate: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForContent(context.user, parent);
           return ability.can('update', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -204,10 +211,10 @@ export const FormType = new GraphQLObjectType({
     canDelete: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForContent(context.user, parent);
           return ability.can('delete', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -218,10 +225,10 @@ export const FormType = new GraphQLObjectType({
     canCreateRecords: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForRecords(context.user, parent);
           return ability.can('create', 'Record');
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -250,11 +257,11 @@ export const FormType = new GraphQLObjectType({
                 { $or: unicityFilters },
               ],
             });
-            if(!record){
+            if (!record) {
               throw new GraphQLError(
                 context.i18next.t('common.errors.dataNotFound')
               );
-            }else{
+            } else {
               return record;
             }
           }

--- a/src/schema/types/page.type.ts
+++ b/src/schema/types/page.type.ts
@@ -3,7 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLBoolean,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import extendAbilityForPage from '@security/extendAbilityForPage';
 import { AccessType, ApplicationType } from '.';
@@ -31,12 +31,12 @@ export const PageType = new GraphQLObjectType({
     context: {
       type: GraphQLJSON,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForPage(context.user, parent);
           if (ability.can('read', parent))
             return parent.context?.displayField ? parent.context : null;
           return null;
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -47,11 +47,11 @@ export const PageType = new GraphQLObjectType({
     contentWithContext: {
       type: GraphQLJSON,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForPage(context.user, parent);
           if (ability.can('read', parent)) return parent.contentWithContext;
           return null;
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -62,13 +62,13 @@ export const PageType = new GraphQLObjectType({
     permissions: {
       type: AccessType,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForPage(context.user, parent);
           if (ability.can('update', parent)) {
             return parent.permissions;
           }
           return null;
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -85,11 +85,11 @@ export const PageType = new GraphQLObjectType({
             .where({ pages: parent._id })
             .getFilter()
         );
-        if(!application){
+        if (!application) {
           throw new GraphQLError(
             context.i18next.t('common.errors.dataNotFound')
           );
-        }else{
+        } else {
           return application;
         }
       },
@@ -97,10 +97,10 @@ export const PageType = new GraphQLObjectType({
     canSee: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForPage(context.user, parent);
           return ability.can('read', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -111,10 +111,10 @@ export const PageType = new GraphQLObjectType({
     canUpdate: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForPage(context.user, parent);
           return ability.can('update', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -125,10 +125,10 @@ export const PageType = new GraphQLObjectType({
     canDelete: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForPage(context.user, parent);
           return ability.can('delete', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')

--- a/src/schema/types/positionAttributeCategory.type.ts
+++ b/src/schema/types/positionAttributeCategory.type.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLID, GraphQLString } from 'graphql';
+import { GraphQLObjectType, GraphQLID, GraphQLString, GraphQLError } from 'graphql';
 import { AppAbility } from '@security/defineUserAbility';
 import { Application } from '@models';
 import { ApplicationType } from './application.type';
@@ -13,10 +13,14 @@ export const PositionAttributeCategoryType = new GraphQLObjectType({
       type: ApplicationType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return Application.findById(parent.application).accessibleBy(
+        const application = Application.findById(parent.application).accessibleBy(
           ability,
           'read'
         );
+        if (!application){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return application;
       },
     },
   }),

--- a/src/schema/types/positionAttributeCategory.type.ts
+++ b/src/schema/types/positionAttributeCategory.type.ts
@@ -1,4 +1,9 @@
-import { GraphQLObjectType, GraphQLID, GraphQLString, GraphQLError } from 'graphql';
+import {
+  GraphQLObjectType,
+  GraphQLID,
+  GraphQLString,
+  GraphQLError,
+} from 'graphql';
 import { AppAbility } from '@security/defineUserAbility';
 import { Application } from '@models';
 import { ApplicationType } from './application.type';
@@ -13,12 +18,13 @@ export const PositionAttributeCategoryType = new GraphQLObjectType({
       type: ApplicationType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const application = Application.findById(parent.application).accessibleBy(
-          ability,
-          'read'
-        );
-        if (!application){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const application = Application.findById(
+          parent.application
+        ).accessibleBy(ability, 'read');
+        if (!application) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return application;
       },

--- a/src/schema/types/pullJob.type.ts
+++ b/src/schema/types/pullJob.type.ts
@@ -3,7 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLList,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import { ApiConfiguration, Form, Channel } from '@models';
@@ -25,12 +25,13 @@ export const PullJobType = new GraphQLObjectType({
       type: ApiConfigurationType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const apiConfiguration = ApiConfiguration.findById(parent.apiConfiguration).accessibleBy(
-          ability,
-          'read'
-        );
-        if (!apiConfiguration){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const apiConfiguration = ApiConfiguration.findById(
+          parent.apiConfiguration
+        ).accessibleBy(ability, 'read');
+        if (!apiConfiguration) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return apiConfiguration;
       },
@@ -42,9 +43,14 @@ export const PullJobType = new GraphQLObjectType({
       type: FormType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const form = Form.findById(parent.convertTo).accessibleBy(ability, 'read');
-        if (!form){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const form = Form.findById(parent.convertTo).accessibleBy(
+          ability,
+          'read'
+        );
+        if (!form) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return form;
       },
@@ -55,9 +61,14 @@ export const PullJobType = new GraphQLObjectType({
       type: ChannelType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const channel = Channel.findById(parent.channel).accessibleBy(ability, 'read');
-        if (!channel){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const channel = Channel.findById(parent.channel).accessibleBy(
+          ability,
+          'read'
+        );
+        if (!channel) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return channel;
       },

--- a/src/schema/types/pullJob.type.ts
+++ b/src/schema/types/pullJob.type.ts
@@ -3,6 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLList,
+  GraphQLError
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import { ApiConfiguration, Form, Channel } from '@models';
@@ -24,10 +25,14 @@ export const PullJobType = new GraphQLObjectType({
       type: ApiConfigurationType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return ApiConfiguration.findById(parent.apiConfiguration).accessibleBy(
+        const apiConfiguration = ApiConfiguration.findById(parent.apiConfiguration).accessibleBy(
           ability,
           'read'
         );
+        if (!apiConfiguration){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return apiConfiguration;
       },
     },
     url: { type: GraphQLString },
@@ -37,7 +42,11 @@ export const PullJobType = new GraphQLObjectType({
       type: FormType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return Form.findById(parent.convertTo).accessibleBy(ability, 'read');
+        const form = Form.findById(parent.convertTo).accessibleBy(ability, 'read');
+        if (!form){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return form;
       },
     },
     mapping: { type: GraphQLJSON },
@@ -46,7 +55,11 @@ export const PullJobType = new GraphQLObjectType({
       type: ChannelType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return Channel.findById(parent.channel).accessibleBy(ability, 'read');
+        const channel = Channel.findById(parent.channel).accessibleBy(ability, 'read');
+        if (!channel){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return channel;
       },
     },
   }),

--- a/src/schema/types/record.type.ts
+++ b/src/schema/types/record.type.ts
@@ -29,6 +29,9 @@ export const RecordType = new GraphQLObjectType({
       async resolve(parent, args, context) {
         try{
           const form = await Form.findById(parent.form);
+          if (!form){
+            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          }
           const ability = await extendAbilityForRecords(context.user, form);
           if (ability.can('read', form)) {
             return form;
@@ -88,6 +91,8 @@ export const RecordType = new GraphQLObjectType({
                 }
               }
               return res;
+            }else{
+              throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
             }
           }
           return parent.data;
@@ -109,10 +114,14 @@ export const RecordType = new GraphQLObjectType({
       type: UserType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return User.findById(parent.createdBy.user).accessibleBy(
+        const user = User.findById(parent.createdBy.user).accessibleBy(
           ability,
           'read'
         );
+        if (!user){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return user;
       },
     },
     modifiedBy: {

--- a/src/schema/types/record.type.ts
+++ b/src/schema/types/record.type.ts
@@ -4,7 +4,7 @@ import {
   GraphQLString,
   GraphQLBoolean,
   GraphQLList,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import { AppAbility } from '@security/defineUserAbility';
 import GraphQLJSON from 'graphql-type-json';
@@ -27,16 +27,18 @@ export const RecordType = new GraphQLObjectType({
     form: {
       type: FormType,
       async resolve(parent, args, context) {
-        try{
+        try {
           const form = await Form.findById(parent.form);
-          if (!form){
-            throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+          if (!form) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
           }
           const ability = await extendAbilityForRecords(context.user, form);
           if (ability.can('read', form)) {
             return form;
           }
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -50,7 +52,7 @@ export const RecordType = new GraphQLObjectType({
         display: { type: GraphQLBoolean },
       },
       async resolve(parent, args, context) {
-        try{
+        try {
           if (args.display) {
             const source = parent.resource
               ? await Resource.findById(parent.resource)
@@ -68,7 +70,7 @@ export const RecordType = new GraphQLObjectType({
                         _id: parent.data[name],
                         archived: { $ne: true },
                       });
-                      if(!record){
+                      if (!record) {
                         throw new GraphQLError(
                           context.i18next.t('common.errors.dataNotFound')
                         );
@@ -91,12 +93,14 @@ export const RecordType = new GraphQLObjectType({
                 }
               }
               return res;
-            }else{
-              throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+            } else {
+              throw new GraphQLError(
+                context.i18next.t('common.errors.dataNotFound')
+              );
             }
           }
           return parent.data;
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -118,8 +122,10 @@ export const RecordType = new GraphQLObjectType({
           ability,
           'read'
         );
-        if (!user){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        if (!user) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return user;
       },

--- a/src/schema/types/referenceData.type.ts
+++ b/src/schema/types/referenceData.type.ts
@@ -3,6 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLBoolean,
+  GraphQLError
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import { ReferenceDataTypeEnumType } from '@const/enumTypes';
@@ -26,10 +27,14 @@ export const ReferenceDataType = new GraphQLObjectType({
       type: ApiConfigurationType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return ApiConfiguration.findById(parent.apiConfiguration).accessibleBy(
+        const apiConfiguration = ApiConfiguration.findById(parent.apiConfiguration).accessibleBy(
           ability,
           'read'
         );
+        if (!apiConfiguration){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return apiConfiguration;
       },
     },
     query: { type: GraphQLString },

--- a/src/schema/types/referenceData.type.ts
+++ b/src/schema/types/referenceData.type.ts
@@ -3,7 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLBoolean,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import { ReferenceDataTypeEnumType } from '@const/enumTypes';
@@ -27,12 +27,13 @@ export const ReferenceDataType = new GraphQLObjectType({
       type: ApiConfigurationType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const apiConfiguration = ApiConfiguration.findById(parent.apiConfiguration).accessibleBy(
-          ability,
-          'read'
-        );
-        if (!apiConfiguration){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const apiConfiguration = ApiConfiguration.findById(
+          parent.apiConfiguration
+        ).accessibleBy(ability, 'read');
+        if (!apiConfiguration) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return apiConfiguration;
       },

--- a/src/schema/types/resource.type.ts
+++ b/src/schema/types/resource.type.ts
@@ -6,7 +6,7 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import {
@@ -143,15 +143,15 @@ export const ResourceType = new GraphQLObjectType({
       type: FormType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const form = Form.findOne({ resource: parent.id, core: true }).accessibleBy(
-          ability,
-          'read'
-        );
-        if(!form){
+        const form = Form.findOne({
+          resource: parent.id,
+          core: true,
+        }).accessibleBy(ability, 'read');
+        if (!form) {
           throw new GraphQLError(
             context.i18next.t('common.errors.dataNotFound')
           );
-        }else{
+        } else {
           return form;
         }
       },
@@ -165,7 +165,7 @@ export const ResourceType = new GraphQLObjectType({
         archived: { type: GraphQLBoolean },
       },
       async resolve(parent, args, context) {
-        try{
+        try {
           let mongooseFilter: any = {
             resource: parent.id,
           };
@@ -210,14 +210,15 @@ export const ResourceType = new GraphQLObjectType({
             pageInfo: {
               hasNextPage,
               startCursor: edges.length > 0 ? edges[0].cursor : null,
-              endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+              endCursor:
+                edges.length > 0 ? edges[edges.length - 1].cursor : null,
             },
             edges,
             totalCount: await Record.countDocuments({
               $and: [mongooseFilter, permissionFilters],
             }),
           };
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -228,12 +229,12 @@ export const ResourceType = new GraphQLObjectType({
     recordsCount: {
       type: GraphQLInt,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForRecords(context.user, parent);
-          return Record.accessibleBy(ability, 'read')
+          return await Record.accessibleBy(ability, 'read')
             .find({ resource: parent.id, archived: { $ne: true } })
             .count();
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -245,14 +246,14 @@ export const ResourceType = new GraphQLObjectType({
     canCreateRecords: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability: AppAbility = context.user.ability;
           // either check that user can manage records, either check that user has a role to create records
           return (
             ability.can('manage', 'Record') ||
             userHasRoleFor('canCreateRecords', context.user, parent)
           );
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')

--- a/src/schema/types/step.type.ts
+++ b/src/schema/types/step.type.ts
@@ -3,12 +3,14 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLBoolean,
+  GraphQLError
 } from 'graphql';
 import { AccessType, WorkflowType } from '.';
 import { ContentEnumType } from '@const/enumTypes';
 import { Workflow } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import extendAbilityForStep from '@security/extendAbilityForStep';
+import { logger } from '@services/logger.service';
 
 /** GraphQL Step type definition */
 export const StepType = new GraphQLObjectType({
@@ -37,31 +39,59 @@ export const StepType = new GraphQLObjectType({
       type: WorkflowType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return Workflow.findOne({ steps: parent.id }).accessibleBy(
+        const workflow = Workflow.findOne({ steps: parent.id }).accessibleBy(
           ability,
           'read'
         );
+        if(!workflow){
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
+        }else{
+          return workflow;
+        }
       },
     },
     canSee: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        const ability = await extendAbilityForStep(context.user, parent);
-        return ability.can('read', parent);
+        try{
+          const ability = await extendAbilityForStep(context.user, parent);
+          return ability.can('read', parent);
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
       },
     },
     canUpdate: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        const ability = await extendAbilityForStep(context.user, parent);
-        return ability.can('update', parent);
+        try{
+          const ability = await extendAbilityForStep(context.user, parent);
+          return ability.can('update', parent);
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
       },
     },
     canDelete: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        const ability = await extendAbilityForStep(context.user, parent);
-        return ability.can('delete', parent);
+        try{
+          const ability = await extendAbilityForStep(context.user, parent);
+          return ability.can('delete', parent);
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
       },
     },
   }),

--- a/src/schema/types/step.type.ts
+++ b/src/schema/types/step.type.ts
@@ -3,7 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLBoolean,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import { AccessType, WorkflowType } from '.';
 import { ContentEnumType } from '@const/enumTypes';
@@ -43,11 +43,11 @@ export const StepType = new GraphQLObjectType({
           ability,
           'read'
         );
-        if(!workflow){
+        if (!workflow) {
           throw new GraphQLError(
             context.i18next.t('common.errors.dataNotFound')
           );
-        }else{
+        } else {
           return workflow;
         }
       },
@@ -55,10 +55,10 @@ export const StepType = new GraphQLObjectType({
     canSee: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForStep(context.user, parent);
           return ability.can('read', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -69,10 +69,10 @@ export const StepType = new GraphQLObjectType({
     canUpdate: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForStep(context.user, parent);
           return ability.can('update', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -83,10 +83,10 @@ export const StepType = new GraphQLObjectType({
     canDelete: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForStep(context.user, parent);
           return ability.can('delete', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')

--- a/src/schema/types/subscription.type.ts
+++ b/src/schema/types/subscription.type.ts
@@ -14,9 +14,14 @@ export const SubscriptionType = new GraphQLObjectType({
       type: FormType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const form = Form.findById(parent.convertTo).accessibleBy(ability, 'read');
-        if (!form){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const form = Form.findById(parent.convertTo).accessibleBy(
+          ability,
+          'read'
+        );
+        if (!form) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return form;
       },
@@ -25,9 +30,14 @@ export const SubscriptionType = new GraphQLObjectType({
       type: ChannelType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const channel = Channel.findById(parent.channel).accessibleBy(ability, 'read');
-        if (!channel){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const channel = Channel.findById(parent.channel).accessibleBy(
+          ability,
+          'read'
+        );
+        if (!channel) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return channel;
       },

--- a/src/schema/types/subscription.type.ts
+++ b/src/schema/types/subscription.type.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLString } from 'graphql';
+import { GraphQLObjectType, GraphQLString, GraphQLError } from 'graphql';
 import { Channel, Form } from '@models';
 import { ChannelType } from './channel.type';
 import { FormType } from './form.type';
@@ -14,14 +14,22 @@ export const SubscriptionType = new GraphQLObjectType({
       type: FormType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return Form.findById(parent.convertTo).accessibleBy(ability, 'read');
+        const form = Form.findById(parent.convertTo).accessibleBy(ability, 'read');
+        if (!form){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return form;
       },
     },
     channel: {
       type: ChannelType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return Channel.findById(parent.channel).accessibleBy(ability, 'read');
+        const channel = Channel.findById(parent.channel).accessibleBy(ability, 'read');
+        if (!channel){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return channel;
       },
     },
   }),

--- a/src/schema/types/version.type.ts
+++ b/src/schema/types/version.type.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLID, GraphQLString } from 'graphql';
+import { GraphQLObjectType, GraphQLID, GraphQLString, GraphQLError } from 'graphql';
 import { AppAbility } from '@security/defineUserAbility';
 import GraphQLJSON from 'graphql-type-json';
 import { UserType } from '../types';
@@ -20,7 +20,11 @@ export const VersionType = new GraphQLObjectType({
       type: UserType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        return User.findById(parent.createdBy).accessibleBy(ability, 'read');
+        const user = User.findById(parent.createdBy).accessibleBy(ability, 'read');
+        if (!user){
+          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        }
+        return user;
       },
     },
   }),

--- a/src/schema/types/version.type.ts
+++ b/src/schema/types/version.type.ts
@@ -1,4 +1,9 @@
-import { GraphQLObjectType, GraphQLID, GraphQLString, GraphQLError } from 'graphql';
+import {
+  GraphQLObjectType,
+  GraphQLID,
+  GraphQLString,
+  GraphQLError,
+} from 'graphql';
 import { AppAbility } from '@security/defineUserAbility';
 import GraphQLJSON from 'graphql-type-json';
 import { UserType } from '../types';
@@ -20,9 +25,14 @@ export const VersionType = new GraphQLObjectType({
       type: UserType,
       resolve(parent, args, context) {
         const ability: AppAbility = context.user.ability;
-        const user = User.findById(parent.createdBy).accessibleBy(ability, 'read');
-        if (!user){
-          throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        const user = User.findById(parent.createdBy).accessibleBy(
+          ability,
+          'read'
+        );
+        if (!user) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.dataNotFound')
+          );
         }
         return user;
       },

--- a/src/schema/types/workflow.type.ts
+++ b/src/schema/types/workflow.type.ts
@@ -4,12 +4,14 @@ import {
   GraphQLString,
   GraphQLList,
   GraphQLBoolean,
+  GraphQLError
 } from 'graphql';
 import { Step, Page, Workflow } from '@models';
 import { AccessType, PageType, StepType } from '.';
 import extendAbilityForStep from '@security/extendAbilityForStep';
 import extendAbilityForContent from '@security/extendAbilityForContent';
 import extendAbilityForPage from '@security/extendAbilityForPage';
+import { logger } from '@services/logger.service';
 
 /** GraphQL Workflow type definition */
 export const WorkflowType = new GraphQLObjectType({
@@ -41,57 +43,107 @@ export const WorkflowType = new GraphQLObjectType({
     permissions: {
       type: AccessType,
       async resolve(parent, args, context) {
-        const parentId = parent.id || parent._id;
-        const ability = await extendAbilityForContent(context.user, parent);
-        if (ability.can('update', parent)) {
+        try{
+          const parentId = parent.id || parent._id;
+          const ability = await extendAbilityForContent(context.user, parent);
+          if (ability.can('update', parent)) {
+            const page = await Page.findOne({
+              $or: [
+                { content: parentId },
+                { contentWithContext: { $elemMatch: { content: parentId } } },
+              ],
+            });
+            if (page){
+              return page.permissions
+            }else{
+              const step = await Step.findOne({ content: parentId });
+              if(!step){
+                throw new GraphQLError(
+                  context.i18next.t('common.errors.dataNotFound')
+                );
+              }else{
+                return step.permissions;
+              }
+            }
+          }
+          return null;
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
+      },
+    },
+    page: {
+      type: PageType,
+      async resolve(parent, args, context) {
+        try{
+          const parentId = parent.id || parent._id;
           const page = await Page.findOne({
             $or: [
               { content: parentId },
               { contentWithContext: { $elemMatch: { content: parentId } } },
             ],
           });
-          if (page) return page.permissions;
-          const step = await Step.findOne({ content: parentId });
-          return step.permissions;
-        }
-        return null;
-      },
-    },
-    page: {
-      type: PageType,
-      async resolve(parent, args, context) {
-        const parentId = parent.id || parent._id;
-        const page = await Page.findOne({
-          $or: [
-            { content: parentId },
-            { contentWithContext: { $elemMatch: { content: parentId } } },
-          ],
-        });
-        const ability = await extendAbilityForPage(context.user, page);
-        if (ability.can('read', page)) {
-          return page;
+          if(!page){
+            throw new GraphQLError(
+              context.i18next.t('common.errors.dataNotFound')
+            );
+          }else{
+            const ability = await extendAbilityForPage(context.user, page);
+            if (ability.can('read', page)) {
+              return page;
+            }
+          }
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
         }
       },
     },
     canSee: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        const ability = await extendAbilityForContent(context.user, parent);
-        return ability.can('read', parent);
+        try{
+          const ability = await extendAbilityForContent(context.user, parent);
+          return ability.can('read', parent);
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
       },
     },
     canUpdate: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        const ability = await extendAbilityForContent(context.user, parent);
-        return ability.can('update', parent);
+        try{
+          const ability = await extendAbilityForContent(context.user, parent);
+          return ability.can('update', parent);
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
       },
     },
     canDelete: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        const ability = await extendAbilityForContent(context.user, parent);
-        return ability.can('delete', parent);
+        try{
+          const ability = await extendAbilityForContent(context.user, parent);
+          return ability.can('delete', parent);
+        }catch (err){
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
+        }
       },
     },
   }),

--- a/src/schema/types/workflow.type.ts
+++ b/src/schema/types/workflow.type.ts
@@ -4,7 +4,7 @@ import {
   GraphQLString,
   GraphQLList,
   GraphQLBoolean,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 import { Step, Page, Workflow } from '@models';
 import { AccessType, PageType, StepType } from '.';
@@ -43,7 +43,7 @@ export const WorkflowType = new GraphQLObjectType({
     permissions: {
       type: AccessType,
       async resolve(parent, args, context) {
-        try{
+        try {
           const parentId = parent.id || parent._id;
           const ability = await extendAbilityForContent(context.user, parent);
           if (ability.can('update', parent)) {
@@ -53,21 +53,21 @@ export const WorkflowType = new GraphQLObjectType({
                 { contentWithContext: { $elemMatch: { content: parentId } } },
               ],
             });
-            if (page){
-              return page.permissions
-            }else{
+            if (page) {
+              return page.permissions;
+            } else {
               const step = await Step.findOne({ content: parentId });
-              if(!step){
+              if (!step) {
                 throw new GraphQLError(
                   context.i18next.t('common.errors.dataNotFound')
                 );
-              }else{
+              } else {
                 return step.permissions;
               }
             }
           }
           return null;
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -78,7 +78,7 @@ export const WorkflowType = new GraphQLObjectType({
     page: {
       type: PageType,
       async resolve(parent, args, context) {
-        try{
+        try {
           const parentId = parent.id || parent._id;
           const page = await Page.findOne({
             $or: [
@@ -86,17 +86,17 @@ export const WorkflowType = new GraphQLObjectType({
               { contentWithContext: { $elemMatch: { content: parentId } } },
             ],
           });
-          if(!page){
+          if (!page) {
             throw new GraphQLError(
               context.i18next.t('common.errors.dataNotFound')
             );
-          }else{
+          } else {
             const ability = await extendAbilityForPage(context.user, page);
             if (ability.can('read', page)) {
               return page;
             }
           }
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -107,10 +107,10 @@ export const WorkflowType = new GraphQLObjectType({
     canSee: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForContent(context.user, parent);
           return ability.can('read', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -121,10 +121,10 @@ export const WorkflowType = new GraphQLObjectType({
     canUpdate: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForContent(context.user, parent);
           return ability.can('update', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')
@@ -135,10 +135,10 @@ export const WorkflowType = new GraphQLObjectType({
     canDelete: {
       type: GraphQLBoolean,
       async resolve(parent, args, context) {
-        try{
+        try {
           const ability = await extendAbilityForContent(context.user, parent);
           return ability.can('delete', parent);
-        }catch (err){
+        } catch (err) {
           logger.error(err.message, { stack: err.stack });
           throw new GraphQLError(
             context.i18next.t('common.errors.internalServerError')

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -6,7 +6,7 @@ import getFilter from '../Query/getFilter';
 import getSortField from '../Query/getSortField';
 import { defaultRecordFieldsFlat } from '@const/defaultRecordFields';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
-import { GraphQLID, GraphQLList } from 'graphql';
+import { GraphQLID, GraphQLList, GraphQLError } from 'graphql';
 import getDisplayText from '../../../form/getDisplayText';
 import { NameExtension } from '../../introspection/getFieldName';
 import getReferenceDataResolver from './getReferenceDataResolver';
@@ -206,6 +206,10 @@ export const getEntityResolver = (
       const form =
         (entity._form && new Form(entity._form)) ||
         (await Form.findById(entity.form, 'permissions fields resource'));
+      
+      if (!form){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const ability = await extendAbilityForRecords(user, form);
       return ability.can('update', subject('Record', entity));
     },
@@ -217,6 +221,9 @@ export const getEntityResolver = (
       const form =
         (entity._form && new Form(entity._form)) ||
         (await Form.findById(entity.form, 'permissions fields resource'));
+      if (!form){
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
       const ability = await extendAbilityForRecords(user, form);
       return ability.can('delete', subject('Record', entity));
     },

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -206,8 +206,8 @@ export const getEntityResolver = (
       const form =
         (entity._form && new Form(entity._form)) ||
         (await Form.findById(entity.form, 'permissions fields resource'));
-      
-      if (!form){
+
+      if (!form) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const ability = await extendAbilityForRecords(user, form);
@@ -221,7 +221,7 @@ export const getEntityResolver = (
       const form =
         (entity._form && new Form(entity._form)) ||
         (await Form.findById(entity.form, 'permissions fields resource'));
-      if (!form){
+      if (!form) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
       const ability = await extendAbilityForRecords(user, form);

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -364,6 +364,12 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
     })
       .select('_id permissions fields')
       .populate('resource');
+    
+    if (!form) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
     const ability = await extendAbilityForRecords(user, form);
     const permissionFilters = Record.accessibleBy(ability, 'read').getFilter();
 

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -364,7 +364,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
     })
       .select('_id permissions fields')
       .populate('resource');
-    
+
     if (!form) {
       throw new GraphQLError(
         context.i18next.t('common.errors.permissionNotGranted')

--- a/src/utils/schema/resolvers/Query/single.ts
+++ b/src/utils/schema/resolvers/Query/single.ts
@@ -13,5 +13,12 @@ export default () =>
     if (!user) {
       throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
-    return Record.findOne({ _id: id, archived: { $ne: true } });
+    const record = Record.findOne({ _id: id, archived: { $ne: true } });
+    if (!record) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }else{
+      return record;
+    }
   };

--- a/src/utils/schema/resolvers/Query/single.ts
+++ b/src/utils/schema/resolvers/Query/single.ts
@@ -18,7 +18,7 @@ export default () =>
       throw new GraphQLError(
         context.i18next.t('common.errors.permissionNotGranted')
       );
-    }else{
+    } else {
       return record;
     }
   };

--- a/src/utils/schema/resolvers/index.ts
+++ b/src/utils/schema/resolvers/index.ts
@@ -88,8 +88,11 @@ export const getResolvers = (
                     referenceData,
                     apiConfiguration
                   );
+                }else{
+                  throw new GraphQLError(
+                    context.i18next.t('common.errors.dataNotFound')
+                  );
                 }
-                return null;
               },
             }),
           {}

--- a/src/utils/schema/resolvers/index.ts
+++ b/src/utils/schema/resolvers/index.ts
@@ -88,7 +88,7 @@ export const getResolvers = (
                     referenceData,
                     apiConfiguration
                   );
-                }else{
+                } else {
                   throw new GraphQLError(
                     context.i18next.t('common.errors.dataNotFound')
                   );


### PR DESCRIPTION
# Description

Inserted graphql mutations inside a try/catch and verified if some mutations are using mongoose findOne/ findById to throw "data not found" if it returns nothing.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/61522

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested verifying if the graphql mutations are inside a try/catch and if it's working properly, and also if mongoose findOne/findById is returning "data not found" when it returns nothing.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

