### PR TITLE
refactor/AB#63228_move-static-cards-to-editor-widget

### DIFF
--- a/migrations/1684107791320-convert-static-cards-to-text-widgets.ts
+++ b/migrations/1684107791320-convert-static-cards-to-text-widgets.ts
@@ -1,0 +1,106 @@
+import { Dashboard } from '@models';
+import { logger } from '@services/logger.service';
+import { startDatabaseForMigration } from '../src/utils/migrations/database.helper';
+import { isNil } from 'lodash';
+
+/** Removes static cards from DB, creates new text widgets instead */
+export const up = async () => {
+  await startDatabaseForMigration();
+
+  const allDashboards = await Dashboard.find({});
+  for (const dashboard of allDashboards) {
+    if (!dashboard.structure) continue;
+    const widgetsToRemove: number[] = [];
+    const widgetsToChange: { id: number; settings: any }[] = [];
+    for (const widget of dashboard.structure) {
+      if (widget.component !== 'summaryCard') continue;
+      if (isNil(widget.settings.isDynamic)) continue;
+      if (widget.settings.isDynamic === true) {
+        logger.info(
+          `Updating dynamic summary card widget settings: Dashboard ${dashboard.name} - Widget ID: ${widget.id}`
+        );
+        const settings = widget.settings;
+        const [card] = settings.cards;
+        const newSettings = {
+          id: settings.id,
+          title: settings.title,
+          card: {
+            title: card?.title || '',
+            resource: card?.resource || null,
+            layout: card?.layout || null,
+            aggregation: card?.aggregation || null,
+            height: card?.height || 2,
+            width: card?.width || 2,
+            html: card?.html || '',
+            showDataSourceLink: card?.showDataSourceLink || false,
+            useStyles: card?.useStyles || true,
+            wholeCardStyles: card?.wholeCardStyles || false,
+          },
+        };
+
+        widgetsToChange.push({ id: widget.id, settings: newSettings });
+        continue;
+      }
+
+      // From this point, we are sure that we are dealing with static cards
+      widgetsToRemove.push(widget.id);
+      logger.info(
+        `Converting static summary card widget to text widget: Dashboard ${dashboard.name} - Widget ID: ${widget.id}`
+      );
+
+      const cards = widget.settings.cards || [];
+      cards.forEach((card) => {
+        const nextID = dashboard.structure.length
+          ? dashboard.structure[dashboard.structure.length - 1].id + 1
+          : 0;
+
+        const newEditorWidget = {
+          id: nextID,
+          component: 'editor',
+          name: 'Text',
+          icon: '/assets/text.svg',
+          color: '#2F383E',
+          defaultCols: 2,
+          defaultRows: 2,
+          minRow: 1,
+          settings: {
+            id: nextID,
+            text: card.html,
+            title: card.title,
+            resource: card.resource,
+            layout: card.layout,
+            record: card.record,
+          },
+        };
+        dashboard.structure.push(newEditorWidget);
+      });
+    }
+
+    dashboard.structure = dashboard.structure.map((widget) => {
+      const shouldUpdate = widgetsToChange.find((w) => w.id === widget.id);
+      if (shouldUpdate)
+        return {
+          ...widget,
+          settings: shouldUpdate.settings,
+        };
+      return widget;
+    });
+
+    dashboard.structure = dashboard.structure.filter(
+      (widget) => !widgetsToRemove.includes(widget.id)
+    );
+
+    await dashboard.save();
+  }
+};
+
+/**
+ * Sample function of down migration
+ *
+ * @returns just migrate data.
+ */
+export const down = async () => {
+  /*
+      Code you downgrade script here!
+   */
+};


### PR DESCRIPTION
# Description

This PR adds a migration to change old summary cards settings into the updated version of the settings or to text widgets, that now support data templating from records value

## Ticket
https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20WHE%20Dashboard/Stories/?workitem=63228

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By running the migration locally 

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

