### PR TITLE
Fix/ab#65380 abc some back end errors are not handled correctly

### DIFF
--- a/src/schema/mutation/addChannel.mutation.ts
+++ b/src/schema/mutation/addChannel.mutation.ts
@@ -20,32 +20,30 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      const application = await Application.findById(args.application);
-      if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-      if (ability.can('update', application)) {
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    const application = await Application.findById(args.application);
+    if (!application)
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    if (ability.can('update', application)) {
+      try {
         const channel = new Channel({
           title: args.title,
           application: args.application,
         });
         return await channel.save();
-      } else {
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t('common.errors.internalServerError')
         );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    } else {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/mutation/addDashboard.mutation.ts
+++ b/src/schema/mutation/addDashboard.mutation.ts
@@ -14,34 +14,32 @@ export default {
     name: { type: new GraphQLNonNull(GraphQLString) },
   },
   resolve(parent, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      if (ability.can('create', 'Dashboard')) {
-        if (args.name !== '') {
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    if (ability.can('create', 'Dashboard')) {
+      if (args.name !== '') {
+        try {
           const dashboard = new Dashboard({
             name: args.name,
             //createdAt: new Date(),
           });
           return dashboard.save();
+        } catch (err) {
+          logger.error(err.message, { stack: err.stack });
+          throw new GraphQLError(
+            context.i18next.t('common.errors.internalServerError')
+          );
         }
-        throw new GraphQLError(
-          context.i18next.t('mutations.dashboard.add.errors.invalidArguments')
-        );
-      } else {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('mutations.dashboard.add.errors.invalidArguments')
+      );
+    } else {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/mutation/addDistributionList.mutation.ts
+++ b/src/schema/mutation/addDistributionList.mutation.ts
@@ -17,31 +17,29 @@ export default {
     distributionList: { type: new GraphQLNonNull(DistributionListInputType) },
   },
   async resolve(_, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = extendAbilityForApplications(
-        user,
-        args.application
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = extendAbilityForApplications(
+      user,
+      args.application
+    );
+    if (ability.cannot('update', 'DistributionList')) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
-      if (ability.cannot('update', 'DistributionList')) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      // Prevent wrong emails to be saved
-      if (
-        args.distributionList.emails.filter((x) => !validateEmail(x)).length > 0
-      ) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.invalidEmailsInput')
-        );
-      }
+    }
+    // Prevent wrong emails to be saved
+    if (
+      args.distributionList.emails.filter((x) => !validateEmail(x)).length > 0
+    ) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.invalidEmailsInput')
+      );
+    }
 
+    try {
       const update = {
         $addToSet: {
           distributionLists: {

--- a/src/schema/mutation/addForm.mutation.ts
+++ b/src/schema/mutation/addForm.mutation.ts
@@ -24,117 +24,114 @@ export default {
     template: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try {
-      // Check authentication
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      // Check permission to create form
-      if (ability.cannot('create', 'Form')) {
+    // Check authentication
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    // Check permission to create form
+    if (ability.cannot('create', 'Form')) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+    // Check if another form with same name exists
+    const graphQLTypeName = Form.getGraphQLTypeName(args.name);
+    validateGraphQLTypeName(graphQLTypeName, context.i18next);
+    if (
+      (await Form.hasDuplicate(graphQLTypeName)) ||
+      (await ReferenceData.hasDuplicate(graphQLTypeName))
+    ) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.duplicatedGraphQLTypeName')
+      );
+    }
+    // define default permission lists
+    const userGlobalRoles =
+      user.roles
+        .filter((role: Role) => !role.application)
+        .map((role: Role) => role._id) || [];
+    const defaultFormPermissions = {
+      canSee: userGlobalRoles,
+      canUpdate: userGlobalRoles,
+      canDelete: userGlobalRoles,
+    };
+    const defaultResourcePermissions = {
+      ...defaultFormPermissions,
+      canSeeRecords: [],
+      canCreateRecords: [],
+      canUpdateRecords: [],
+      canDeleteRecords: [],
+    };
+    if (!args.resource) {
+      // Check permission to create resource
+      if (ability.cannot('create', 'Resource')) {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-      // Check if another form with same name exists
-      const graphQLTypeName = Form.getGraphQLTypeName(args.name);
-      validateGraphQLTypeName(graphQLTypeName, context.i18next);
-      if (
-        (await Form.hasDuplicate(graphQLTypeName)) ||
-        (await ReferenceData.hasDuplicate(graphQLTypeName))
-      ) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.duplicatedGraphQLTypeName')
-        );
-      }
-      // define default permission lists
-      const userGlobalRoles =
-        user.roles
-          .filter((role: Role) => !role.application)
-          .map((role: Role) => role._id) || [];
-      const defaultFormPermissions = {
-        canSee: userGlobalRoles,
-        canUpdate: userGlobalRoles,
-        canDelete: userGlobalRoles,
-      };
-      const defaultResourcePermissions = {
-        ...defaultFormPermissions,
-        canSeeRecords: [],
-        canCreateRecords: [],
-        canUpdateRecords: [],
-        canDeleteRecords: [],
-      };
       try {
-        if (!args.resource) {
-          // Check permission to create resource
-          if (ability.cannot('create', 'Resource')) {
-            throw new GraphQLError(
-              context.i18next.t('common.errors.permissionNotGranted')
-            );
-          }
-          // create resource
-          const resource = new Resource({
-            name: args.name,
-            //createdAt: new Date(),
-            permissions: defaultResourcePermissions,
-          });
-          await resource.save();
-          // create form
-          const form = new Form({
-            name: args.name,
-            graphQLTypeName,
-            status: status.pending,
-            resource,
-            core: true,
-            permissions: defaultFormPermissions,
-          });
-          await form.save();
-          buildTypes();
-          return form;
-        } else {
-          // fetch the resource and the core form
-          const resource = await Resource.findById(args.resource);
-          const coreForm = await Form.findOne({
-            resource: args.resource,
-            core: true,
-          });
-          // create the form following the template or the core form
-          let fields = coreForm.fields;
-          let structure = coreForm.structure;
-          if (args.template) {
-            const templateForm = await Form.findOne({
-              resource: args.resource,
-              _id: args.template,
-            });
-            if (templateForm) structure = templateForm.structure;
-            if (templateForm.fields.length > 0) fields = templateForm.fields;
-          }
-          const form = new Form({
-            name: args.name,
-            graphQLTypeName,
-            status: status.pending,
-            resource,
-            structure,
-            fields,
-            permissions: defaultFormPermissions,
-          });
-          await form.save();
-          buildTypes();
-          return form;
-        }
+        // create resource
+        const resource = new Resource({
+          name: args.name,
+          //createdAt: new Date(),
+          permissions: defaultResourcePermissions,
+        });
+        await resource.save();
+        // create form
+        const form = new Form({
+          name: args.name,
+          graphQLTypeName,
+          status: status.pending,
+          resource,
+          core: true,
+          permissions: defaultFormPermissions,
+        });
+        await form.save();
+        buildTypes();
+        return form;
       } catch (error) {
         throw new GraphQLError(
           context.i18next.t('mutations.form.add.errors.resourceDuplicated')
         );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
-      throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
-      );
+    } else {
+      try {
+        // fetch the resource and the core form
+        const resource = await Resource.findById(args.resource);
+        const coreForm = await Form.findOne({
+          resource: args.resource,
+          core: true,
+        });
+        // create the form following the template or the core form
+        let fields = coreForm.fields;
+        let structure = coreForm.structure;
+        if (args.template) {
+          const templateForm = await Form.findOne({
+            resource: args.resource,
+            _id: args.template,
+          });
+          if (templateForm) structure = templateForm.structure;
+          if (templateForm.fields.length > 0) fields = templateForm.fields;
+        }
+        const form = new Form({
+          name: args.name,
+          graphQLTypeName,
+          status: status.pending,
+          resource,
+          structure,
+          fields,
+          permissions: defaultFormPermissions,
+        });
+        await form.save();
+        buildTypes();
+        return form;
+      } catch (error) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.form.add.errors.resourceDuplicated')
+        );
+      }
     }
   },
 };

--- a/src/schema/mutation/addForm.mutation.ts
+++ b/src/schema/mutation/addForm.mutation.ts
@@ -10,7 +10,6 @@ import { buildTypes } from '@utils/schema';
 import { FormType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { status } from '@const/enumTypes';
-import { logger } from '@services/logger.service';
 
 /**
  * Create a new form

--- a/src/schema/mutation/addPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/addPositionAttributeCategory.mutation.ts
@@ -19,32 +19,30 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      const application = await Application.findById(args.application);
-      if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-      if (ability.can('update', application)) {
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    const application = await Application.findById(args.application);
+    if (!application)
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    if (ability.can('update', application)) {
+      try {
         const category = new PositionAttributeCategory({
           title: args.title,
           application: args.application,
         });
         return await category.save();
-      } else {
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t('common.errors.internalServerError')
         );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    } else {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/mutation/addRole.mutation.ts
+++ b/src/schema/mutation/addRole.mutation.ts
@@ -20,47 +20,48 @@ export default {
     application: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      if (args.application) {
-        const application = await Application.findById(args.application);
-        if (!application)
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
-        const role = new Role({
-          title: args.title,
-        });
-        if (!application)
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    if (args.application) {
+      const application = await Application.findById(args.application);
+      if (!application)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      const role = new Role({
+        title: args.title,
+      });
+      if (!application)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      try {
         role.application = args.application;
         if (ability.can('create', role)) {
           return await role.save();
         }
-      } else {
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+        throw new GraphQLError(
+          context.i18next.t('common.errors.internalServerError')
+        );
+      }
+    } else {
+      try {
         const role = new Role({
           title: args.title,
         });
         if (ability.can('create', role)) {
           return await role.save();
         }
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+        throw new GraphQLError(
+          context.i18next.t('common.errors.internalServerError')
+        );
       }
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
-      throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
-      );
     }
+    throw new GraphQLError(
+      context.i18next.t('common.errors.permissionNotGranted')
+    );
   },
 };

--- a/src/schema/mutation/addSubscription.mutation.ts
+++ b/src/schema/mutation/addSubscription.mutation.ts
@@ -25,38 +25,32 @@ export default {
     channel: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      const application = await Application.findById(args.application);
-      if (!application)
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    const application = await Application.findById(args.application);
+    if (!application)
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+
+    if (args.convertTo) {
+      const form = await Form.findById(args.convertTo);
+      if (!form)
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    }
 
-      if (args.convertTo) {
-        const form = await Form.findById(args.convertTo);
-        if (!form)
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
-      }
+    if (args.channel) {
+      const filters = {
+        application: mongoose.Types.ObjectId(args.application),
+        _id: args.channel,
+      };
+      const channel = await Channel.findOne(filters);
+      if (!channel)
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    }
 
-      if (args.channel) {
-        const filters = {
-          application: mongoose.Types.ObjectId(args.application),
-          _id: args.channel,
-        };
-        const channel = await Channel.findOne(filters);
-        if (!channel)
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
-      }
-
+    try {
       const subscription = {
         routingKey: args.routingKey,
         title: args.title,

--- a/src/schema/mutation/addTemplate.mutation.ts
+++ b/src/schema/mutation/addTemplate.mutation.ts
@@ -16,23 +16,21 @@ export default {
     template: { type: new GraphQLNonNull(TemplateInputType) },
   },
   async resolve(_, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = extendAbilityForApplications(
-        user,
-        args.application
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = extendAbilityForApplications(
+      user,
+      args.application
+    );
+    if (ability.cannot('update', 'Template')) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
-      if (ability.cannot('update', 'Template')) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
+    }
 
+    try {
       const update = {
         $addToSet: {
           templates: {

--- a/src/schema/mutation/addUsers.mutation.ts
+++ b/src/schema/mutation/addUsers.mutation.ts
@@ -19,103 +19,101 @@ export default {
     application: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
 
-      // Check permissions depending if it's an application's user or a global user
-      if (ability.cannot('update', 'User')) {
-        if (args.application) {
-          const canUpdate = user.roles
-            .filter((x) =>
-              x.application ? x.application.equals(args.application) : false
-            )
-            .flatMap((x) => x.permissions)
-            .some((x) => x.type === permissions.canSeeUsers);
-          if (!canUpdate) {
-            throw new GraphQLError(
-              context.i18next.t('common.errors.permissionNotGranted')
-            );
-          }
-        } else {
+    // Check permissions depending if it's an application's user or a global user
+    if (ability.cannot('update', 'User')) {
+      if (args.application) {
+        const canUpdate = user.roles
+          .filter((x) =>
+            x.application ? x.application.equals(args.application) : false
+          )
+          .flatMap((x) => x.permissions)
+          .some((x) => x.type === permissions.canSeeUsers);
+        if (!canUpdate) {
           throw new GraphQLError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
-      }
-      if (args.users.filter((x) => !validateEmail(x.email)).length > 0) {
+      } else {
         throw new GraphQLError(
-          context.i18next.t('common.errors.invalidEmailsInput')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-      // Separate registered users and new users
-      const invitedUsers: User[] = [];
-      const existingUserUpdates: any[] = [];
-      const registeredUsers = await User.find({
-        username: { $in: args.users.map((x) => x.email) },
-      }).select('username');
-      const registeredEmails = registeredUsers.map((x) => x.username);
-      // New users
-      args.users
-        .filter((x) => !registeredEmails.includes(x.email))
-        .forEach((x) => {
-          const newUser = new User();
-          newUser.username = x.email;
-          newUser.roles = [x.role];
-          if (x.positionAttributes) {
-            newUser.positionAttributes = x.positionAttributes;
-          }
-          // remove after 7 days if the user does not activate the account
-          const date = new Date();
-          date.setDate(date.getDate() + 7);
-          newUser.deleteAt = date;
-          invitedUsers.push(newUser);
-        });
-      // Registered users
-      args.users
-        .filter((x) => registeredEmails.includes(x.email))
-        .forEach((x) => {
-          const updateUser = {
-            $addToSet: {
-              roles: x.role,
-              positionAttributes: { $each: x.positionAttributes },
-            },
-          };
-          existingUserUpdates.push({
-            updateOne: {
-              filter: { username: x.email },
-              update: updateUser,
-            },
-          });
-        });
-
-      const application = args.application
-        ? await Application.findById(args.application)
-        : null;
-      // Save the new users
-      if (invitedUsers.length > 0) {
-        await User.insertMany(invitedUsers);
-        if (config.get('email.sendInvite')) {
-          await sendCreateAccountInvitation(
-            invitedUsers.map((x) => x.username),
-            user,
-            application
-          );
+    }
+    if (args.users.filter((x) => !validateEmail(x.email)).length > 0) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.invalidEmailsInput')
+      );
+    }
+    // Separate registered users and new users
+    const invitedUsers: User[] = [];
+    const existingUserUpdates: any[] = [];
+    const registeredUsers = await User.find({
+      username: { $in: args.users.map((x) => x.email) },
+    }).select('username');
+    const registeredEmails = registeredUsers.map((x) => x.username);
+    // New users
+    args.users
+      .filter((x) => !registeredEmails.includes(x.email))
+      .forEach((x) => {
+        const newUser = new User();
+        newUser.username = x.email;
+        newUser.roles = [x.role];
+        if (x.positionAttributes) {
+          newUser.positionAttributes = x.positionAttributes;
         }
-      }
-      //Update the existing ones
-      if (registeredEmails.length > 0) {
-        await User.bulkWrite(existingUserUpdates);
-        if (application && config.get('email.sendInvite')) {
-          await sendAppInvitation(registeredEmails, user, application);
-        }
-      }
+        // remove after 7 days if the user does not activate the account
+        const date = new Date();
+        date.setDate(date.getDate() + 7);
+        newUser.deleteAt = date;
+        invitedUsers.push(newUser);
+      });
+    // Registered users
+    args.users
+      .filter((x) => registeredEmails.includes(x.email))
+      .forEach((x) => {
+        const updateUser = {
+          $addToSet: {
+            roles: x.role,
+            positionAttributes: { $each: x.positionAttributes },
+          },
+        };
+        existingUserUpdates.push({
+          updateOne: {
+            filter: { username: x.email },
+            update: updateUser,
+          },
+        });
+      });
 
+    const application = args.application
+      ? await Application.findById(args.application)
+      : null;
+    // Save the new users
+    if (invitedUsers.length > 0) {
+      await User.insertMany(invitedUsers);
+      if (config.get('email.sendInvite')) {
+        await sendCreateAccountInvitation(
+          invitedUsers.map((x) => x.username),
+          user,
+          application
+        );
+      }
+    }
+    //Update the existing ones
+    if (registeredEmails.length > 0) {
+      await User.bulkWrite(existingUserUpdates);
+      if (application && config.get('email.sendInvite')) {
+        await sendAppInvitation(registeredEmails, user, application);
+      }
+    }
+
+    try {
       // Return the full list of users
       return await User.find({
         username: { $in: args.users.map((x) => x.email) },

--- a/src/schema/mutation/deleteAggregation.mutation.ts
+++ b/src/schema/mutation/deleteAggregation.mutation.ts
@@ -15,42 +15,40 @@ export default {
     resource: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try {
-      if (!args.resource) {
+    if (!args.resource) {
+      throw new GraphQLError(
+        context.i18next.t(
+          'mutations.aggregation.delete.errors.invalidArguments'
+        )
+      );
+    }
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    // Edition of a resource
+    if (args.resource) {
+      const filters = Resource.accessibleBy(ability, 'update')
+        .where({ _id: args.resource })
+        .getFilter();
+      const resource: Resource = await Resource.findOne(filters);
+      if (!resource) {
         throw new GraphQLError(
-          context.i18next.t(
-            'mutations.aggregation.delete.errors.invalidArguments'
-          )
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      // Edition of a resource
-      if (args.resource) {
-        const filters = Resource.accessibleBy(ability, 'update')
-          .where({ _id: args.resource })
-          .getFilter();
-        const resource: Resource = await Resource.findOne(filters);
-        if (!resource) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
-        }
 
+      try {
         const aggregation = resource.aggregations.id(args.id).remove();
         await resource.save();
         return aggregation;
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+        throw new GraphQLError(
+          context.i18next.t('common.errors.internalServerError')
+        );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
-      throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
-      );
     }
   },
 };

--- a/src/schema/mutation/deleteCustomNotification.mutation.ts
+++ b/src/schema/mutation/deleteCustomNotification.mutation.ts
@@ -16,23 +16,21 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(_, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = extendAbilityForApplications(
-        user,
-        args.application
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = extendAbilityForApplications(
+      user,
+      args.application
+    );
+    if (ability.cannot('delete', 'CustomNotification')) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
-      if (ability.cannot('delete', 'CustomNotification')) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
+    }
 
+    try {
       const update = {
         $pull: { customNotifications: { _id: args.id } },
       };

--- a/src/schema/mutation/deleteDistributionList.mutation.ts
+++ b/src/schema/mutation/deleteDistributionList.mutation.ts
@@ -15,23 +15,21 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(_, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = extendAbilityForApplications(
-        user,
-        args.application
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = extendAbilityForApplications(
+      user,
+      args.application
+    );
+    if (ability.cannot('update', 'DistributionList')) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
-      if (ability.cannot('update', 'DistributionList')) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
+    }
 
+    try {
       const update = {
         $pull: { distributionLists: { _id: args.id } },
       };

--- a/src/schema/mutation/deleteForm.mutation.ts
+++ b/src/schema/mutation/deleteForm.mutation.ts
@@ -15,27 +15,25 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      // Get ability
-      const ability: AppAbility = user.ability;
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    // Get ability
+    const ability: AppAbility = user.ability;
 
-      // Get the form
-      const filters = Form.accessibleBy(ability, 'delete')
-        .where({ _id: args.id })
-        .getFilter();
-      const form = await Form.findOne(filters);
-      if (!form) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
+    // Get the form
+    const filters = Form.accessibleBy(ability, 'delete')
+      .where({ _id: args.id })
+      .getFilter();
+    const form = await Form.findOne(filters);
+    if (!form) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+    try {
       // if is core form we have to delete the linked forms and resource
       if (form.core) {
         // delete the resource and all forms associated

--- a/src/schema/mutation/deleteGroup.mutation.ts
+++ b/src/schema/mutation/deleteGroup.mutation.ts
@@ -14,31 +14,31 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability: AppAbility = context.user.ability;
-      const filters = Group.accessibleBy(ability, 'delete')
-        .where({ _id: args.id })
-        .getFilter();
-      const group = await Group.findOneAndDelete(filters);
-      if (group) {
-        return group;
-      } else {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
+    const ability: AppAbility = context.user.ability;
+    const filters = Group.accessibleBy(ability, 'delete')
+      .where({ _id: args.id })
+      .getFilter();
+
+    let group;
+    try {
+      group = await Group.findOneAndDelete(filters);
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
+      );
+    }
+    if (group) {
+      return group;
+    } else {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/mutation/deleteLayout.mutation.ts
+++ b/src/schema/mutation/deleteLayout.mutation.ts
@@ -16,53 +16,58 @@ export default {
     form: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try {
-      if (args.form && args.resource) {
+    if (args.form && args.resource) {
+      throw new GraphQLError(
+        context.i18next.t('mutations.layout.delete.errors.invalidArguments')
+      );
+    }
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    // Edition of a resource
+    if (args.resource) {
+      const filters = Resource.accessibleBy(ability, 'update')
+        .where({ _id: args.resource })
+        .getFilter();
+      const resource: Resource = await Resource.findOne(filters);
+      if (!resource) {
         throw new GraphQLError(
-          context.i18next.t('mutations.layout.delete.errors.invalidArguments')
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      // Edition of a resource
-      if (args.resource) {
-        const filters = Resource.accessibleBy(ability, 'update')
-          .where({ _id: args.resource })
-          .getFilter();
-        const resource: Resource = await Resource.findOne(filters);
-        if (!resource) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
-        }
+      try {
         const layout = resource.layouts.id(args.id).remove();
         await resource.save();
         return layout;
-      } else {
-        // Edition of a Form
-        const filters = Form.accessibleBy(ability, 'update')
-          .where({ _id: args.form })
-          .getFilter();
-        const form: Form = await Form.findOne(filters);
-        if (!form) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
-        }
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+        throw new GraphQLError(
+          context.i18next.t('common.errors.internalServerError')
+        );
+      }
+    } else {
+      // Edition of a Form
+      const filters = Form.accessibleBy(ability, 'update')
+        .where({ _id: args.form })
+        .getFilter();
+      const form: Form = await Form.findOne(filters);
+      if (!form) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      try {
         const layout = form.layouts.id(args.id).remove();
         await form.save();
         return layout;
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+        throw new GraphQLError(
+          context.i18next.t('common.errors.internalServerError')
+        );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
-      throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
-      );
     }
   },
 };

--- a/src/schema/mutation/deletePage.mutation.ts
+++ b/src/schema/mutation/deletePage.mutation.ts
@@ -15,25 +15,23 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
+    // Authentication check
+    const user = context.user;
+    if (!user)
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+
+    // get data
+    const page = await Page.findById(args.id);
+
+    // get permissions
+    const ability = await extendAbilityForPage(user, page);
+    if (ability.cannot('delete', page)) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user)
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-
-      // get data
-      const page = await Page.findById(args.id);
-
-      // get permissions
-      const ability = await extendAbilityForPage(user, page);
-      if (ability.cannot('delete', page)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-
       // delete page
       await page.deleteOne();
       return page;

--- a/src/schema/mutation/deleteRole.mutation.ts
+++ b/src/schema/mutation/deleteRole.mutation.ts
@@ -14,31 +14,31 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability: AppAbility = context.user.ability;
-      const filters = Role.accessibleBy(ability, 'delete')
-        .where({ _id: args.id })
-        .getFilter();
-      const role = await Role.findOneAndDelete(filters);
-      if (role) {
-        return role;
-      } else {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
+    const ability: AppAbility = context.user.ability;
+    const filters = Role.accessibleBy(ability, 'delete')
+      .where({ _id: args.id })
+      .getFilter();
+
+    let role;
+    try {
+      role = await Role.findOneAndDelete(filters);
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
+      );
+    }
+    if (role) {
+      return role;
+    } else {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/mutation/deleteSubscription.mutation.ts
+++ b/src/schema/mutation/deleteSubscription.mutation.ts
@@ -21,22 +21,20 @@ export default {
     routingKey: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability: AppAbility = context.user.ability;
-      const filters = Application.accessibleBy(ability, 'update')
-        .where({ _id: args.applicationId })
-        .getFilter();
-      const application = await Application.findOne(filters);
-      if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    const ability: AppAbility = context.user.ability;
+    const filters = Application.accessibleBy(ability, 'update')
+      .where({ _id: args.applicationId })
+      .getFilter();
+    const application = await Application.findOne(filters);
+    if (!application)
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    try {
       application.subscriptions = await application.subscriptions.filter(
         (sub) => sub.routingKey !== args.routingKey
       );

--- a/src/schema/mutation/deleteTemplate.mutation.ts
+++ b/src/schema/mutation/deleteTemplate.mutation.ts
@@ -15,23 +15,21 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(_, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = extendAbilityForApplications(
-        user,
-        args.application
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = extendAbilityForApplications(
+      user,
+      args.application
+    );
+    if (ability.cannot('update', 'Template')) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
-      if (ability.cannot('update', 'Template')) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
+    }
 
+    try {
       const update = {
         $pull: { templates: { _id: args.id } },
       };

--- a/src/schema/mutation/deleteUsers.mutation.ts
+++ b/src/schema/mutation/deleteUsers.mutation.ts
@@ -19,27 +19,25 @@ export default {
     ids: { type: new GraphQLNonNull(new GraphQLList(GraphQLID)) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      if (ability.can('delete', 'User')) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    if (ability.can('delete', 'User')) {
+      try {
         const result = await User.deleteMany({ _id: { $in: args.ids } });
         return result.deletedCount;
-      } else {
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t('common.errors.internalServerError')
         );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    } else {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/mutation/deleteWorkflow.mutation.ts
+++ b/src/schema/mutation/deleteWorkflow.mutation.ts
@@ -14,17 +14,15 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability: AppAbility = context.user.ability;
-      let workflow = null;
+    const ability: AppAbility = context.user.ability;
+    let workflow = null;
+    try {
       if (ability.can('delete', 'Workflow')) {
         workflow = await Workflow.findByIdAndDelete(args.id);
       } else {
@@ -38,16 +36,16 @@ export default {
           workflow = await Workflow.findByIdAndDelete(args.id);
         }
       }
-      if (!workflow)
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      return workflow;
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
       );
     }
+    if (!workflow)
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    return workflow;
   },
 };

--- a/src/schema/mutation/duplicatePage.mutation.ts
+++ b/src/schema/mutation/duplicatePage.mutation.ts
@@ -18,112 +18,117 @@ export default {
     application: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Check ability
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      // Check parameters
-      if (!args.page && !args.step) {
-        throw new GraphQLError(
-          context.i18next.t(
-            'mutations.application.content.duplicate.errors.missingArguments'
-          )
-        );
-      }
-      if (args.page && args.step) {
-        throw new GraphQLError(
-          context.i18next.t(
-            'mutations.application.content.duplicate.errors.incompatibleArguments'
-          )
-        );
-      }
-      // Find application
-      const application = await Application.findById(args.application);
-      if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-      // Check access to the application
-      if (ability.can('update', application)) {
-        if (args.page) {
-          // If page
-          const page = await Page.findById(args.page);
-          if (!page) throw new GraphQLError('common.errors.dataNotFound');
-          const pageApplication = await Application.findOne({
-            pages: { $in: [args.page] },
-          });
-          if (!pageApplication)
-            throw new GraphQLError('common.errors.dataNotFound');
-          if (ability.can('update', pageApplication)) {
-            // Get list of roles for default permissions
-            const roles = await Role.find({ application: application._id });
-            const permissions = {
-              canSee: roles.map((x) => x.id),
-              canUpdate: [],
-              canDelete: [],
-            };
-            // Create the new page and set the permissions
-            const newPage = await duplicatePage(
-              page,
-              `${page.name} Copy`,
-              permissions
-            );
-            const update = {
-              $push: { pages: newPage.id },
-            };
+    // Check ability
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    // Check parameters
+    if (!args.page && !args.step) {
+      throw new GraphQLError(
+        context.i18next.t(
+          'mutations.application.content.duplicate.errors.missingArguments'
+        )
+      );
+    }
+    if (args.page && args.step) {
+      throw new GraphQLError(
+        context.i18next.t(
+          'mutations.application.content.duplicate.errors.incompatibleArguments'
+        )
+      );
+    }
+    // Find application
+    const application = await Application.findById(args.application);
+    if (!application)
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    // Check access to the application
+    if (ability.can('update', application)) {
+      if (args.page) {
+        // If page
+        const page = await Page.findById(args.page);
+        if (!page) throw new GraphQLError('common.errors.dataNotFound');
+        const pageApplication = await Application.findOne({
+          pages: { $in: [args.page] },
+        });
+        if (!pageApplication)
+          throw new GraphQLError('common.errors.dataNotFound');
+        if (ability.can('update', pageApplication)) {
+          // Get list of roles for default permissions
+          const roles = await Role.find({ application: application._id });
+          const permissions = {
+            canSee: roles.map((x) => x.id),
+            canUpdate: [],
+            canDelete: [],
+          };
+          // Create the new page and set the permissions
+          const newPage = await duplicatePage(
+            page,
+            `${page.name} Copy`,
+            permissions
+          );
+          const update = {
+            $push: { pages: newPage.id },
+          };
+          try {
             await Application.findByIdAndUpdate(args.application, update);
             return newPage;
-          }
-        } else {
-          // If step
-          const step = await Step.findById(args.step);
-          if (!step) throw new GraphQLError('common.errors.dataNotFound');
-          const workflow = await Workflow.findOne({
-            steps: { $in: [args.step] },
-          });
-          if (!workflow) throw new GraphQLError('common.errors.dataNotFound');
-          const page = await Page.findOne({
-            content: workflow._id,
-          });
-          if (!page) throw new GraphQLError('common.errors.dataNotFound');
-          const stepApplication = await Application.findOne({
-            pages: { $in: [page._id] },
-          });
-          if (!stepApplication)
-            throw new GraphQLError('common.errors.dataNotFound');
-          if (ability.can('update', stepApplication)) {
-            // Get list of roles for default permissions
-            const roles = await Role.find({ application: application._id });
-            const permissions = {
-              canSee: roles.map((x) => x.id),
-              canUpdate: [],
-              canDelete: [],
-            };
-            // Create the new page and set the permissions
-            const newPage = await duplicatePage(
-              new Page(step),
-              `${step.name} Copy`,
-              permissions
+          } catch (err) {
+            logger.error(err.message, { stack: err.stack });
+            throw new GraphQLError(
+              context.i18next.t('common.errors.internalServerError')
             );
-            const update = {
-              $push: { pages: newPage.id },
-            };
-            await Application.findByIdAndUpdate(args.application, update);
-            return newPage;
           }
         }
       } else {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
+        // If step
+        const step = await Step.findById(args.step);
+        if (!step) throw new GraphQLError('common.errors.dataNotFound');
+        const workflow = await Workflow.findOne({
+          steps: { $in: [args.step] },
+        });
+        if (!workflow) throw new GraphQLError('common.errors.dataNotFound');
+        const page = await Page.findOne({
+          content: workflow._id,
+        });
+        if (!page) throw new GraphQLError('common.errors.dataNotFound');
+        const stepApplication = await Application.findOne({
+          pages: { $in: [page._id] },
+        });
+        if (!stepApplication)
+          throw new GraphQLError('common.errors.dataNotFound');
+        if (ability.can('update', stepApplication)) {
+          // Get list of roles for default permissions
+          const roles = await Role.find({ application: application._id });
+          const permissions = {
+            canSee: roles.map((x) => x.id),
+            canUpdate: [],
+            canDelete: [],
+          };
+          // Create the new page and set the permissions
+          const newPage = await duplicatePage(
+            new Page(step),
+            `${step.name} Copy`,
+            permissions
+          );
+          const update = {
+            $push: { pages: newPage.id },
+          };
+          try {
+            await Application.findByIdAndUpdate(args.application, update);
+            return newPage;
+          } catch (err) {
+            logger.error(err.message, { stack: err.stack });
+            throw new GraphQLError(
+              context.i18next.t('common.errors.internalServerError')
+            );
+          }
+        }
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    } else {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/mutation/editChannel.mutation.ts
+++ b/src/schema/mutation/editChannel.mutation.ts
@@ -20,19 +20,17 @@ export default {
     title: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = context.user.ability;
-      const channel = await Channel.findById(args.id);
-      if (!channel)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-      if (ability.can('update', channel)) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = context.user.ability;
+    const channel = await Channel.findById(args.id);
+    if (!channel)
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    if (ability.can('update', channel)) {
+      try {
         return await Channel.findByIdAndUpdate(
           args.id,
           {
@@ -40,15 +38,15 @@ export default {
           },
           { new: true }
         );
-      } else {
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t('common.errors.internalServerError')
         );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    } else {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/mutation/editCustomNotification.mutation.ts
+++ b/src/schema/mutation/editCustomNotification.mutation.ts
@@ -22,34 +22,33 @@ export default {
     notification: { type: new GraphQLNonNull(CustomNotificationInputType) },
   },
   async resolve(_, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = extendAbilityForApplications(
-        user,
-        args.application
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = extendAbilityForApplications(
+      user,
+      args.application
+    );
+    if (ability.cannot('update', 'CustomNotification')) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
-      if (ability.cannot('update', 'CustomNotification')) {
+    }
+    // Test that the frequency is not too high
+    if (args.notification.schedule) {
+      // make sure minute is not a wildcard
+      const reg = new RegExp('^([0-9]|[1-5][0-9])$');
+      if (!reg.test(args.notification.schedule.split(' ')[0])) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t(
+            'mutations.customNotification.add.errors.maximumFrequency'
+          )
         );
       }
-      // Test that the frequency is not too high
-      if (args.notification.schedule) {
-        // make sure minute is not a wildcard
-        const reg = new RegExp('^([0-9]|[1-5][0-9])$');
-        if (!reg.test(args.notification.schedule.split(' ')[0])) {
-          throw new GraphQLError(
-            context.i18next.t(
-              'mutations.customNotification.add.errors.maximumFrequency'
-            )
-          );
-        }
-      }
+    }
+    let application;
+    try {
       // Save custom notification in application
       const update = {
         $set: {
@@ -66,30 +65,28 @@ export default {
         },
       };
 
-      const application = await Application.findOneAndUpdate(
+      application = await Application.findOneAndUpdate(
         { _id: args.application, 'customNotifications._id': args.id },
         update,
         { new: true }
       );
-
-      const notificationDetail = application.customNotifications.find(
-        (customNotification) => customNotification.id.toString() === args.id
-      );
-      if (
-        args.notification.notification_status ===
-        customNotificationStatus.active
-      ) {
-        scheduleCustomNotificationJob(notificationDetail, application);
-      } else {
-        unscheduleCustomNotificationJob(notificationDetail);
-      }
-
-      return notificationDetail;
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
       );
     }
+
+    const notificationDetail = application.customNotifications.find(
+      (customNotification) => customNotification.id.toString() === args.id
+    );
+    if (
+      args.notification.notification_status === customNotificationStatus.active
+    ) {
+      scheduleCustomNotificationJob(notificationDetail, application);
+    } else {
+      unscheduleCustomNotificationJob(notificationDetail);
+    }
+    return notificationDetail;
   },
 };

--- a/src/schema/mutation/editDashboard.mutation.ts
+++ b/src/schema/mutation/editDashboard.mutation.ts
@@ -25,29 +25,28 @@ export default {
     showFilter: { type: GraphQLBoolean },
   },
   async resolve(parent, args, context) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    // check inputs
+    if (!args || isEmpty(args)) {
+      throw new GraphQLError(
+        context.i18next.t('mutations.dashboard.edit.errors.invalidArguments')
+      );
+    }
+    // get data
+    let dashboard = await Dashboard.findById(args.id);
+    // check permissions
+    const ability = await extendAbilityForContent(user, dashboard);
+    if (ability.cannot('update', dashboard)) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      // check inputs
-      if (!args || isEmpty(args)) {
-        throw new GraphQLError(
-          context.i18next.t('mutations.dashboard.edit.errors.invalidArguments')
-        );
-      }
-      // get data
-      let dashboard = await Dashboard.findById(args.id);
-      // check permissions
-      const ability = await extendAbilityForContent(user, dashboard);
-      if (ability.cannot('update', dashboard)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
       // do the update on dashboard
       const updateDashboard: {
         //modifiedAt?: Date;

--- a/src/schema/mutation/editDistributionList.mutation.ts
+++ b/src/schema/mutation/editDistributionList.mutation.ts
@@ -18,31 +18,28 @@ export default {
     distributionList: { type: new GraphQLNonNull(DistributionListInputType) },
   },
   async resolve(_, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = extendAbilityForApplications(
-        user,
-        args.application
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = extendAbilityForApplications(
+      user,
+      args.application
+    );
+    if (ability.cannot('update', 'DistributionList')) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
-      if (ability.cannot('update', 'DistributionList')) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      // Prevent wrong emails to be saved
-      if (
-        args.distributionList.emails.filter((x) => !validateEmail(x)).length > 0
-      ) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.invalidEmailsInput')
-        );
-      }
-
+    }
+    // Prevent wrong emails to be saved
+    if (
+      args.distributionList.emails.filter((x) => !validateEmail(x)).length > 0
+    ) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.invalidEmailsInput')
+      );
+    }
+    try {
       const update = {
         $set: {
           'distributionLists.$.name': args.distributionList.name,

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -79,424 +79,415 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+
+    // Permission check
+    const ability: AppAbility = user.ability;
+    const form = await Form.findById(args.id);
+    if (ability.cannot('update', form)) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
+    // Initialize the update object --- TODO = put interface
+    /* const update: any = {
+  modifiedAt: new Date(),
+}; */
+    const update: any = {};
+
+    // Update name
+    if (args.name) {
+      const graphQLTypeName = Form.getGraphQLTypeName(args.name);
+      validateGraphQLTypeName(
+        Form.getGraphQLTypeName(args.name),
+        context.i18next
+      );
+      if (
+        (await Form.hasDuplicate(graphQLTypeName, form.id)) ||
+        (await ReferenceData.hasDuplicate(graphQLTypeName))
+      ) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
+          context.i18next.t('common.errors.duplicatedGraphQLTypeName')
         );
       }
-
-      // Permission check
-      const ability: AppAbility = user.ability;
-      const form = await Form.findById(args.id);
-      if (ability.cannot('update', form)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
+      update.name = args.name;
+      update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
+      if (form.core) {
+        await Resource.findByIdAndUpdate(form.resource, {
+          name: args.name,
+        });
       }
+    }
 
-      // Initialize the update object --- TODO = put interface
-      /* const update: any = {
-    modifiedAt: new Date(),
-  }; */
-      const update: any = {};
-
-      // Update name
-      if (args.name) {
-        const graphQLTypeName = Form.getGraphQLTypeName(args.name);
-        validateGraphQLTypeName(
-          Form.getGraphQLTypeName(args.name),
-          context.i18next
-        );
-        if (
-          (await Form.hasDuplicate(graphQLTypeName, form.id)) ||
-          (await ReferenceData.hasDuplicate(graphQLTypeName))
-        ) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.duplicatedGraphQLTypeName')
-          );
-        }
-        update.name = args.name;
-        update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
-        if (form.core) {
-          await Resource.findByIdAndUpdate(form.resource, {
-            name: args.name,
-          });
+    // Update status
+    if (args.status) {
+      update.status = args.status;
+      // Activate the form.
+      if (update.status === status.active) {
+        // Create notification channel
+        const notificationChannel = new Channel({
+          title: `Form - ${form.name}`,
+          form: form._id,
+        });
+        await notificationChannel.save();
+        update.channel = notificationChannel.form;
+      } else {
+        // Deactivate the form
+        // delete channel and notifications if form not active anymore
+        const channel = await Channel.findOneAndDelete({ form: form._id });
+        if (channel) {
+          update.channel = [];
         }
       }
+    }
 
-      // Update status
-      if (args.status) {
-        update.status = args.status;
-        // Activate the form.
-        if (update.status === status.active) {
-          // Create notification channel
-          const notificationChannel = new Channel({
-            title: `Form - ${form.name}`,
-            form: form._id,
-          });
-          await notificationChannel.save();
-          update.channel = notificationChannel.form;
+    // Update permissions
+    if (args.permissions) {
+      const permissions: PermissionChange = args.permissions;
+      for (const permission in permissions) {
+        if (isArray(permissions[permission])) {
+          // if it's an array, replace the old value with the provided list
+          update['permissions.' + permission] = permissions[permission];
         } else {
-          // Deactivate the form
-          // delete channel and notifications if form not active anymore
-          const channel = await Channel.findOneAndDelete({ form: form._id });
-          if (channel) {
-            update.channel = [];
+          const obj = permissions[permission];
+          if (obj.add && obj.add.length) {
+            const pushRoles = {
+              [`permissions.${permission}`]: { $each: obj.add },
+            };
+
+            if (update.$addToSet) Object.assign(update.$addToSet, pushRoles);
+            else Object.assign(update, { $addToSet: pushRoles });
           }
-        }
-      }
+          if (obj.remove && obj.remove.length) {
+            let pullRoles: any;
 
-      // Update permissions
-      if (args.permissions) {
-        const permissions: PermissionChange = args.permissions;
-        for (const permission in permissions) {
-          if (isArray(permissions[permission])) {
-            // if it's an array, replace the old value with the provided list
-            update['permissions.' + permission] = permissions[permission];
-          } else {
-            const obj = permissions[permission];
-            if (obj.add && obj.add.length) {
-              const pushRoles = {
-                [`permissions.${permission}`]: { $each: obj.add },
-              };
-
-              if (update.$addToSet) Object.assign(update.$addToSet, pushRoles);
-              else Object.assign(update, { $addToSet: pushRoles });
-            }
-            if (obj.remove && obj.remove.length) {
-              let pullRoles: any;
-
-              if (typeof obj.remove[0] === 'string') {
-                // CanSee, canUpdate, canDelete, canCreateRecords
-                pullRoles = {
-                  [`permissions.${permission}`]: {
-                    $in: obj.remove.map(
-                      (role: any) => new mongoose.Types.ObjectId(role)
-                    ),
-                  },
-                };
-              } else {
-                // canSeeRecords, canUpdateRecords, canDeleteRecords, recordsUnicity
-                pullRoles = {
-                  [`permissions.${permission}`]: {
-                    $in: obj.remove.map((perm: any) =>
-                      perm.access
-                        ? {
-                            role: new mongoose.Types.ObjectId(perm.role),
-                            access: perm.access,
-                          }
-                        : {
-                            role: new mongoose.Types.ObjectId(perm.role),
-                          }
-                    ),
-                  },
-                };
-              }
-
-              if (update.$pull) Object.assign(update.$pull, pullRoles);
-              else Object.assign(update, { $pull: pullRoles });
-            }
-          }
-        }
-      }
-
-      // Update fields and structure, check that structure is different
-      if (args.structure && !isEqual(form.structure, args.structure)) {
-        update.structure = args.structure;
-        const structure = JSON.parse(args.structure);
-        const fields = [];
-        for (const page of structure.pages) {
-          await extractFields(page, fields, form.core);
-          findDuplicateFields(fields);
-          for (const field of fields.filter((x) =>
-            ['resource', 'resources'].includes(x.type)
-          )) {
-            // Raises an error if the field is already used as related name for this resource
-            if (
-              await Form.findOne({
-                fields: {
-                  $elemMatch: {
-                    resource: field.resource,
-                    relatedName: field.relatedName,
-                  },
+            if (typeof obj.remove[0] === 'string') {
+              // CanSee, canUpdate, canDelete, canCreateRecords
+              pullRoles = {
+                [`permissions.${permission}`]: {
+                  $in: obj.remove.map(
+                    (role: any) => new mongoose.Types.ObjectId(role)
+                  ),
                 },
-                _id: { $ne: form.id },
-                ...(form.resource && { resource: { $ne: form.resource } }),
-              })
-            ) {
-              throw new GraphQLError(
-                i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
-                  name: field.relatedName,
-                })
-              );
+              };
+            } else {
+              // canSeeRecords, canUpdateRecords, canDeleteRecords, recordsUnicity
+              pullRoles = {
+                [`permissions.${permission}`]: {
+                  $in: obj.remove.map((perm: any) =>
+                    perm.access
+                      ? {
+                          role: new mongoose.Types.ObjectId(perm.role),
+                          access: perm.access,
+                        }
+                      : {
+                          role: new mongoose.Types.ObjectId(perm.role),
+                        }
+                  ),
+                },
+              };
             }
-            // Raises an error if the field exists in the resource
-            if (
-              await Resource.findOne({
-                fields: { $elemMatch: { name: field.relatedName } },
-                _id: field.resource,
-              })
-            ) {
-              throw new GraphQLError(
-                i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
-                  name: field.relatedName,
-                })
-              );
-            }
+
+            if (update.$pull) Object.assign(update.$pull, pullRoles);
+            else Object.assign(update, { $pull: pullRoles });
           }
         }
-        // === Resource inheritance management ===
-        const prevStructure = JSON.parse(
-          form.structure ? form.structure : '{}'
-        ); // Get the current form's state structure
-        if (form.resource && !isEqual(prevStructure, structure)) {
-          // If the form has a resource and its structure has changed
-          const resource = await Resource.findById(form.resource);
-          const templates = await Form.find({
-            resource: form.resource,
-            _id: { $ne: mongoose.Types.ObjectId(args.id) },
-          }).select('_id structure fields');
-          const oldFields: any[] = JSON.parse(JSON.stringify(resource.fields));
-          const usedFields = templates
-            .map((x) => x.fields)
-            .flat()
-            .concat(fields);
-          // Check fields against the resource to add new ones or edit old ones
-          for (const field of fields) {
-            // For each field in the form being saved
-            const oldField = oldFields.find((x) => x.name === field.name); // Find the equivalent field in the resource's fields
-            if (!oldField) {
-              // If the field isn't found in the resource
-              const newField: any = Object.assign({}, field); // Create a copy of the form's field
-              newField.isRequired =
-                form.core && field.isRequired ? true : false; // If it's a core form and the field isRequired, copy this property
-              oldFields.push(newField); // Add this field to the list of the resource's fields
-            } else {
-              // Check if field can be updated
-              if (!oldField.isCore || (oldField.isCore && form.core)) {
-                // If resource's field isn't core or if it's core but the edited form is core too, make it writable
-                const storedFieldChanged = !isEqual(oldField, field);
-                if (storedFieldChanged) {
-                  // Inherit the field's permissions
-                  field.permissions = oldField.permissions;
-                  // If the resource's field and the current form's field are different
-                  const index = oldFields.findIndex(
-                    (x) => x.name === field.name
-                  ); // Get the index of the form's field in the resources
-                  oldFields.splice(index, 1, field); // Replace resource's field by the form's field
-                }
-                for (const template of templates) {
-                  // For each form that inherits from the same resource
-                  if (storedFieldChanged) {
-                    template.fields = template.fields.map((x) => {
-                      // For each field of the childForm
-                      return x.name === field.name // If the child field's name equals the parent field's name
-                        ? x.hasOwnProperty('defaultValue') &&
-                          !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
-                          ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
-                          : field // Else replace child's field by parent's field
-                        : x; // Else don't change the child's field
-                    });
-                  }
-                  if (!field.generated) {
-                    // Update structure
-                    const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
-                    replaceField(
-                      field.name,
-                      newStructure,
-                      structure,
-                      prevStructure
-                    ); // Replace the inheriting form's field by the edited form's field
-                    template.structure = JSON.stringify(newStructure); // Save the new structure
-                  }
-                }
-              }
-            }
-          }
-          // Check if there are unused or duplicated fields in the resource
-          for (let index = 0; index < oldFields.length; index++) {
-            const field = oldFields[index]; // Store the resource's field
-            if (!field.isCalculated) {
-              // prevent calculated fields to be deleted automatically
-              const fieldToRemove =
-                ((form.core
-                  ? !fields.some((x) => x.name === field.name)
-                  : true) && // If edited form is core, check if resource's field is absent from form's fields
-                  !usedFields.some((x) => x.name === field.name)) || // Unused -- TODO What if it's in one inherited form and not in another ?
-                oldFields.some(
-                  (x, id) => field.name === x.name && id !== index
-                ); // Duplicated If there's another field with the same name but not the same ID
-              if (fieldToRemove) {
-                oldFields.splice(index, 1);
-                index--;
-              }
-            }
-          }
-          // Check if form is a core template of a resource
-          if (!form.core) {
-            // Check if a required field is missing
-            // Keep old version and move that to extract fields ?
-            let fieldExists = false;
-            for (const field of oldFields.filter((x) => x.isCore)) {
-              // For each non-core field in the resource
-              for (const x of fields) {
-                if (x.name === field.name) {
-                  x.isCore = true;
-                  fieldExists = true;
-                }
-              }
-              if (!fieldExists) {
-                throw new GraphQLError(
-                  i18next.t('mutations.form.edit.errors.coreFieldMissing', {
-                    name: field.name,
-                  })
-                );
-              }
-              fieldExists = false;
-            }
-          } else {
-            // List deleted fields
-            const deletedFields = form.fields.filter(
-              (x) => !fields.some((y) => x.name === y.name)
-            );
-            // List new fields
-            const newFields = fields.filter(
-              (x) => !form.fields.some((y) => x.name === y.name)
-            );
-            // Detect structure updates
-            const structureUpdate = {};
-            const newStructure = structure;
-            if (form.structure) {
-              // Store the property's objects that have been removed between the new and previous versions of the form
-              for (const property of INHERITED_PROPERTIES) {
-                if (!isEqual(prevStructure[property], newStructure[property])) {
-                  structureUpdate[property] = newStructure[property]
-                    ? differenceWith(
-                        prevStructure[property],
-                        newStructure[property],
-                        isEqual
-                      )
-                    : prevStructure[property];
-                }
-              }
-            }
+      }
+    }
 
-            // Loop on templates
-            for (const template of templates) {
-              // === REFLECT DELETION ===
-              // For each old field from core form which is not anymore in the current core form fields
-              for (const field of deletedFields) {
-                // Check if we rename or delete a field used in a child form
-                if (usedFields.some((x) => x.name === field.name)) {
-                  // If this deleted / modified field was used, reflect the deletion / edition
-                  const index = template.fields.findIndex(
-                    (x) => x.name === field.name
-                  );
-                  template.fields.splice(index, 1);
-                  if (!field.generated) {
-                    // Remove from structure
-                    const templateStructure = JSON.parse(template.structure);
-                    removeField(templateStructure, field.name);
-                    template.structure = JSON.stringify(templateStructure);
-                  }
-                }
-              }
-
-              // === REFLECT ADDITION ===
-              // For each new field from core form which were not before in the old core form fields
-              for (const field of newFields) {
-                // Add to fields and structure if needed
-                if (!template.fields.some((x) => x.name === field.name)) {
-                  template.fields.unshift(field);
-
-                  if (!field.generated) {
-                    // Add to structure
-                    const templateStructure = JSON.parse(template.structure);
-                    addField(templateStructure, field.name, structure);
-                    template.structure = JSON.stringify(templateStructure);
-                  }
-                }
-              }
-
-              // REFLECT STRUCTURE CHANGES ===
-              const templateStructure = JSON.parse(template.structure);
-              for (const objectKey in structureUpdate) {
-                // In a childForm's structure, if there are property's objects that have been deleted from the core form, delete them there too
-                if (
-                  templateStructure[objectKey] &&
-                  templateStructure[objectKey].length &&
-                  structureUpdate[objectKey] &&
-                  structureUpdate[objectKey].length
-                ) {
-                  templateStructure[objectKey] = differenceWith(
-                    templateStructure[objectKey],
-                    structureUpdate[objectKey],
-                    isEqual
-                  );
-                }
-                // Merge the new property's objects to the children
-                templateStructure[objectKey] = templateStructure[objectKey]
-                  ? unionWith(
-                      templateStructure[objectKey],
-                      newStructure[objectKey],
-                      isEqual
-                    )
-                  : newStructure[objectKey];
-                // If the property is null, undefined or empty, directly remove the entry from the structure
-                if (
-                  !templateStructure[objectKey] ||
-                  !templateStructure[objectKey].length
-                ) {
-                  delete templateStructure[objectKey];
-                }
-              }
-              template.structure = JSON.stringify(templateStructure);
-            }
-
-            for (const field of deletedFields) {
-              // We remove the field from the resource
-              const index = oldFields.findIndex((x) => x.name === field.name);
-              if (index >= 0) {
-                oldFields.splice(index, 1);
-              }
-            }
-          }
-
-          // Build bulk update of non-core templates
-          const bulkUpdate = [];
-          for (const template of templates) {
-            bulkUpdate.push({
-              updateOne: {
-                filter: { _id: template._id },
-                update: {
-                  structure: template.structure,
-                  fields: template.fields,
+    // Update fields and structure, check that structure is different
+    if (args.structure && !isEqual(form.structure, args.structure)) {
+      update.structure = args.structure;
+      const structure = JSON.parse(args.structure);
+      const fields = [];
+      for (const page of structure.pages) {
+        await extractFields(page, fields, form.core);
+        findDuplicateFields(fields);
+        for (const field of fields.filter((x) =>
+          ['resource', 'resources'].includes(x.type)
+        )) {
+          // Raises an error if the field is already used as related name for this resource
+          if (
+            await Form.findOne({
+              fields: {
+                $elemMatch: {
+                  resource: field.resource,
+                  relatedName: field.relatedName,
                 },
               },
-            });
+              _id: { $ne: form.id },
+              ...(form.resource && { resource: { $ne: form.resource } }),
+            })
+          ) {
+            throw new GraphQLError(
+              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
+                name: field.relatedName,
+              })
+            );
           }
-          if (bulkUpdate.length > 0) {
-            // Update all child form for addition/deletion/structure changes
-            await Form.bulkWrite(bulkUpdate);
+          // Raises an error if the field exists in the resource
+          if (
+            await Resource.findOne({
+              fields: { $elemMatch: { name: field.relatedName } },
+              _id: field.resource,
+            })
+          ) {
+            throw new GraphQLError(
+              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
+                name: field.relatedName,
+              })
+            );
+          }
+        }
+      }
+      // === Resource inheritance management ===
+      const prevStructure = JSON.parse(form.structure ? form.structure : '{}'); // Get the current form's state structure
+      if (form.resource && !isEqual(prevStructure, structure)) {
+        // If the form has a resource and its structure has changed
+        const resource = await Resource.findById(form.resource);
+        const templates = await Form.find({
+          resource: form.resource,
+          _id: { $ne: mongoose.Types.ObjectId(args.id) },
+        }).select('_id structure fields');
+        const oldFields: any[] = JSON.parse(JSON.stringify(resource.fields));
+        const usedFields = templates
+          .map((x) => x.fields)
+          .flat()
+          .concat(fields);
+        // Check fields against the resource to add new ones or edit old ones
+        for (const field of fields) {
+          // For each field in the form being saved
+          const oldField = oldFields.find((x) => x.name === field.name); // Find the equivalent field in the resource's fields
+          if (!oldField) {
+            // If the field isn't found in the resource
+            const newField: any = Object.assign({}, field); // Create a copy of the form's field
+            newField.isRequired = form.core && field.isRequired ? true : false; // If it's a core form and the field isRequired, copy this property
+            oldFields.push(newField); // Add this field to the list of the resource's fields
+          } else {
+            // Check if field can be updated
+            if (!oldField.isCore || (oldField.isCore && form.core)) {
+              // If resource's field isn't core or if it's core but the edited form is core too, make it writable
+              const storedFieldChanged = !isEqual(oldField, field);
+              if (storedFieldChanged) {
+                // Inherit the field's permissions
+                field.permissions = oldField.permissions;
+                // If the resource's field and the current form's field are different
+                const index = oldFields.findIndex((x) => x.name === field.name); // Get the index of the form's field in the resources
+                oldFields.splice(index, 1, field); // Replace resource's field by the form's field
+              }
+              for (const template of templates) {
+                // For each form that inherits from the same resource
+                if (storedFieldChanged) {
+                  template.fields = template.fields.map((x) => {
+                    // For each field of the childForm
+                    return x.name === field.name // If the child field's name equals the parent field's name
+                      ? x.hasOwnProperty('defaultValue') &&
+                        !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
+                        ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
+                        : field // Else replace child's field by parent's field
+                      : x; // Else don't change the child's field
+                  });
+                }
+                if (!field.generated) {
+                  // Update structure
+                  const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
+                  replaceField(
+                    field.name,
+                    newStructure,
+                    structure,
+                    prevStructure
+                  ); // Replace the inheriting form's field by the edited form's field
+                  template.structure = JSON.stringify(newStructure); // Save the new structure
+                }
+              }
+            }
+          }
+        }
+        // Check if there are unused or duplicated fields in the resource
+        for (let index = 0; index < oldFields.length; index++) {
+          const field = oldFields[index]; // Store the resource's field
+          if (!field.isCalculated) {
+            // prevent calculated fields to be deleted automatically
+            const fieldToRemove =
+              ((form.core
+                ? !fields.some((x) => x.name === field.name)
+                : true) && // If edited form is core, check if resource's field is absent from form's fields
+                !usedFields.some((x) => x.name === field.name)) || // Unused -- TODO What if it's in one inherited form and not in another ?
+              oldFields.some((x, id) => field.name === x.name && id !== index); // Duplicated If there's another field with the same name but not the same ID
+            if (fieldToRemove) {
+              oldFields.splice(index, 1);
+              index--;
+            }
+          }
+        }
+        // Check if form is a core template of a resource
+        if (!form.core) {
+          // Check if a required field is missing
+          // Keep old version and move that to extract fields ?
+          let fieldExists = false;
+          for (const field of oldFields.filter((x) => x.isCore)) {
+            // For each non-core field in the resource
+            for (const x of fields) {
+              if (x.name === field.name) {
+                x.isCore = true;
+                fieldExists = true;
+              }
+            }
+            if (!fieldExists) {
+              throw new GraphQLError(
+                i18next.t('mutations.form.edit.errors.coreFieldMissing', {
+                  name: field.name,
+                })
+              );
+            }
+            fieldExists = false;
+          }
+        } else {
+          // List deleted fields
+          const deletedFields = form.fields.filter(
+            (x) => !fields.some((y) => x.name === y.name)
+          );
+          // List new fields
+          const newFields = fields.filter(
+            (x) => !form.fields.some((y) => x.name === y.name)
+          );
+          // Detect structure updates
+          const structureUpdate = {};
+          const newStructure = structure;
+          if (form.structure) {
+            // Store the property's objects that have been removed between the new and previous versions of the form
+            for (const property of INHERITED_PROPERTIES) {
+              if (!isEqual(prevStructure[property], newStructure[property])) {
+                structureUpdate[property] = newStructure[property]
+                  ? differenceWith(
+                      prevStructure[property],
+                      newStructure[property],
+                      isEqual
+                    )
+                  : prevStructure[property];
+              }
+            }
           }
 
-          // Update resource fields
-          await Resource.findByIdAndUpdate(form.resource, {
-            fields: oldFields,
+          // Loop on templates
+          for (const template of templates) {
+            // === REFLECT DELETION ===
+            // For each old field from core form which is not anymore in the current core form fields
+            for (const field of deletedFields) {
+              // Check if we rename or delete a field used in a child form
+              if (usedFields.some((x) => x.name === field.name)) {
+                // If this deleted / modified field was used, reflect the deletion / edition
+                const index = template.fields.findIndex(
+                  (x) => x.name === field.name
+                );
+                template.fields.splice(index, 1);
+                if (!field.generated) {
+                  // Remove from structure
+                  const templateStructure = JSON.parse(template.structure);
+                  removeField(templateStructure, field.name);
+                  template.structure = JSON.stringify(templateStructure);
+                }
+              }
+            }
+
+            // === REFLECT ADDITION ===
+            // For each new field from core form which were not before in the old core form fields
+            for (const field of newFields) {
+              // Add to fields and structure if needed
+              if (!template.fields.some((x) => x.name === field.name)) {
+                template.fields.unshift(field);
+
+                if (!field.generated) {
+                  // Add to structure
+                  const templateStructure = JSON.parse(template.structure);
+                  addField(templateStructure, field.name, structure);
+                  template.structure = JSON.stringify(templateStructure);
+                }
+              }
+            }
+
+            // REFLECT STRUCTURE CHANGES ===
+            const templateStructure = JSON.parse(template.structure);
+            for (const objectKey in structureUpdate) {
+              // In a childForm's structure, if there are property's objects that have been deleted from the core form, delete them there too
+              if (
+                templateStructure[objectKey] &&
+                templateStructure[objectKey].length &&
+                structureUpdate[objectKey] &&
+                structureUpdate[objectKey].length
+              ) {
+                templateStructure[objectKey] = differenceWith(
+                  templateStructure[objectKey],
+                  structureUpdate[objectKey],
+                  isEqual
+                );
+              }
+              // Merge the new property's objects to the children
+              templateStructure[objectKey] = templateStructure[objectKey]
+                ? unionWith(
+                    templateStructure[objectKey],
+                    newStructure[objectKey],
+                    isEqual
+                  )
+                : newStructure[objectKey];
+              // If the property is null, undefined or empty, directly remove the entry from the structure
+              if (
+                !templateStructure[objectKey] ||
+                !templateStructure[objectKey].length
+              ) {
+                delete templateStructure[objectKey];
+              }
+            }
+            template.structure = JSON.stringify(templateStructure);
+          }
+
+          for (const field of deletedFields) {
+            // We remove the field from the resource
+            const index = oldFields.findIndex((x) => x.name === field.name);
+            if (index >= 0) {
+              oldFields.splice(index, 1);
+            }
+          }
+        }
+
+        // Build bulk update of non-core templates
+        const bulkUpdate = [];
+        for (const template of templates) {
+          bulkUpdate.push({
+            updateOne: {
+              filter: { _id: template._id },
+              update: {
+                structure: template.structure,
+                fields: template.fields,
+              },
+            },
           });
         }
-        update.fields = fields;
-        // Update version
-        const version = new Version({
-          //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
-          data: form.structure,
+        if (bulkUpdate.length > 0) {
+          // Update all child form for addition/deletion/structure changes
+          await Form.bulkWrite(bulkUpdate);
+        }
+
+        // Update resource fields
+        await Resource.findByIdAndUpdate(form.resource, {
+          fields: oldFields,
         });
-        await version.save();
-        update.$push = { versions: version._id };
       }
+      update.fields = fields;
+      // Update version
+      const version = new Version({
+        //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
+        data: form.structure,
+      });
+      await version.save();
+      update.$push = { versions: version._id };
+    }
+    try {
       // Return updated form
       return await Form.findByIdAndUpdate(
         args.id,

--- a/src/schema/mutation/editLayout.mutation.ts
+++ b/src/schema/mutation/editLayout.mutation.ts
@@ -17,59 +17,64 @@ export default {
     form: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try {
-      if (args.form && args.resource) {
+    if (args.form && args.resource) {
+      throw new GraphQLError(
+        context.i18next.t(
+          'mutations.layout.edit.errors.invalidAddPageArguments'
+        )
+      );
+    }
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    // Edition of a resource
+    if (args.resource) {
+      const filters = Resource.accessibleBy(ability, 'update')
+        .where({ _id: args.resource })
+        .getFilter();
+      const resource: Resource = await Resource.findOne(filters);
+      if (!resource) {
         throw new GraphQLError(
-          context.i18next.t(
-            'mutations.layout.edit.errors.invalidAddPageArguments'
-          )
+          context.i18next.t('common.errors.permissionNotGranted')
         );
       }
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      // Edition of a resource
-      if (args.resource) {
-        const filters = Resource.accessibleBy(ability, 'update')
-          .where({ _id: args.resource })
-          .getFilter();
-        const resource: Resource = await Resource.findOne(filters);
-        if (!resource) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
-        }
+      try {
         resource.layouts.id(args.id).name = args.layout.name;
         resource.layouts.id(args.id).query = args.layout.query;
         resource.layouts.id(args.id).display = args.layout.display;
         await resource.save();
         return resource.layouts.id(args.id);
-      } else {
-        // Edition of a Form
-        const filters = Form.accessibleBy(ability, 'update')
-          .where({ _id: args.form })
-          .getFilter();
-        const form: Form = await Form.findOne(filters);
-        if (!form) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
-        }
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+        throw new GraphQLError(
+          context.i18next.t('common.errors.internalServerError')
+        );
+      }
+    } else {
+      // Edition of a Form
+      const filters = Form.accessibleBy(ability, 'update')
+        .where({ _id: args.form })
+        .getFilter();
+      const form: Form = await Form.findOne(filters);
+      if (!form) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      try {
         form.layouts.id(args.id).name = args.layout.name;
         form.layouts.id(args.id).query = args.layout.query;
         form.layouts.id(args.id).display = args.layout.display;
         await form.save();
         return form.layouts.id(args.id);
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+        throw new GraphQLError(
+          context.i18next.t('common.errors.internalServerError')
+        );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
-      throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
-      );
     }
   },
 };

--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -36,75 +36,68 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    // Build update
+    const update = {
+      //modifiedAt: new Date(),
+      ...args,
+    };
+    delete update.id;
+    // Check update
+    if (update.name) {
+      // Check name
+      const graphQLTypeName = ReferenceData.getGraphQLTypeName(args.name);
+      validateGraphQLTypeName(graphQLTypeName);
+      if (
+        (await Form.hasDuplicate(graphQLTypeName)) ||
+        (await ReferenceData.hasDuplicate(graphQLTypeName, args.id))
+      ) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.reference.edit.errors.formResDuplicated')
+        );
+      }
+      update.graphQLTypeName = ReferenceData.getGraphQLTypeName(args.name);
+    }
+    if (update.fields) {
+      // Generate graphql field names
+      for (const field of update.fields) {
+        field.graphQLFieldName = ReferenceData.getGraphQLFieldName(field.name);
+      }
+      // Check fields
+      for (const field of update.fields) {
+        validateGraphQLFieldName(field.graphQLFieldName, context.i18next);
+      }
+    }
+    // We need at least one field in order to update the api reference data
+    if (Object.keys(update).length < 1) {
+      throw new GraphQLError(
+        context.i18next.t('mutations.reference.edit.errors.invalidArguments')
+      );
+    }
+    let referenceData;
     try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      // Build update
-      const update = {
-        //modifiedAt: new Date(),
-        ...args,
-      };
-      delete update.id;
-      // Check update
-      if (update.name) {
-        // Check name
-        const graphQLTypeName = ReferenceData.getGraphQLTypeName(args.name);
-        validateGraphQLTypeName(graphQLTypeName);
-        if (
-          (await Form.hasDuplicate(graphQLTypeName)) ||
-          (await ReferenceData.hasDuplicate(graphQLTypeName, args.id))
-        ) {
-          throw new GraphQLError(
-            context.i18next.t(
-              'mutations.reference.edit.errors.formResDuplicated'
-            )
-          );
-        }
-        update.graphQLTypeName = ReferenceData.getGraphQLTypeName(args.name);
-      }
-      if (update.fields) {
-        // Generate graphql field names
-        for (const field of update.fields) {
-          field.graphQLFieldName = ReferenceData.getGraphQLFieldName(
-            field.name
-          );
-        }
-        // Check fields
-        for (const field of update.fields) {
-          validateGraphQLFieldName(field.graphQLFieldName, context.i18next);
-        }
-      }
-      // We need at least one field in order to update the api reference data
-      if (Object.keys(update).length < 1) {
-        throw new GraphQLError(
-          context.i18next.t('mutations.reference.edit.errors.invalidArguments')
-        );
-      }
       const filters = ReferenceData.accessibleBy(ability, 'update')
         .where({ _id: args.id })
         .getFilter();
-      const referenceData = await ReferenceData.findOneAndUpdate(
-        filters,
-        update,
-        { new: true }
-      );
-      if (referenceData) {
-        buildTypes();
-        return referenceData;
-      } else {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
+      referenceData = await ReferenceData.findOneAndUpdate(filters, update, {
+        new: true,
+      });
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
+      );
+    }
+    if (referenceData) {
+      buildTypes();
+      return referenceData;
+    } else {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/mutation/editSubscription.mutation.ts
+++ b/src/schema/mutation/editSubscription.mutation.ts
@@ -28,26 +28,25 @@ export default {
     previousSubscription: { type: new GraphQLNonNull(GraphQLString) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability: AppAbility = context.user.ability;
-      const filters = Application.accessibleBy(ability, 'update')
-        .where({ _id: args.applicationId })
-        .getFilter();
-      const application = await Application.findOne(filters);
-      if (!application) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      const subscription = {
+    const ability: AppAbility = context.user.ability;
+    const filters = Application.accessibleBy(ability, 'update')
+      .where({ _id: args.applicationId })
+      .getFilter();
+    const application = await Application.findOne(filters);
+    if (!application) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+    let subscription;
+    try {
+      subscription = {
         routingKey: args.routingKey,
         title: args.title,
       };
@@ -67,16 +66,16 @@ export default {
       await Application.findByIdAndUpdate(args.applicationId, application, {
         new: true,
       });
-      if (args.routingKey !== args.previousSubscription) {
-        createAndConsumeQueue(args.routingKey);
-        deleteQueue(args.previousSubscription);
-      }
-      return subscription;
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
       );
     }
+    if (args.routingKey !== args.previousSubscription) {
+      createAndConsumeQueue(args.routingKey);
+      deleteQueue(args.previousSubscription);
+    }
+    return subscription;
   },
 };

--- a/src/schema/mutation/editTemplate.mutation.ts
+++ b/src/schema/mutation/editTemplate.mutation.ts
@@ -17,23 +17,21 @@ export default {
     template: { type: new GraphQLNonNull(TemplateInputType) },
   },
   async resolve(_, args, context) {
-    try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = extendAbilityForApplications(
-        user,
-        args.application
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = extendAbilityForApplications(
+      user,
+      args.application
+    );
+    if (ability.cannot('update', 'Template')) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
       );
-      if (ability.cannot('update', 'Template')) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
+    }
 
+    try {
       const update = {
         $set: {
           'templates.$.name': args.template.name,

--- a/src/schema/mutation/editUser.mutation.ts
+++ b/src/schema/mutation/editUser.mutation.ts
@@ -20,91 +20,96 @@ export default {
     positionAttributes: { type: new GraphQLList(PositionAttributeInputType) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+
+    const ability: AppAbility = context.user.ability;
+    let roles = args.roles;
+    if (args.application) {
+      if (ability.cannot('update', 'User')) {
+        // Check applications permissions if we don't have the global one
+        const canUpdate = user.roles.some(
+          (x) =>
+            x.application &&
+            x.application.equals(args.application) &&
+            x.permissions.some(
+              (y) => y.type === permissions.canSeeUsers && !y.global
+            )
+        );
+        if (!canUpdate) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+      }
+      const nonAppRoles = await User.findById(args.id).populate({
+        path: 'roles',
+        match: { application: { $ne: args.application } }, // Only returns roles not attached to the application
+      });
+      roles = nonAppRoles.roles.map((x) => x._id).concat(roles);
+      const update = {
+        roles,
+      };
+      if (args.positionAttributes) {
+        const positionAttributes = args.positionAttributes.filter(
+          (element) => element.value.length > 0
+        );
+        Object.assign(update, {
+          positionAttributes,
+        });
+      }
+      if (Object.keys(update).length < 1) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
+          context.i18next.t('mutations.user.edit.errors.invalidArguments')
         );
       }
-
-      const ability: AppAbility = context.user.ability;
-      let roles = args.roles;
-      if (args.application) {
-        if (ability.cannot('update', 'User')) {
-          // Check applications permissions if we don't have the global one
-          const canUpdate = user.roles.some(
-            (x) =>
-              x.application &&
-              x.application.equals(args.application) &&
-              x.permissions.some(
-                (y) => y.type === permissions.canSeeUsers && !y.global
-              )
-          );
-          if (!canUpdate) {
-            throw new GraphQLError(
-              context.i18next.t('common.errors.permissionNotGranted')
-            );
-          }
-        }
-        const nonAppRoles = await User.findById(args.id).populate({
-          path: 'roles',
-          match: { application: { $ne: args.application } }, // Only returns roles not attached to the application
-        });
-        roles = nonAppRoles.roles.map((x) => x._id).concat(roles);
-        const update = {
-          roles,
-        };
-        if (args.positionAttributes) {
-          const positionAttributes = args.positionAttributes.filter(
-            (element) => element.value.length > 0
-          );
-          Object.assign(update, {
-            positionAttributes,
-          });
-        }
-        if (Object.keys(update).length < 1) {
-          throw new GraphQLError(
-            context.i18next.t('mutations.user.edit.errors.invalidArguments')
-          );
-        }
+      try {
         return await User.findByIdAndUpdate(args.id, update, {
           new: true,
         }).populate({
           path: 'roles',
           match: { application: args.application }, // Only returns roles attached to the application
         });
-      } else {
-        if (ability.cannot('update', 'User')) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
-        }
-        const update = {};
-        if (args.roles) {
-          const appRoles = await User.findById(args.id).populate({
-            path: 'roles',
-            match: { application: { $ne: null } }, // Returns roles attached to any application
-          });
-          roles = appRoles.roles.map((x) => x._id).concat(roles);
-          Object.assign(update, { roles: roles });
-        }
-        if (args.groups) {
-          Object.assign(update, { groups: args.groups });
-        }
-        if (Object.keys(update).length < 1) {
-          throw new GraphQLError(
-            context.i18next.t('mutations.user.edit.errors.invalidArguments')
-          );
-        }
-        return await User.findByIdAndUpdate(args.id, update, { new: true });
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+        throw new GraphQLError(
+          context.i18next.t('common.errors.internalServerError')
+        );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
-      throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
-      );
+    } else {
+      if (ability.cannot('update', 'User')) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      const update = {};
+      if (args.roles) {
+        const appRoles = await User.findById(args.id).populate({
+          path: 'roles',
+          match: { application: { $ne: null } }, // Returns roles attached to any application
+        });
+        roles = appRoles.roles.map((x) => x._id).concat(roles);
+        Object.assign(update, { roles: roles });
+      }
+      if (args.groups) {
+        Object.assign(update, { groups: args.groups });
+      }
+      if (Object.keys(update).length < 1) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.user.edit.errors.invalidArguments')
+        );
+      }
+      try {
+        return await User.findByIdAndUpdate(args.id, update, { new: true });
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
+        throw new GraphQLError(
+          context.i18next.t('common.errors.internalServerError')
+        );
+      }
     }
   },
 };

--- a/src/schema/mutation/editWorkflow.mutation.ts
+++ b/src/schema/mutation/editWorkflow.mutation.ts
@@ -22,31 +22,29 @@ export default {
     steps: { type: new GraphQLList(GraphQLID) },
   },
   async resolve(parent, args, context) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+
+    // check inputs
+    if (!args || (!args.name && !args.steps)) {
+      throw new GraphQLError(
+        context.i18next.t('mutations.workflow.edit.errors.invalidArguments')
+      );
+    }
+
+    // get data and check permissions
+    let workflow = await Workflow.findById(args.id);
+    const ability = await extendAbilityForContent(user, workflow);
+    if (ability.cannot('update', workflow)) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-
-      // check inputs
-      if (!args || (!args.name && !args.steps)) {
-        throw new GraphQLError(
-          context.i18next.t('mutations.workflow.edit.errors.invalidArguments')
-        );
-      }
-
-      // get data and check permissions
-      let workflow = await Workflow.findById(args.id);
-      const ability = await extendAbilityForContent(user, workflow);
-      if (ability.cannot('update', workflow)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-
       // do the update
       const update = Object.assign(
         {},

--- a/src/schema/mutation/publishNotification.mutation.ts
+++ b/src/schema/mutation/publishNotification.mutation.ts
@@ -23,19 +23,18 @@ export default {
     channel: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
+    if (!args || !args.action || !args.content || !args.channel)
+      throw new GraphQLError(
+        context.i18next.t(
+          'mutations.notification.publish.errors.invalidArguments'
+        )
+      );
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+
     try {
-      if (!args || !args.action || !args.content || !args.channel)
-        throw new GraphQLError(
-          context.i18next.t(
-            'mutations.notification.publish.errors.invalidArguments'
-          )
-        );
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
       const notification = new Notification({
         action: args.action,
         content: args.content,

--- a/src/schema/mutation/restoreRecord.mutation.ts
+++ b/src/schema/mutation/restoreRecord.mutation.ts
@@ -14,26 +14,25 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    // Get the record
+    const record = await Record.findById(args.id).populate({
+      path: 'form',
+      model: 'Form',
+    });
+    // Check ability
+    const ability = await extendAbilityForRecords(user, record.form);
+    if (ability.cannot('update', record)) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      // Get the record
-      const record = await Record.findById(args.id).populate({
-        path: 'form',
-        model: 'Form',
-      });
-      // Check ability
-      const ability = await extendAbilityForRecords(user, record.form);
-      if (ability.cannot('update', record)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
       // Update the record
       return await Record.findByIdAndUpdate(
         record._id,

--- a/src/schema/mutation/seeNotification.mutation.ts
+++ b/src/schema/mutation/seeNotification.mutation.ts
@@ -14,15 +14,13 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       const ability: AppAbility = context.user.ability;
       const filters = Notification.accessibleBy(ability, 'update')
         .where({ _id: args.id })

--- a/src/schema/mutation/seeNotifications.mutation.ts
+++ b/src/schema/mutation/seeNotifications.mutation.ts
@@ -19,23 +19,20 @@ export default {
     ids: { type: new GraphQLNonNull(GraphQLList(GraphQLID)) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability: AppAbility = context.user.ability;
-      if (!args) {
-        throw new GraphQLError(
-          context.i18next.t(
-            'mutations.notification.see.errors.invalidArguments'
-          )
-        );
-      }
+    const ability: AppAbility = context.user.ability;
+    if (!args) {
+      throw new GraphQLError(
+        context.i18next.t('mutations.notification.see.errors.invalidArguments')
+      );
+    }
+
+    try {
       const filters = Notification.accessibleBy(ability, 'update')
         .where({ _id: { $in: args.ids } })
         .getFilter();

--- a/src/schema/mutation/toggleApplicationLock.mutation.ts
+++ b/src/schema/mutation/toggleApplicationLock.mutation.ts
@@ -20,23 +20,22 @@ export default {
     lock: { type: new GraphQLNonNull(GraphQLBoolean) },
   },
   async resolve(parent, args, context) {
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = context.user.ability;
+    const filters = Application.accessibleBy(ability, 'update')
+      .where({ _id: args.id })
+      .getFilter();
+    let application = await Application.findOne(filters);
+    if (!application) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
     try {
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = context.user.ability;
-      const filters = Application.accessibleBy(ability, 'update')
-        .where({ _id: args.id })
-        .getFilter();
-      let application = await Application.findOne(filters);
-      if (!application) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
       const update = {
         lockedBy: args.lock ? user._id : null,
         locked: args.lock,

--- a/src/schema/mutation/uploadFile.mutation.ts
+++ b/src/schema/mutation/uploadFile.mutation.ts
@@ -21,12 +21,13 @@ export default {
     form: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
+    const file = await args.file;
+    const form = await Form.findById(args.form);
+    if (!form) {
+      throw new GraphQLError(i18next.t('common.errors.dataNotFound'));
+    }
+
     try {
-      const file = await args.file;
-      const form = await Form.findById(args.form);
-      if (!form) {
-        throw new GraphQLError(i18next.t('common.errors.dataNotFound'));
-      }
       const path = await uploadFile('forms', args.form, file.file);
       return path;
     } catch (err) {

--- a/src/schema/query/apiConfiguration.query.ts
+++ b/src/schema/query/apiConfiguration.query.ts
@@ -13,27 +13,25 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability = context.user.ability;
-      if (ability.can('read', 'ApiConfiguration')) {
+    const ability = context.user.ability;
+    if (ability.can('read', 'ApiConfiguration')) {
+      try {
         return await ApiConfiguration.findById(args.id);
-      } else {
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t('common.errors.internalServerError')
         );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    } else {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/query/apiConfigurations.query.ts
+++ b/src/schema/query/apiConfigurations.query.ts
@@ -26,15 +26,13 @@ export default {
     // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
     checkPageSize(first);
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       const ability: AppAbility = context.user.ability;
 
       const abilityFilters = ApiConfiguration.accessibleBy(

--- a/src/schema/query/application.query.ts
+++ b/src/schema/query/application.query.ts
@@ -16,20 +16,19 @@ export default {
     asRole: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    let application;
+    try {
       const ability = context.user.ability;
       const filters = Application.accessibleBy(ability)
         .where({ _id: args.id })
         .getFilter();
-      const application = await Application.findOne(filters);
+      application = await Application.findOne(filters);
       if (application && args.asRole) {
         const pages: Page[] = await Page.aggregate([
           {
@@ -49,17 +48,17 @@ export default {
         ]);
         application.pages = pages.map((x) => x._id);
       }
-      if (!application) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      return application;
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
       );
     }
+    if (!application) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+    return application;
   },
 };

--- a/src/schema/query/applications.query.ts
+++ b/src/schema/query/applications.query.ts
@@ -105,30 +105,28 @@ export default {
     // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
     checkPageSize(first);
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    // Inputs check
+    if (args.sortField) {
+      if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
+        throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
+      }
+    }
+
+    const ability: AppAbility = context.user.ability;
+
+    // Inputs check
+    if (args.sortField) {
+      if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
+        throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
+      }
+    }
+
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      // Inputs check
-      if (args.sortField) {
-        if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
-          throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
-        }
-      }
-
-      const ability: AppAbility = context.user.ability;
-
-      // Inputs check
-      if (args.sortField) {
-        if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
-          throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
-        }
-      }
-
       const abilityFilters = Application.accessibleBy(
         ability,
         'read'

--- a/src/schema/query/channels.query.ts
+++ b/src/schema/query/channels.query.ts
@@ -13,15 +13,13 @@ export default {
     application: { type: GraphQLID },
   },
   resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       const ability = context.user.ability;
       return args.application
         ? Channel.accessibleBy(ability, 'read').where({

--- a/src/schema/query/dashboard.query.ts
+++ b/src/schema/query/dashboard.query.ts
@@ -22,23 +22,22 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      // get data and check permissions
-      const dashboard = await Dashboard.findById(args.id);
-      const ability = await extendAbilityForContent(user, dashboard);
-      if (ability.cannot('read', dashboard)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
+    // get data and check permissions
+    const dashboard = await Dashboard.findById(args.id);
+    const ability = await extendAbilityForContent(user, dashboard);
+    if (ability.cannot('read', dashboard)) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
+    try {
       // Check if dashboard has context linked to it
       const page = await Page.findOne({
         contentWithContext: { $elemMatch: { content: args.id } },

--- a/src/schema/query/dashboards.query.ts
+++ b/src/schema/query/dashboards.query.ts
@@ -14,15 +14,13 @@ export default {
     all: { type: GraphQLBoolean },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       const ability = context.user.ability;
       const filters = {};
       if (!args.all) {

--- a/src/schema/query/forms.query.ts
+++ b/src/schema/query/forms.query.ts
@@ -105,21 +105,19 @@ export default {
     // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
     checkPageSize(first);
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    // Inputs check
+    if (args.sortField) {
+      if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
+        throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
       }
-      // Inputs check
-      if (args.sortField) {
-        if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
-          throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
-        }
-      }
+    }
 
+    try {
       const ability: AppAbility = user.ability;
 
       const abilityFilters = Form.accessibleBy(ability, 'read').getFilter();

--- a/src/schema/query/group.query.ts
+++ b/src/schema/query/group.query.ts
@@ -14,41 +14,29 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability: AppAbility = context.user.ability;
-      if (ability.can('read', 'Group')) {
-        try {
-          const group = await Group.accessibleBy(ability, 'read').findOne({
-            _id: args.id,
-          });
-          if (!group) {
-            throw new GraphQLError(
-              context.i18next.t('common.errors.dataNotFound')
-            );
-          }
-          return group;
-        } catch {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
-        }
-      } else {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
+    const ability: AppAbility = context.user.ability;
+    if (ability.can('read', 'Group')) {
+      let group;
+      try {
+        group = await Group.accessibleBy(ability, 'read').findOne({
+          _id: args.id,
+        });
+      } catch {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+      if (!group) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+      return group;
+    } else {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/query/group.query.ts
+++ b/src/schema/query/group.query.ts
@@ -2,7 +2,6 @@ import { GraphQLID, GraphQLError, GraphQLNonNull } from 'graphql';
 import { Group } from '@models';
 import { GroupType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
-import { logger } from '@services/logger.service';
 
 /**
  * Get Query by ID.

--- a/src/schema/query/groups.query.ts
+++ b/src/schema/query/groups.query.ts
@@ -15,15 +15,13 @@ export default {
     application: { type: GraphQLID },
   },
   resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       const ability: AppAbility = context.user.ability;
       return Group.accessibleBy(ability, 'read');
     } catch (err) {

--- a/src/schema/query/me.query.ts
+++ b/src/schema/query/me.query.ts
@@ -9,20 +9,19 @@ import { logger } from '@services/logger.service';
 export default {
   type: UserType,
   resolve: async (parent, args, context) => {
+    let user;
     try {
-      const user = context.user;
-      if (user) {
-        return user;
-      } else {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+      user = context.user;
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
       );
+    }
+    if (user) {
+      return user;
+    } else {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
   },
 };

--- a/src/schema/query/notifications.query.ts
+++ b/src/schema/query/notifications.query.ts
@@ -26,15 +26,13 @@ export default {
     // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
     checkPageSize(first);
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       const ability: AppAbility = context.user.ability;
 
       const abilityFilters = Notification.accessibleBy(

--- a/src/schema/query/page.query.ts
+++ b/src/schema/query/page.query.ts
@@ -14,32 +14,31 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+
+    let page;
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-
       // get data
-      const page = await Page.findById(args.id);
-
-      // check ability
-      const ability = await extendAbilityForPage(user, page);
-      if (ability.cannot('read', page)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-
-      return page;
+      page = await Page.findById(args.id);
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
       );
     }
+
+    // check ability
+    const ability = await extendAbilityForPage(user, page);
+    if (ability.cannot('read', page)) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
+    return page;
   },
 };

--- a/src/schema/query/permissions.query.ts
+++ b/src/schema/query/permissions.query.ts
@@ -13,23 +13,21 @@ export default {
     application: { type: GraphQLBoolean },
   },
   resolve(parent, args, context) {
-    try {
-      const user = context.user;
-      if (user) {
+    const user = context.user;
+    if (user) {
+      try {
         if (args.application) {
           return Permission.find({ global: false });
         }
         return Permission.find({ global: true });
-      } else {
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
         throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
+          context.i18next.t('common.errors.internalServerError')
         );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
-      throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
-      );
+    } else {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
   },
 };

--- a/src/schema/query/positionAttributes.query.ts
+++ b/src/schema/query/positionAttributes.query.ts
@@ -14,20 +14,19 @@ export default {
     category: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = context.user.ability;
+    if (ability.cannot('read', 'User')) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = context.user.ability;
-      if (ability.cannot('read', 'User')) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
       const positionAttributes = [];
       const lastAttributeValue = [];
       const users = await User.find(

--- a/src/schema/query/pullJobs.query.ts
+++ b/src/schema/query/pullJobs.query.ts
@@ -22,15 +22,13 @@ export default {
     // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
     checkPageSize(first);
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       const ability: AppAbility = context.user.ability;
       const abilityFilters = PullJob.accessibleBy(ability, 'read').getFilter();
       const filters: any[] = [abilityFilters];

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -22,53 +22,50 @@ export default {
     lang: { type: GraphQLString },
   },
   async resolve(parent, args, context) {
-    try {
-      // Setting language, if provided
-      if (args.lang) {
-        await context.i18next.i18n.changeLanguage(args.lang);
-      }
+    // Setting language, if provided
+    if (args.lang) {
+      await context.i18next.i18n.changeLanguage(args.lang);
+    }
 
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.i18n.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(
+        context.i18next.i18n.t('common.errors.userNotLogged')
+      );
+    }
 
-      // Get data
-      const record: Record = await Record.findById(args.id)
-        .populate({
-          path: 'versions',
-          populate: {
-            path: 'createdBy',
-            model: 'User',
-          },
-        })
-        .populate({
-          path: 'createdBy.user',
+    // Get data
+    const record: Record = await Record.findById(args.id)
+      .populate({
+        path: 'versions',
+        populate: {
+          path: 'createdBy',
           model: 'User',
-        })
-        .populate({
-          path: 'form',
-          model: 'Form',
-          populate: {
-            path: 'resource',
-            model: 'Resource',
-          },
-        });
+        },
+      })
+      .populate({
+        path: 'createdBy.user',
+        model: 'User',
+      })
+      .populate({
+        path: 'form',
+        model: 'Form',
+        populate: {
+          path: 'resource',
+          model: 'Resource',
+        },
+      });
 
-      // Check ability
-      const ability = await extendAbilityForRecords(user, record.form);
-      if (
-        ability.cannot('read', record) ||
-        ability.cannot('read', record.form)
-      ) {
-        throw new GraphQLError(
-          context.i18next.i18n.t('common.errors.permissionNotGranted')
-        );
-      }
+    // Check ability
+    const ability = await extendAbilityForRecords(user, record.form);
+    if (ability.cannot('read', record) || ability.cannot('read', record.form)) {
+      throw new GraphQLError(
+        context.i18next.i18n.t('common.errors.permissionNotGranted')
+      );
+    }
 
+    try {
       // Create the history and return it
       const history = await new RecordHistory(record, {
         translate: context.i18next.i18n.t,

--- a/src/schema/query/records.query.ts
+++ b/src/schema/query/records.query.ts
@@ -12,16 +12,14 @@ import { logger } from '@services/logger.service';
 export default {
   type: new GraphQLList(RecordType),
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability = await extendAbilityForRecords(user);
+    const ability = await extendAbilityForRecords(user);
+    try {
       // Return the records
       const records = await Record.accessibleBy(ability, 'read').find();
       return getAccessibleFields(records, ability);

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -56,413 +56,404 @@ export default {
     // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
     checkPageSize(first);
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      // global variables
-      let pipeline: any[] = [];
+    // global variables
+    let pipeline: any[] = [];
 
-      const skip: number = get(args, 'skip', 0);
+    const skip: number = get(args, 'skip', 0);
 
-      // Build data source step
-      // TODO: enhance if switching from azure cosmos to mongo
-      const resource = await Resource.findById(args.resource, {
-        name: 1,
-        fields: 1,
-        aggregations: 1,
-      });
+    // Build data source step
+    // TODO: enhance if switching from azure cosmos to mongo
+    const resource = await Resource.findById(args.resource, {
+      name: 1,
+      fields: 1,
+      aggregations: 1,
+    });
 
-      // Check abilities
-      const ability = await extendAbilityForRecords(user);
-      const permissionFilters = Record.accessibleBy(
-        ability,
-        'read'
-      ).getFilter();
+    // Check abilities
+    const ability = await extendAbilityForRecords(user);
+    const permissionFilters = Record.accessibleBy(ability, 'read').getFilter();
 
-      // As we only queried one aggregation
-      const aggregation = resource.aggregations.find((x) =>
-        isEqual(x.id, args.aggregation)
+    // As we only queried one aggregation
+    const aggregation = resource.aggregations.find((x) =>
+      isEqual(x.id, args.aggregation)
+    );
+    const mongooseFilter = {};
+    // Check if resource exists and aggregation exists
+    if (resource && aggregation) {
+      Object.assign(
+        mongooseFilter,
+        { resource: mongoose.Types.ObjectId(args.resource) },
+        { archived: { $ne: true } }
       );
-      const mongooseFilter = {};
-      // Check if resource exists and aggregation exists
-      if (resource && aggregation) {
-        Object.assign(
-          mongooseFilter,
-          { resource: mongoose.Types.ObjectId(args.resource) },
-          { archived: { $ne: true } }
-        );
-      } else {
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
-      }
+    } else {
+      throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+    }
 
-      pipeline.push({
-        $match: {
-          $and: [mongooseFilter, permissionFilters],
-        },
-      });
+    pipeline.push({
+      $match: {
+        $and: [mongooseFilter, permissionFilters],
+      },
+    });
 
-      // Build the source fields step
-      if (aggregation.sourceFields && aggregation.sourceFields.length) {
-        // If we have user fields
-        if (
-          aggregation.sourceFields.some((x) =>
-            defaultRecordFields.some(
-              (y) =>
-                (x === y.field && y.type === UserType) || y.field === 'form'
-            )
+    // Build the source fields step
+    if (aggregation.sourceFields && aggregation.sourceFields.length) {
+      // If we have user fields
+      if (
+        aggregation.sourceFields.some((x) =>
+          defaultRecordFields.some(
+            (y) => (x === y.field && y.type === UserType) || y.field === 'form'
           )
-        ) {
-          // Form
-          if (aggregation.sourceFields.includes('form')) {
-            const relatedForms = await Form.find({
-              resource: args.resource,
-            }).select('id name');
-            resource.fields.push({
-              name: 'form',
-              choices: relatedForms.map((x) => {
-                return { value: x.id, text: x.name };
-              }),
-            });
-          }
-          // Created By
-          if (aggregation.sourceFields.includes('createdBy')) {
+        )
+      ) {
+        // Form
+        if (aggregation.sourceFields.includes('form')) {
+          const relatedForms = await Form.find({
+            resource: args.resource,
+          }).select('id name');
+          resource.fields.push({
+            name: 'form',
+            choices: relatedForms.map((x) => {
+              return { value: x.id, text: x.name };
+            }),
+          });
+        }
+        // Created By
+        if (aggregation.sourceFields.includes('createdBy')) {
+          pipeline = pipeline.concat(CREATED_BY_STAGES);
+        }
+        // Last updated by
+        if (aggregation.sourceFields.includes('lastUpdatedBy')) {
+          if (!aggregation.sourceFields.includes('createdBy')) {
             pipeline = pipeline.concat(CREATED_BY_STAGES);
           }
-          // Last updated by
-          if (aggregation.sourceFields.includes('lastUpdatedBy')) {
-            if (!aggregation.sourceFields.includes('createdBy')) {
-              pipeline = pipeline.concat(CREATED_BY_STAGES);
-            }
+          pipeline = pipeline.concat([
+            {
+              $addFields: {
+                lastVersion: {
+                  $last: '$versions',
+                },
+              },
+            },
+            {
+              $lookup: {
+                from: 'versions',
+                localField: 'lastVersion',
+                foreignField: '_id',
+                as: 'lastVersion',
+              },
+            },
+            {
+              $lookup: {
+                from: 'users',
+                localField: 'lastVersion.createdBy',
+                foreignField: '_id',
+                as: 'lastUpdatedBy',
+              },
+            },
+            {
+              $addFields: {
+                lastUpdatedBy: {
+                  $last: '$lastUpdatedBy',
+                },
+              },
+            },
+            {
+              $addFields: {
+                lastUpdatedBy: {
+                  $ifNull: ['$lastUpdatedBy', '$createdBy'],
+                },
+              },
+            },
+          ]);
+        }
+      }
+      // Fetch related fields from other forms
+      const relatedFields: any[] = await Form.aggregate([
+        {
+          $match: {
+            fields: {
+              $elemMatch: {
+                resource: String(args.resource),
+                $or: [
+                  {
+                    type: 'resource',
+                  },
+                  {
+                    type: 'resources',
+                  },
+                ],
+              },
+            },
+          },
+        },
+        {
+          $unwind: '$fields',
+        },
+        {
+          $match: {
+            'fields.resource': String(args.resource),
+            $or: [
+              {
+                'fields.type': 'resource',
+              },
+              {
+                'fields.type': 'resources',
+              },
+            ],
+          },
+        },
+        {
+          $addFields: {
+            'fields.form': '$_id',
+          },
+        },
+        {
+          $replaceRoot: {
+            newRoot: '$fields',
+          },
+        },
+      ]);
+      pipeline.push({
+        $addFields: {
+          record_id: {
+            $toString: '$_id',
+          },
+        },
+      });
+      // Loop on fields to apply lookups for special fields
+      for (const fieldName of aggregation.sourceFields) {
+        const field = resource.fields.find((x) => x.name === fieldName);
+        // If field is a calculated field
+        if (field && field.isCalculated) {
+          pipeline.unshift(
+            ...buildCalculatedFieldPipeline(field.expression, field.name)
+          );
+        }
+
+        // If we have resource(s) questions
+        if (
+          field &&
+          (field.type === 'resource' || field.type === 'resources')
+        ) {
+          if (field.type === 'resource') {
+            pipeline.push({
+              $addFields: {
+                [`data.${fieldName}`]: { $toObjectId: `$data.${fieldName}` },
+              },
+            });
+          } else {
+            pipeline.push({
+              $addFields: {
+                [`data.${fieldName}`]: {
+                  $map: {
+                    input: `$data.${fieldName}`,
+                    in: { $toObjectId: '$$this' },
+                  },
+                },
+              },
+            });
+          }
+          pipeline.push({
+            $lookup: {
+              from: 'records',
+              localField: `data.${fieldName}`,
+              foreignField: '_id',
+              as: `data.${fieldName}`,
+            },
+          });
+          if (field.type === 'resource') {
+            pipeline.push({
+              $unwind: `$data.${fieldName}`,
+            });
+          }
+          pipeline.push({
+            $addFields: selectableDefaultRecordFieldsFlat.reduce(
+              (fields, selectableField) => {
+                if (!selectableField.includes('By')) {
+                  return Object.assign(fields, {
+                    [`data.${fieldName}.data.${selectableField}`]: `$data.${fieldName}.${selectableField}`,
+                  });
+                }
+                return fields;
+              },
+              {}
+            ),
+          });
+          pipeline.push({
+            $addFields: {
+              [`data.${fieldName}`]: `$data.${fieldName}.data`,
+            },
+          });
+        }
+        // If we have a field referring to another form with a question targeting our source
+        if (!field) {
+          const relatedField = relatedFields.find(
+            (x: any) => x.relatedName === fieldName
+          );
+          if (relatedField) {
             pipeline = pipeline.concat([
               {
-                $addFields: {
-                  lastVersion: {
-                    $last: '$versions',
-                  },
-                },
-              },
-              {
                 $lookup: {
-                  from: 'versions',
-                  localField: 'lastVersion',
-                  foreignField: '_id',
-                  as: 'lastVersion',
-                },
-              },
-              {
-                $lookup: {
-                  from: 'users',
-                  localField: 'lastVersion.createdBy',
-                  foreignField: '_id',
-                  as: 'lastUpdatedBy',
+                  from: 'records',
+                  localField: 'record_id',
+                  foreignField: `data.${relatedField.name}`,
+                  as: `data.${fieldName}`,
                 },
               },
               {
                 $addFields: {
-                  lastUpdatedBy: {
-                    $last: '$lastUpdatedBy',
+                  [`data.${fieldName}`]: {
+                    $filter: {
+                      input: `$data.${fieldName}`,
+                      cond: {
+                        $eq: ['$$this.form', relatedField.form],
+                      },
+                    },
                   },
                 },
               },
               {
-                $addFields: {
-                  lastUpdatedBy: {
-                    $ifNull: ['$lastUpdatedBy', '$createdBy'],
+                $addFields: selectableDefaultRecordFieldsFlat.reduce(
+                  (fields, selectableField) => {
+                    if (!selectableField.includes('By')) {
+                      return Object.assign(fields, {
+                        [`data.${fieldName}.data.${selectableField}`]: `$data.${fieldName}.${selectableField}`,
+                      });
+                    }
+                    return fields;
                   },
+                  {}
+                ),
+              },
+              {
+                $addFields: {
+                  [`data.${fieldName}`]: `$data.${fieldName}.data`,
                 },
               },
             ]);
           }
         }
-        // Fetch related fields from other forms
-        const relatedFields: any[] = await Form.aggregate([
-          {
-            $match: {
-              fields: {
-                $elemMatch: {
-                  resource: String(args.resource),
-                  $or: [
-                    {
-                      type: 'resource',
-                    },
-                    {
-                      type: 'resources',
-                    },
-                  ],
-                },
-              },
-            },
-          },
-          {
-            $unwind: '$fields',
-          },
-          {
-            $match: {
-              'fields.resource': String(args.resource),
-              $or: [
-                {
-                  'fields.type': 'resource',
-                },
-                {
-                  'fields.type': 'resources',
-                },
-              ],
-            },
-          },
-          {
-            $addFields: {
-              'fields.form': '$_id',
-            },
-          },
-          {
-            $replaceRoot: {
-              newRoot: '$fields',
-            },
-          },
-        ]);
-        pipeline.push({
-          $addFields: {
-            record_id: {
-              $toString: '$_id',
-            },
-          },
-        });
-        // Loop on fields to apply lookups for special fields
-        for (const fieldName of aggregation.sourceFields) {
-          const field = resource.fields.find((x) => x.name === fieldName);
-          // If field is a calculated field
-          if (field && field.isCalculated) {
-            pipeline.unshift(
-              ...buildCalculatedFieldPipeline(field.expression, field.name)
-            );
-          }
-
-          // If we have resource(s) questions
-          if (
-            field &&
-            (field.type === 'resource' || field.type === 'resources')
-          ) {
-            if (field.type === 'resource') {
-              pipeline.push({
-                $addFields: {
-                  [`data.${fieldName}`]: { $toObjectId: `$data.${fieldName}` },
-                },
-              });
-            } else {
-              pipeline.push({
-                $addFields: {
-                  [`data.${fieldName}`]: {
-                    $map: {
-                      input: `$data.${fieldName}`,
-                      in: { $toObjectId: '$$this' },
-                    },
-                  },
-                },
-              });
-            }
-            pipeline.push({
-              $lookup: {
-                from: 'records',
-                localField: `data.${fieldName}`,
-                foreignField: '_id',
-                as: `data.${fieldName}`,
-              },
-            });
-            if (field.type === 'resource') {
-              pipeline.push({
-                $unwind: `$data.${fieldName}`,
-              });
-            }
-            pipeline.push({
-              $addFields: selectableDefaultRecordFieldsFlat.reduce(
-                (fields, selectableField) => {
-                  if (!selectableField.includes('By')) {
-                    return Object.assign(fields, {
-                      [`data.${fieldName}.data.${selectableField}`]: `$data.${fieldName}.${selectableField}`,
-                    });
-                  }
-                  return fields;
-                },
-                {}
-              ),
-            });
-            pipeline.push({
-              $addFields: {
-                [`data.${fieldName}`]: `$data.${fieldName}.data`,
-              },
-            });
-          }
-          // If we have a field referring to another form with a question targeting our source
-          if (!field) {
-            const relatedField = relatedFields.find(
-              (x: any) => x.relatedName === fieldName
-            );
-            if (relatedField) {
-              pipeline = pipeline.concat([
-                {
-                  $lookup: {
-                    from: 'records',
-                    localField: 'record_id',
-                    foreignField: `data.${relatedField.name}`,
-                    as: `data.${fieldName}`,
-                  },
-                },
-                {
-                  $addFields: {
-                    [`data.${fieldName}`]: {
-                      $filter: {
-                        input: `$data.${fieldName}`,
-                        cond: {
-                          $eq: ['$$this.form', relatedField.form],
-                        },
-                      },
-                    },
-                  },
-                },
-                {
-                  $addFields: selectableDefaultRecordFieldsFlat.reduce(
-                    (fields, selectableField) => {
-                      if (!selectableField.includes('By')) {
-                        return Object.assign(fields, {
-                          [`data.${fieldName}.data.${selectableField}`]: `$data.${fieldName}.${selectableField}`,
-                        });
-                      }
-                      return fields;
-                    },
-                    {}
-                  ),
-                },
-                {
-                  $addFields: {
-                    [`data.${fieldName}`]: `$data.${fieldName}.data`,
-                  },
-                },
-              ]);
-            }
-          }
-          // If we have referenceData fields
-          if (field && field.referenceData && field.referenceData.id) {
-            const referenceData = await ReferenceData.findById(
-              field.referenceData.id
-            ).populate({
-              path: 'apiConfiguration',
-              model: 'ApiConfiguration',
-              select: { name: 1, endpoint: 1, graphQLEndpoint: 1 },
-            });
-            const referenceDataAggregation: any[] =
-              await buildReferenceDataAggregation(
-                referenceData,
-                field,
-                context
-              );
-            pipeline.push(...referenceDataAggregation);
-          }
+        // If we have referenceData fields
+        if (field && field.referenceData && field.referenceData.id) {
+          const referenceData = await ReferenceData.findById(
+            field.referenceData.id
+          ).populate({
+            path: 'apiConfiguration',
+            model: 'ApiConfiguration',
+            select: { name: 1, endpoint: 1, graphQLEndpoint: 1 },
+          });
+          const referenceDataAggregation: any[] =
+            await buildReferenceDataAggregation(referenceData, field, context);
+          pipeline.push(...referenceDataAggregation);
         }
-        pipeline.push({
-          $project: {
-            ...(aggregation.sourceFields as any[]).reduce(
-              (o, field) =>
-                Object.assign(o, {
-                  [field]: selectableDefaultRecordFieldsFlat.includes(field)
-                    ? 1
-                    : `$data.${field}`,
-                }),
-              {}
-            ),
-          },
-        });
-      } else {
-        throw new GraphQLError(
-          context.i18next.t(
-            'query.records.aggregation.errors.invalidAggregation'
-          )
-        );
       }
-      // Build pipeline stages
-      if (aggregation.pipeline && aggregation.pipeline.length) {
-        buildPipeline(pipeline, aggregation.pipeline, resource, context);
-      }
-      // Build mapping step
-      if (args.mapping) {
-        pipeline.push({
-          $project: {
-            category: `$${args.mapping.category}`,
-            field: `$${args.mapping.field}`,
-            id: '$_id',
-            ...(args.mapping.series && {
-              series: `$${args.mapping.series}`,
-            }),
-          },
-        });
-      } else {
-        // Only sending some examples of the queried data
-        pipeline.push({
-          $addFields: {
-            id: '$_id',
-          },
-        });
-        pipeline.push({
-          $facet: {
-            items: [{ $skip: skip }, { $limit: first }],
-            totalCount: [
-              {
-                $count: 'count',
-              },
-            ],
-          },
-        });
-      }
+      pipeline.push({
+        $project: {
+          ...(aggregation.sourceFields as any[]).reduce(
+            (o, field) =>
+              Object.assign(o, {
+                [field]: selectableDefaultRecordFieldsFlat.includes(field)
+                  ? 1
+                  : `$data.${field}`,
+              }),
+            {}
+          ),
+        },
+      });
+    } else {
+      throw new GraphQLError(
+        context.i18next.t('query.records.aggregation.errors.invalidAggregation')
+      );
+    }
+    // Build pipeline stages
+    if (aggregation.pipeline && aggregation.pipeline.length) {
+      buildPipeline(pipeline, aggregation.pipeline, resource, context);
+    }
+    // Build mapping step
+    if (args.mapping) {
+      pipeline.push({
+        $project: {
+          category: `$${args.mapping.category}`,
+          field: `$${args.mapping.field}`,
+          id: '$_id',
+          ...(args.mapping.series && {
+            series: `$${args.mapping.series}`,
+          }),
+        },
+      });
+    } else {
+      // Only sending some examples of the queried data
+      pipeline.push({
+        $addFields: {
+          id: '$_id',
+        },
+      });
+      pipeline.push({
+        $facet: {
+          items: [{ $skip: skip }, { $limit: first }],
+          totalCount: [
+            {
+              $count: 'count',
+            },
+          ],
+        },
+      });
+    }
+
+    let recordAggregation;
+    try {
       // Get aggregated data
-      const recordAggregation = await Record.aggregate(pipeline);
-      let items;
-      let totalCount;
-      if (args.mapping) {
-        items = recordAggregation;
-        totalCount = recordAggregation.length;
-      } else {
-        items = recordAggregation[0].items;
-        totalCount = recordAggregation[0]?.totalCount[0]?.count || 0;
-      }
-      const copiedItems = cloneDeep(items);
-
-      // For each detected field with choices, set the value of each entry to be display text value and then return
-      try {
-        if (args.mapping && args.mapping.category && args.mapping.field) {
-          const mappedFields = [
-            { key: 'category', value: args.mapping.category },
-            { key: 'field', value: args.mapping.field },
-          ];
-          if (args.mapping.series) {
-            mappedFields.push({
-              key: 'series',
-              value: args.mapping.series,
-            });
-          }
-          await setDisplayText(mappedFields, copiedItems, resource, context);
-          return copiedItems;
-        } else {
-          const mappedFields = Object.keys(items[0]).map((key) => ({
-            key,
-            value: key,
-          }));
-          await setDisplayText(mappedFields, copiedItems, resource, context);
-          return { items: copiedItems, totalCount };
-        }
-      } catch (err) {
-        logger.error(err.message, { stack: err.stack });
-        return args.mapping ? items : { items, totalCount };
-      }
+      recordAggregation = await Record.aggregate(pipeline);
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
       );
+    }
+
+    let items;
+    let totalCount;
+    if (args.mapping) {
+      items = recordAggregation;
+      totalCount = recordAggregation.length;
+    } else {
+      items = recordAggregation[0].items;
+      totalCount = recordAggregation[0]?.totalCount[0]?.count || 0;
+    }
+    const copiedItems = cloneDeep(items);
+
+    // For each detected field with choices, set the value of each entry to be display text value and then return
+    try {
+      if (args.mapping && args.mapping.category && args.mapping.field) {
+        const mappedFields = [
+          { key: 'category', value: args.mapping.category },
+          { key: 'field', value: args.mapping.field },
+        ];
+        if (args.mapping.series) {
+          mappedFields.push({
+            key: 'series',
+            value: args.mapping.series,
+          });
+        }
+        await setDisplayText(mappedFields, copiedItems, resource, context);
+        return copiedItems;
+      } else {
+        const mappedFields = Object.keys(items[0]).map((key) => ({
+          key,
+          value: key,
+        }));
+        await setDisplayText(mappedFields, copiedItems, resource, context);
+        return { items: copiedItems, totalCount };
+      }
+    } catch (err) {
+      logger.error(err.message, { stack: err.stack });
+      return args.mapping ? items : { items, totalCount };
     }
   },
 };

--- a/src/schema/query/referenceData.query.ts
+++ b/src/schema/query/referenceData.query.ts
@@ -13,14 +13,12 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
       return await ReferenceData.findById(args.id);
     } catch (err) {
       logger.error(err.message, { stack: err.stack });

--- a/src/schema/query/referenceDatas.query.ts
+++ b/src/schema/query/referenceDatas.query.ts
@@ -37,15 +37,13 @@ export default {
     // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
     checkPageSize(first);
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       const ability: AppAbility = context.user.ability;
 
       const abilityFilters = ReferenceData.accessibleBy(

--- a/src/schema/query/resource.query.ts
+++ b/src/schema/query/resource.query.ts
@@ -14,29 +14,28 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+
+    const ability: AppAbility = user.ability;
+    let resource;
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-
-      const ability: AppAbility = user.ability;
-      const resource = await Resource.findOne({ _id: args.id });
-
-      if (ability.cannot('read', resource)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      return resource;
+      resource = await Resource.findOne({ _id: args.id });
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
       );
     }
+
+    if (ability.cannot('read', resource)) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+    return resource;
   },
 };

--- a/src/schema/query/resources.query.ts
+++ b/src/schema/query/resources.query.ts
@@ -78,24 +78,22 @@ export default {
     // Make sure that the page size is not too important
     const first = args.first || DEFAULT_FIRST;
     checkPageSize(first);
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+
+    const ability: AppAbility = user.ability;
+
+    // Inputs check
+    if (args.sortField) {
+      if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
+        throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
+      }
+    }
+
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-
-      const ability: AppAbility = user.ability;
-
-      // Inputs check
-      if (args.sortField) {
-        if (!SORT_FIELDS.map((x) => x.name).includes(args.sortField)) {
-          throw new GraphQLError(`Cannot sort by ${args.sortField} field`);
-        }
-      }
-
       const abilityFilters = Resource.accessibleBy(ability, 'read').getFilter();
       const queryFilters = getFilter(args.filter, FILTER_FIELDS);
       const filters: any[] = [queryFilters, abilityFilters];

--- a/src/schema/query/role.query.ts
+++ b/src/schema/query/role.query.ts
@@ -2,7 +2,6 @@ import { GraphQLID, GraphQLError, GraphQLNonNull } from 'graphql';
 import { Role } from '@models';
 import { RoleType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
-import { logger } from '@services/logger.service';
 
 /**
  * Get Query by ID.

--- a/src/schema/query/roles.query.ts
+++ b/src/schema/query/roles.query.ts
@@ -15,17 +15,15 @@ export default {
     application: { type: GraphQLID },
   },
   resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability: AppAbility = context.user.ability;
-      if (ability.can('read', 'Role')) {
+    const ability: AppAbility = context.user.ability;
+    if (ability.can('read', 'Role')) {
+      try {
         if (args.all) {
           return Role.accessibleBy(ability, 'read');
         } else {
@@ -39,15 +37,15 @@ export default {
             });
           }
         }
-      } else {
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t('common.errors.internalServerError')
         );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    } else {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/query/rolesFromApplications.query.ts
+++ b/src/schema/query/rolesFromApplications.query.ts
@@ -13,15 +13,13 @@ export default {
     applications: { type: new GraphQLNonNull(GraphQLList(GraphQLID)) },
   },
   resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       return Role.find({ application: { $in: args.applications } }).select(
         'id title application'
       );

--- a/src/schema/query/step.query.ts
+++ b/src/schema/query/step.query.ts
@@ -14,30 +14,29 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   async resolve(parent, args, context) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+
+    let step;
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-
       // get data and check permissions
-      const step = await Step.findById(args.id);
-      const ability = await extendAbilityForStep(user, step);
-      if (ability.cannot('read', step)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-
-      return step;
+      step = await Step.findById(args.id);
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')
       );
     }
+    const ability = await extendAbilityForStep(user, step);
+    if (ability.cannot('read', step)) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
+    return step;
   },
 };

--- a/src/schema/query/steps.query.ts
+++ b/src/schema/query/steps.query.ts
@@ -11,15 +11,13 @@ import { logger } from '@services/logger.service';
 export default {
   type: new GraphQLList(StepType),
   resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       const ability: AppAbility = context.user.ability;
       return Step.accessibleBy(ability, 'read');
     } catch (err) {

--- a/src/schema/query/user.query.ts
+++ b/src/schema/query/user.query.ts
@@ -2,7 +2,6 @@ import { GraphQLError, GraphQLID, GraphQLNonNull } from 'graphql';
 import { User } from '@models';
 import { UserType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
-import { logger } from '@services/logger.service';
 
 /**
  * Get User by ID.

--- a/src/schema/query/user.query.ts
+++ b/src/schema/query/user.query.ts
@@ -14,34 +14,23 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
   resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability: AppAbility = context.user.ability;
+    const ability: AppAbility = context.user.ability;
 
-      if (ability.can('read', 'User')) {
-        try {
-          return User.findById(args.id).populate('roles').populate('groups');
-        } catch {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.dataNotFound')
-          );
-        }
-      } else {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
+    if (ability.can('read', 'User')) {
+      try {
+        return User.findById(args.id).populate('roles').populate('groups');
+      } catch {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    } else {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/query/users.query.ts
+++ b/src/schema/query/users.query.ts
@@ -15,18 +15,16 @@ export default {
     applications: { type: GraphQLList(GraphQLID) },
   },
   resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      const ability: AppAbility = context.user.ability;
+    const ability: AppAbility = context.user.ability;
 
-      if (ability.can('read', 'User')) {
+    if (ability.can('read', 'User')) {
+      try {
         if (!args.applications) {
           return User.find({}).populate({
             path: 'roles',
@@ -67,15 +65,15 @@ export default {
           ];
           return User.aggregate(aggregations);
         }
-      } else {
+      } catch (err) {
+        logger.error(err.message, { stack: err.stack });
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t('common.errors.internalServerError')
         );
       }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    } else {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
   },

--- a/src/schema/query/workflow.query.ts
+++ b/src/schema/query/workflow.query.ts
@@ -16,24 +16,22 @@ export default {
     asRole: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+
+    // get data and check permissions
+    const workflow = await Workflow.findById(args.id);
+    const ability = await extendAbilityForContent(user, workflow);
+    if (ability.cannot('read', workflow)) {
+      throw new GraphQLError(
+        context.i18next.t('common.errors.permissionNotGranted')
+      );
+    }
+
     try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-
-      // get data and check permissions
-      const workflow = await Workflow.findById(args.id);
-      const ability = await extendAbilityForContent(user, workflow);
-      if (ability.cannot('read', workflow)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-
       if (args.asRole) {
         const steps = await Step.aggregate([
           {

--- a/src/schema/query/workflows.query.ts
+++ b/src/schema/query/workflows.query.ts
@@ -11,15 +11,13 @@ import { logger } from '@services/logger.service';
 export default {
   type: new GraphQLList(WorkflowType),
   resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
+    try {
       const ability: AppAbility = context.user.ability;
       return Workflow.accessibleBy(ability, 'read');
     } catch (err) {


### PR DESCRIPTION
# Description
Because we put all mutations inside try / catch, some errors that should be sent by methods inside these try / catch are not visible when using the API
if possible, we should detect in the try / catch if the error is a graphQL error before sending the default 'internal error'

## Ticket
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/65380

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

