### PR TITLE
fix/OORT-635-dataset-when-sending-email

### DIFF
--- a/src/utils/files/extractGridData.ts
+++ b/src/utils/files/extractGridData.ts
@@ -127,7 +127,8 @@ const getRows = async (
   // todo: optimize in order to avoid using graphQL?
   const query = buildQuery(params.query);
   let offset = 0;
-  const batchSize = 2000;
+  // Maximum page size is 1000
+  const batchSize = 1000;
   const rows: any[] = [];
   do {
     try {


### PR DESCRIPTION
# Description
In the extractGridData.ts file, the getRows function had a batchSize = 2000, and the error "Maximum page size is 1000. Please use a different page size." was always raised and none data row was available with it.

## Ticket
[OORT-635: Dataset template not showing when sending email](https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/3?selectedIssue=OORT-635)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Adding the {{dataset}} placeholder to send grid information via email.

## Sreenshots
![email](https://github.com/ReliefApplications/oort-backend/assets/28535394/46154335-20b5-49eb-87dc-f8863cafc790)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

