### PR TITLE
fix/OORT-639-sorting-by-calculated-fields

### DIFF
--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -376,14 +376,33 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
       // Build aggregation for calculated fields
       const calculatedFieldsAggregation: any[] = [];
 
+      // only add calculated fields that are in the query
+      // in order to decrease the pipeline size
+      const shouldAddCalculatedFieldToPipeline = (field: any) => {
+        // If field is requested in the query
+        if (queryFields.findIndex((x) => x.name === field.name) > -1)
+          return true;
+
+        // If sort field is a calculated field
+        if (sortField === field.name) return true;
+
+        const isUsedInFilter = (qFilter: any) => {
+          if (qFilter.field) return qFilter.field === field.name;
+          return qFilter.filters?.some((f) => isUsedInFilter(f)) ?? false;
+        };
+
+        // Check if the field is used in the filter
+        if (isUsedInFilter(filter)) return true;
+
+        // Check if the field is used in any styles' filters
+        if (styles.some((s) => isUsedInFilter(s.filter))) return true;
+
+        // If not used in any of the above, don't add it to the pipeline
+        return false;
+      };
+
       fields
-        .filter(
-          (f) =>
-            f.isCalculated &&
-            // only add calculated fields that are in the query
-            // in order to decrease the pipeline size
-            queryFields.findIndex((x) => x.name === f.name) > -1
-        )
+        .filter((f) => f.isCalculated && shouldAddCalculatedFieldToPipeline(f))
         .forEach((f) =>
           calculatedFieldsAggregation.push(
             ...buildCalculatedFieldPipeline(f.expression, f.name)


### PR DESCRIPTION
# Description
If calculated fields are used for sorting/filtering/style rules, they're added to the pipeline as well, so grids that are sorted using calculated fields can be properly sorted

## Ticket
[OORT-639: Sorting by calculated fields when they're not on the query](https://oortcloud.atlassian.net/browse/OORT-639)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Using calculated fields in the grids

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

