### PR TITLE
fix/OORT-633_update-field-level-permission-fails

### DIFF
--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -281,7 +281,26 @@ export default {
                 const storedFieldChanged = !isEqual(oldField, field);
                 if (storedFieldChanged) {
                   // Inherit the field's permissions
-                  field.permissions = oldField.permissions;
+                  field.permissions = {
+                    canSee: oldField.permissions.canSee.length
+                      ? typeof oldField.permissions.canSee[0] === 'string'
+                        ? [
+                            new mongoose.Types.ObjectId(
+                              oldField.permissions.canSee[0]
+                            ),
+                          ]
+                        : oldField.permissions.canSee
+                      : [],
+                    canUpdate: oldField.permissions.canUpdate.length
+                      ? typeof oldField.permissions.canUpdate[0] === 'string'
+                        ? [
+                            new mongoose.Types.ObjectId(
+                              oldField.permissions.canUpdate[0]
+                            ),
+                          ]
+                        : oldField.permissions.canUpdate
+                      : [],
+                  };
                   // If the resource's field and the current form's field are different
                   const index = oldFields.findIndex(
                     (x) => x.name === field.name


### PR DESCRIPTION
# Description
The update of field level permission in the resources page fails after editing and saving the form, because the field permissions were saved as strings and not object Ids.

## Ticket
[OORT-633: Permissions: Toggling field level permission fails sometimes](https://oortcloud.atlassian.net/browse/OORT-633)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Editing forms and trying to update their fields permissions in the resources pages.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

