### PR TITLE
AB#54896 set maximum pagination limit big requests can raise mongoDB …

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -11,6 +11,9 @@ module.exports = {
       windowMs: 1 * 60 * 1000, // 1 minute
       max: 100,
     },
+    pagination:{
+      limit: 1000
+    }
   },
   frontOffice: {
     uri: '',

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -10,6 +10,7 @@
 			"invalidAPI": "API cannot be reached.",
 			"invalidEmailsInput": "Wrong format detected. Please provide valid emails.",
 			"invalidGraphQLName": "The name can only consist of alphanumeric characters and underscores, and must start with a letter. Please choose a different name.",
+			"maximumPaginationLimit": "Maximum page size is {{paginationLimit}}. Please use a different page size.",
 			"permissionNotGranted": "Permission not granted.",
 			"userNotLogged": "You must be connected."
 		}

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -10,6 +10,7 @@
 			"invalidAPI": "******",
 			"invalidEmailsInput": "******",
 			"invalidGraphQLName": "******",
+			"maximumPaginationLimit": "****** {{paginationLimit}} ******",
 			"permissionNotGranted": "******",
 			"userNotLogged": "******"
 		}

--- a/src/schema/query/apiConfigurations.query.ts
+++ b/src/schema/query/apiConfigurations.query.ts
@@ -7,7 +7,7 @@ import {
 import { ApiConfiguration } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
-import config from 'config';
+import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -24,14 +24,7 @@ export default {
   },
   async resolve(parent, args, context) {
     const first = args.first || DEFAULT_FIRST;
-    const paginationMaxLimit: number = config.get('server.pagination.limit');
-    if (first > paginationMaxLimit) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.maximumPaginationLimit', {
-          paginationLimit: paginationMaxLimit,
-        })
-      );
-    }
+    paginationMaxLimit(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/apiConfigurations.query.ts
+++ b/src/schema/query/apiConfigurations.query.ts
@@ -7,6 +7,7 @@ import {
 import { ApiConfiguration } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import config from 'config';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -22,6 +23,15 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
+    const first = args.first || DEFAULT_FIRST;
+    const paginationMaxLimit: number = config.get('server.pagination.limit');
+    if (first > paginationMaxLimit) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.maximumPaginationLimit', {
+          paginationLimit: paginationMaxLimit,
+        })
+      );
+    }
     try {
       // Authentication check
       const user = context.user;
@@ -38,8 +48,6 @@ export default {
         'read'
       ).getFilter();
       const filters: any[] = [abilityFilters];
-
-      const first = args.first || DEFAULT_FIRST;
       const afterCursor = args.afterCursor;
       const cursorFilters = afterCursor
         ? {

--- a/src/schema/query/apiConfigurations.query.ts
+++ b/src/schema/query/apiConfigurations.query.ts
@@ -7,7 +7,7 @@ import {
 import { ApiConfiguration } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
-import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
+import checkPageSize from '@utils/schema/errors/checkPageSize.util';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -23,8 +23,9 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
+    // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
-    paginationMaxLimit(first);
+    checkPageSize(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/applications.query.ts
+++ b/src/schema/query/applications.query.ts
@@ -10,7 +10,7 @@ import GraphQLJSON from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
 import { logger } from '@services/logger.service';
-import config from 'config';
+import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -103,14 +103,7 @@ export default {
   },
   async resolve(parent, args, context) {
     const first = args.first || DEFAULT_FIRST;
-    const paginationMaxLimit: number = config.get('server.pagination.limit');
-    if (first > paginationMaxLimit) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.maximumPaginationLimit', {
-          paginationLimit: paginationMaxLimit,
-        })
-      );
-    }
+    paginationMaxLimit(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/applications.query.ts
+++ b/src/schema/query/applications.query.ts
@@ -10,6 +10,7 @@ import GraphQLJSON from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
 import { logger } from '@services/logger.service';
+import config from 'config';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -101,6 +102,15 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
+    const first = args.first || DEFAULT_FIRST;
+    const paginationMaxLimit: number = config.get('server.pagination.limit');
+    if (first > paginationMaxLimit) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.maximumPaginationLimit', {
+          paginationLimit: paginationMaxLimit,
+        })
+      );
+    }
     try {
       // Authentication check
       const user = context.user;
@@ -132,7 +142,6 @@ export default {
       const queryFilters = getFilter(args.filter, FILTER_FIELDS);
       const filters: any[] = [queryFilters, abilityFilters];
 
-      const first = args.first || DEFAULT_FIRST;
       const afterCursor = args.afterCursor;
 
       const sortField =

--- a/src/schema/query/applications.query.ts
+++ b/src/schema/query/applications.query.ts
@@ -10,7 +10,7 @@ import GraphQLJSON from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
 import { logger } from '@services/logger.service';
-import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
+import checkPageSize from '@utils/schema/errors/checkPageSize.util';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -102,8 +102,9 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
+    // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
-    paginationMaxLimit(first);
+    checkPageSize(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/forms.query.ts
+++ b/src/schema/query/forms.query.ts
@@ -6,7 +6,7 @@ import { GraphQLJSON } from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
 import { logger } from '@services/logger.service';
-import config from 'config';
+import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -103,14 +103,7 @@ export default {
   },
   async resolve(parent, args, context) {
     const first = args.first || DEFAULT_FIRST;
-    const paginationMaxLimit: number = config.get('server.pagination.limit');
-    if (first > paginationMaxLimit) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.maximumPaginationLimit', {
-          paginationLimit: paginationMaxLimit,
-        })
-      );
-    }
+    paginationMaxLimit(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/forms.query.ts
+++ b/src/schema/query/forms.query.ts
@@ -6,7 +6,7 @@ import { GraphQLJSON } from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
 import { logger } from '@services/logger.service';
-import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
+import checkPageSize from '@utils/schema/errors/checkPageSize.util';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -102,8 +102,9 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
+    // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
-    paginationMaxLimit(first);
+    checkPageSize(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/forms.query.ts
+++ b/src/schema/query/forms.query.ts
@@ -6,6 +6,7 @@ import { GraphQLJSON } from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
 import { logger } from '@services/logger.service';
+import config from 'config';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -101,6 +102,15 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
+    const first = args.first || DEFAULT_FIRST;
+    const paginationMaxLimit: number = config.get('server.pagination.limit');
+    if (first > paginationMaxLimit) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.maximumPaginationLimit', {
+          paginationLimit: paginationMaxLimit,
+        })
+      );
+    }
     try {
       // Authentication check
       const user = context.user;
@@ -122,7 +132,6 @@ export default {
       const queryFilters = getFilter(args.filter, FILTER_FIELDS);
       const filters: any[] = [queryFilters, abilityFilters];
 
-      const first = args.first || DEFAULT_FIRST;
       const afterCursor = args.afterCursor;
 
       const sortField =

--- a/src/schema/query/notifications.query.ts
+++ b/src/schema/query/notifications.query.ts
@@ -7,7 +7,7 @@ import {
 import { Notification } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
-import config from 'config';
+import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -24,14 +24,7 @@ export default {
   },
   async resolve(parent, args, context) {
     const first = args.first || DEFAULT_FIRST;
-    const paginationMaxLimit: number = config.get('server.pagination.limit');
-    if (first > paginationMaxLimit) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.maximumPaginationLimit', {
-          paginationLimit: paginationMaxLimit,
-        })
-      );
-    }
+    paginationMaxLimit(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/notifications.query.ts
+++ b/src/schema/query/notifications.query.ts
@@ -7,6 +7,7 @@ import {
 import { Notification } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import config from 'config';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -22,6 +23,15 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
+    const first = args.first || DEFAULT_FIRST;
+    const paginationMaxLimit: number = config.get('server.pagination.limit');
+    if (first > paginationMaxLimit) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.maximumPaginationLimit', {
+          paginationLimit: paginationMaxLimit,
+        })
+      );
+    }
     try {
       // Authentication check
       const user = context.user;
@@ -39,7 +49,6 @@ export default {
       ).getFilter();
       const filters: any[] = [abilityFilters];
 
-      const first = args.first || DEFAULT_FIRST;
       const afterCursor = args.afterCursor;
       const cursorFilters = afterCursor
         ? {

--- a/src/schema/query/notifications.query.ts
+++ b/src/schema/query/notifications.query.ts
@@ -7,7 +7,7 @@ import {
 import { Notification } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
-import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
+import checkPageSize from '@utils/schema/errors/checkPageSize.util';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -23,8 +23,9 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
+    // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
-    paginationMaxLimit(first);
+    checkPageSize(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/pullJobs.query.ts
+++ b/src/schema/query/pullJobs.query.ts
@@ -3,7 +3,7 @@ import { PullJobConnectionType, encodeCursor, decodeCursor } from '../types';
 import { PullJob } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
-import config from 'config';
+import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -20,14 +20,7 @@ export default {
   },
   async resolve(parent, args, context) {
     const first = args.first || DEFAULT_FIRST;
-    const paginationMaxLimit: number = config.get('server.pagination.limit');
-    if (first > paginationMaxLimit) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.maximumPaginationLimit', {
-          paginationLimit: paginationMaxLimit,
-        })
-      );
-    }
+    paginationMaxLimit(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/pullJobs.query.ts
+++ b/src/schema/query/pullJobs.query.ts
@@ -3,7 +3,7 @@ import { PullJobConnectionType, encodeCursor, decodeCursor } from '../types';
 import { PullJob } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
-import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
+import checkPageSize from '@utils/schema/errors/checkPageSize.util';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -19,8 +19,9 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
+    // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
-    paginationMaxLimit(first);
+    checkPageSize(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/pullJobs.query.ts
+++ b/src/schema/query/pullJobs.query.ts
@@ -3,6 +3,7 @@ import { PullJobConnectionType, encodeCursor, decodeCursor } from '../types';
 import { PullJob } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import config from 'config';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -18,6 +19,15 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
+    const first = args.first || DEFAULT_FIRST;
+    const paginationMaxLimit: number = config.get('server.pagination.limit');
+    if (first > paginationMaxLimit) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.maximumPaginationLimit', {
+          paginationLimit: paginationMaxLimit,
+        })
+      );
+    }
     try {
       // Authentication check
       const user = context.user;
@@ -31,7 +41,6 @@ export default {
       const abilityFilters = PullJob.accessibleBy(ability, 'read').getFilter();
       const filters: any[] = [abilityFilters];
 
-      const first = args.first || DEFAULT_FIRST;
       const afterCursor = args.afterCursor;
       const cursorFilters = afterCursor
         ? {

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -14,7 +14,10 @@ import {
 } from '@const/defaultRecordFields';
 import { logger } from '@services/logger.service';
 import buildCalculatedFieldPipeline from '../../utils/aggregation/buildCalculatedFieldPipeline';
-import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
+import checkPageSize from '@utils/schema/errors/checkPageSize.util';
+
+/** Pagination default items per query */
+const DEFAULT_FIRST = 10;
 
 /**
  * Get created By stages
@@ -50,8 +53,9 @@ export default {
     skip: { type: GraphQLInt },
   },
   async resolve(parent, args, context) {
-    const first: number = get(args, 'first', 10);
-    paginationMaxLimit(first);
+    // Make sure that the page size is not too important
+    const first = args.first || DEFAULT_FIRST;
+    checkPageSize(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -14,6 +14,7 @@ import {
 } from '@const/defaultRecordFields';
 import { logger } from '@services/logger.service';
 import buildCalculatedFieldPipeline from '../../utils/aggregation/buildCalculatedFieldPipeline';
+import config from 'config';
 
 /**
  * Get created By stages
@@ -49,6 +50,15 @@ export default {
     skip: { type: GraphQLInt },
   },
   async resolve(parent, args, context) {
+    const first: number = get(args, 'first', 10);
+    const paginationMaxLimit: number = config.get('server.pagination.limit');
+    if (first > paginationMaxLimit) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.maximumPaginationLimit', {
+          paginationLimit: paginationMaxLimit,
+        })
+      );
+    }
     try {
       // Authentication check
       const user = context.user;
@@ -60,7 +70,7 @@ export default {
 
       // global variables
       let pipeline: any[] = [];
-      const first: number = get(args, 'first', 10);
+
       const skip: number = get(args, 'skip', 0);
 
       // Build data source step

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -14,7 +14,7 @@ import {
 } from '@const/defaultRecordFields';
 import { logger } from '@services/logger.service';
 import buildCalculatedFieldPipeline from '../../utils/aggregation/buildCalculatedFieldPipeline';
-import config from 'config';
+import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
 
 /**
  * Get created By stages
@@ -51,14 +51,7 @@ export default {
   },
   async resolve(parent, args, context) {
     const first: number = get(args, 'first', 10);
-    const paginationMaxLimit: number = config.get('server.pagination.limit');
-    if (first > paginationMaxLimit) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.maximumPaginationLimit', {
-          paginationLimit: paginationMaxLimit,
-        })
-      );
-    }
+    paginationMaxLimit(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/referenceDatas.query.ts
+++ b/src/schema/query/referenceDatas.query.ts
@@ -7,7 +7,7 @@ import {
 import { ReferenceData } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
-import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
+import checkPageSize from '@utils/schema/errors/checkPageSize.util';
 
 /** Pagination default items per query */
 const DEFAULT_FIRST = 10;
@@ -23,8 +23,9 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
+    // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
-    paginationMaxLimit(first);
+    checkPageSize(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/referenceDatas.query.ts
+++ b/src/schema/query/referenceDatas.query.ts
@@ -7,7 +7,7 @@ import {
 import { ReferenceData } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
-import config from 'config';
+import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
 
 /** Pagination default items per query */
 const DEFAULT_FIRST = 10;
@@ -24,14 +24,7 @@ export default {
   },
   async resolve(parent, args, context) {
     const first = args.first || DEFAULT_FIRST;
-    const paginationMaxLimit: number = config.get('server.pagination.limit');
-    if (first > paginationMaxLimit) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.maximumPaginationLimit', {
-          paginationLimit: paginationMaxLimit,
-        })
-      );
-    }
+    paginationMaxLimit(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/referenceDatas.query.ts
+++ b/src/schema/query/referenceDatas.query.ts
@@ -7,6 +7,7 @@ import {
 import { ReferenceData } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import config from 'config';
 
 /** Pagination default items per query */
 const DEFAULT_FIRST = 10;
@@ -22,6 +23,15 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
+    const first = args.first || DEFAULT_FIRST;
+    const paginationMaxLimit: number = config.get('server.pagination.limit');
+    if (first > paginationMaxLimit) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.maximumPaginationLimit', {
+          paginationLimit: paginationMaxLimit,
+        })
+      );
+    }
     try {
       // Authentication check
       const user = context.user;
@@ -39,7 +49,6 @@ export default {
       ).getFilter();
       const filters: any[] = [abilityFilters];
 
-      const first = args.first || DEFAULT_FIRST;
       const afterCursor = args.afterCursor;
       const cursorFilters = afterCursor
         ? {

--- a/src/schema/query/resources.query.ts
+++ b/src/schema/query/resources.query.ts
@@ -6,7 +6,7 @@ import GraphQLJSON from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
 import { logger } from '@services/logger.service';
-import config from 'config';
+import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -76,14 +76,7 @@ export default {
   },
   async resolve(parent, args, context) {
     const first = args.first || DEFAULT_FIRST;
-    const paginationMaxLimit: number = config.get('server.pagination.limit');
-    if (first > paginationMaxLimit) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.maximumPaginationLimit', {
-          paginationLimit: paginationMaxLimit,
-        })
-      );
-    }
+    paginationMaxLimit(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/schema/query/resources.query.ts
+++ b/src/schema/query/resources.query.ts
@@ -6,6 +6,7 @@ import GraphQLJSON from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
 import { logger } from '@services/logger.service';
+import config from 'config';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -74,6 +75,15 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
+    const first = args.first || DEFAULT_FIRST;
+    const paginationMaxLimit: number = config.get('server.pagination.limit');
+    if (first > paginationMaxLimit) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.maximumPaginationLimit', {
+          paginationLimit: paginationMaxLimit,
+        })
+      );
+    }
     try {
       // Authentication check
       const user = context.user;
@@ -96,7 +106,6 @@ export default {
       const queryFilters = getFilter(args.filter, FILTER_FIELDS);
       const filters: any[] = [queryFilters, abilityFilters];
 
-      const first = args.first || DEFAULT_FIRST;
       const afterCursor = args.afterCursor;
 
       const sortField =

--- a/src/schema/query/resources.query.ts
+++ b/src/schema/query/resources.query.ts
@@ -6,7 +6,7 @@ import GraphQLJSON from 'graphql-type-json';
 import getFilter from '@utils/filter/getFilter';
 import getSortOrder from '@utils/schema/resolvers/Query/getSortOrder';
 import { logger } from '@services/logger.service';
-import { paginationMaxLimit } from '@utils/schema/resolvers/Query/all';
+import checkPageSize from '@utils/schema/errors/checkPageSize.util';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -75,8 +75,9 @@ export default {
     sortOrder: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
+    // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
-    paginationMaxLimit(first);
+    checkPageSize(first);
     try {
       // Authentication check
       const user = context.user;

--- a/src/utils/schema/errors/checkPageSize.util.ts
+++ b/src/utils/schema/errors/checkPageSize.util.ts
@@ -1,0 +1,22 @@
+import config from 'config';
+import { GraphQLError } from 'graphql';
+import i18next from 'i18next';
+
+/**
+ * Check pagination maximum limit of data.
+ * Throw pagination maximum limit cross than error.
+ *
+ * @param maxLimit Question maxLimit number
+ */
+export const checkPageSize = (maxLimit: number): void => {
+  const maxPaginationLimit = config.get<number>('server.pagination.limit');
+  if (maxLimit > maxPaginationLimit) {
+    throw new GraphQLError(
+      i18next.t('common.errors.maximumPaginationLimit', {
+        paginationLimit: maxPaginationLimit,
+      })
+    );
+  }
+};
+
+export default checkPageSize;

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -16,28 +16,10 @@ import { getAccessibleFields } from '@utils/form';
 import buildCalculatedFieldPipeline from '@utils/aggregation/buildCalculatedFieldPipeline';
 import { flatten, get, isArray } from 'lodash';
 import { logger } from '@services/logger.service';
-import config from 'config';
-import i18next from 'i18next';
+import checkPageSize from '@utils/schema/errors/checkPageSize.util';
 
 /** Default number for items to get */
 const DEFAULT_FIRST = 25;
-
-/**
- * Checks pagination maximum limit of data.
- * Throw pagination maximum limit cross than error.
- *
- * @param maxLimit Question maxLimit number
- */
-export const paginationMaxLimit = (maxLimit: number): void => {
-  const maxPaginationLimit: number = config.get('server.pagination.limit');
-  if (maxLimit > maxPaginationLimit) {
-    throw new GraphQLError(
-      i18next.t('common.errors.maximumPaginationLimit', {
-        paginationLimit: maxPaginationLimit,
-      })
-    );
-  }
-};
 
 /** Default aggregation common to all records to make lookups for default fields. */
 const defaultRecordAggregation = [
@@ -252,7 +234,8 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
     context,
     info
   ) => {
-    paginationMaxLimit(first);
+    // Make sure that the page size is not too important
+    checkPageSize(first);
     try {
       const user: User = context.user;
       if (!user) {

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -17,9 +17,27 @@ import buildCalculatedFieldPipeline from '@utils/aggregation/buildCalculatedFiel
 import { flatten, get, isArray } from 'lodash';
 import { logger } from '@services/logger.service';
 import config from 'config';
+import i18next from 'i18next';
 
 /** Default number for items to get */
 const DEFAULT_FIRST = 25;
+
+/**
+ * Checks pagination maximum limit of data.
+ * Throw pagination maximum limit cross than error.
+ *
+ * @param maxLimit Question maxLimit number
+ */
+export const paginationMaxLimit = (maxLimit: number): void => {
+  const maxPaginationLimit: number = config.get('server.pagination.limit');
+  if (maxLimit > maxPaginationLimit) {
+    throw new GraphQLError(
+      i18next.t('common.errors.maximumPaginationLimit', {
+        paginationLimit: maxPaginationLimit,
+      })
+    );
+  }
+};
 
 /** Default aggregation common to all records to make lookups for default fields. */
 const defaultRecordAggregation = [
@@ -234,14 +252,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
     context,
     info
   ) => {
-    const paginationMaxLimit: number = config.get('server.pagination.limit');
-    if (first > paginationMaxLimit) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.maximumPaginationLimit', {
-          paginationLimit: paginationMaxLimit,
-        })
-      );
-    }
+    paginationMaxLimit(first);
     try {
       const user: User = context.user;
       if (!user) {

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -16,6 +16,7 @@ import { getAccessibleFields } from '@utils/form';
 import buildCalculatedFieldPipeline from '@utils/aggregation/buildCalculatedFieldPipeline';
 import { flatten, get, isArray } from 'lodash';
 import { logger } from '@services/logger.service';
+import config from 'config';
 
 /** Default number for items to get */
 const DEFAULT_FIRST = 25;
@@ -233,6 +234,14 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
     context,
     info
   ) => {
+    const paginationMaxLimit: number = config.get('server.pagination.limit');
+    if (first > paginationMaxLimit) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.maximumPaginationLimit', {
+          paginationLimit: paginationMaxLimit,
+        })
+      );
+    }
     try {
       const user: User = context.user;
       if (!user) {


### PR DESCRIPTION
# Description
in the config file, add a parameter for the max pagination
in all places that would use pagination, throw an error if page size is greater than 1000
error can be:
Maximum page size is 1000. Please use a different page size.
1000 should be injected from the config, so the text of the notification should be:
Maximum page size is {value}. Please use a different page size.
and you inject the value dynamically in the string

## Ticket
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/54896

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

