### PR TITLE
AB#61667 DB Duplicating an application does not copy styling on the a…

### DIFF
--- a/src/models/application.model.ts
+++ b/src/models/application.model.ts
@@ -123,7 +123,8 @@ addOnBeforeDeleteMany(applicationSchema, async (applications) => {
   await Channel.deleteMany({ application: { $in: applications } });
 
   for (const application of applications) {
-    await deleteFolder('applications', application.id);
+    if (!!application.cssFilename)
+      await deleteFolder('applications', application.cssFilename);
   }
   // await Promise.all(promises);
 });


### PR DESCRIPTION
# Description
What to do:
make sure that when copying an app, the styling is also copied ( it should NOT use the same file, the file must be a copy of existing one

## Ticket
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/61667

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

