### PR TITLE
fix/add-update-permission-type-migration

### DIFF
--- a/migrations/1684803344240-update-fields-permission-type.ts
+++ b/migrations/1684803344240-update-fields-permission-type.ts
@@ -1,0 +1,54 @@
+import { Types } from 'mongoose';
+import { logger } from '@services/logger.service';
+import { startDatabaseForMigration } from '../src/utils/migrations/database.helper';
+import { Resource } from '@models';
+import { cloneDeep, isEqual } from 'lodash';
+
+/**
+ * Checks the canSee / canUpdate permissions of each field on each resource
+ * If it is a string, it will be converted to an ObjectId
+ */
+export const up = async () => {
+  await startDatabaseForMigration();
+  const resources = await Resource.find();
+  const initResources = cloneDeep(resources);
+  for (const resource of resources) {
+    const fields = resource.fields;
+
+    const newFields = fields.map((field) => {
+      return {
+        ...field,
+        permissions: {
+          canSee: (field.permissions?.canSee || []).map((perm) =>
+            typeof perm === 'string' ? new Types.ObjectId(perm) : perm
+          ),
+          canUpdate: (field.permissions?.canUpdate || []).map((perm) =>
+            typeof perm === 'string' ? new Types.ObjectId(perm) : perm
+          ),
+        },
+      } as typeof field;
+    });
+
+    resource.fields = newFields;
+  }
+
+  try {
+    if (!isEqual(initResources, resources)) {
+      logger.info('Updating permissions types on resource fields');
+      await Promise.all(resources.map((resource) => resource.save()));
+    }
+  } catch (e) {
+    logger.error('Error trying to save new resource types', e);
+  }
+};
+
+/**
+ * Sample function of down migration
+ *
+ * @returns just migrate data.
+ */
+export const down = async () => {
+  /*
+      Code you downgrade script here!
+   */
+};

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -668,7 +668,7 @@ export default {
       if (args.fieldsPermissions) {
         const permissions: FieldPermissionChange = args.fieldsPermissions;
         for (const permission in permissions) {
-          const obj = permissions[permission];
+          const obj: SimpleFieldPermissionChange = permissions[permission];
           // Add permission on target field
           if (obj.add) {
             checkFieldPermission(


### PR DESCRIPTION
# Description

This PR includes a new migration, that checks the canSee / canUpdate permissions of each field on each resource. If it is a string, it will be converted to an ObjectId. 

The strings were causing some operations to fail when updating field permissions since the $addToSet and $pull were done with ObjectIds (no error was thrown, just nothing happened)

## Ticket
No ticket linked to this PR

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By checking if the roles on the permissions were of type ObjectID after the migration was run


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

