### PR TITLE
Fix/ab#65380 some back end errors are not handled correctly

### DIFF
--- a/src/schema/mutation/addAggregation.mutation.ts
+++ b/src/schema/mutation/addAggregation.mutation.ts
@@ -4,6 +4,7 @@ import { AggregationType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import AggregationInputType from '../../schema/inputs/aggregation.input';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Add new aggregation.
@@ -18,13 +19,13 @@ export default {
   async resolve(parent, args, context) {
     try {
       if (!args.resource || !args.aggregation) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('mutations.aggregation.add.errors.invalidArguments')
         );
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -36,7 +37,7 @@ export default {
           .getFilter();
         const resource: Resource = await Resource.findOne(filters);
         if (!resource) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
@@ -45,6 +46,10 @@ export default {
         return resource.aggregations.pop();
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addApiConfiguration.mutation.ts
+++ b/src/schema/mutation/addApiConfiguration.mutation.ts
@@ -5,6 +5,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import { authType, status } from '@const/enumTypes';
 import { validateApi } from '@utils/validators/validateApi';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Create a new apiConfiguration.
@@ -19,7 +20,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -39,17 +40,21 @@ export default {
           });
           return await apiConfiguration.save();
         }
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t(
             'mutations.apiConfiguration.add.errors.invalidArguments'
           )
         );
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addApplication.mutation.ts
+++ b/src/schema/mutation/addApplication.mutation.ts
@@ -7,6 +7,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import { status } from '@const/enumTypes';
 import permissions from '@const/permissions';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Create a new application.
@@ -19,7 +20,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -102,11 +103,15 @@ export default {
         }
         return application;
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addChannel.mutation.ts
+++ b/src/schema/mutation/addChannel.mutation.ts
@@ -8,6 +8,7 @@ import { Application, Channel } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { ChannelType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Create a new channel.
@@ -23,14 +24,16 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
       const ability: AppAbility = user.ability;
       const application = await Application.findById(args.application);
       if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        throw new GraphQLHandlingError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
       if (ability.can('update', application)) {
         const channel = new Channel({
           title: args.title,
@@ -38,11 +41,15 @@ export default {
         });
         return await channel.save();
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addCustomNotification.mutation.ts
+++ b/src/schema/mutation/addCustomNotification.mutation.ts
@@ -7,6 +7,7 @@ import extendAbilityForApplications from '@security/extendAbilityForApplication'
 import { scheduleCustomNotificationJob } from '../../server/customNotificationScheduler';
 import { customNotificationStatus } from '@const/enumTypes';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Mutation to add a new custom notification.
@@ -21,7 +22,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -30,7 +31,7 @@ export default {
         args.application
       );
       if (ability.cannot('create', 'CustomNotification')) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -39,7 +40,7 @@ export default {
         // make sure minute is not a wildcard
         const reg = new RegExp('^([0-9]|[1-5][0-9])$');
         if (!reg.test(args.notification.schedule.split(' ')[0])) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t(
               'mutations.customNotification.add.errors.maximumFrequency'
             )
@@ -77,6 +78,10 @@ export default {
       }
       return notificationDetail;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addDashboard.mutation.ts
+++ b/src/schema/mutation/addDashboard.mutation.ts
@@ -3,6 +3,7 @@ import { Dashboard } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { DashboardType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Create a new dashboard.
@@ -17,7 +18,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -30,15 +31,19 @@ export default {
           });
           return dashboard.save();
         }
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('mutations.dashboard.add.errors.invalidArguments')
         );
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addLayout.mutation.ts
+++ b/src/schema/mutation/addLayout.mutation.ts
@@ -4,6 +4,7 @@ import { LayoutType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import LayoutInputType from '../../schema/inputs/layout.input';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Add new grid layout.
@@ -19,7 +20,7 @@ export default {
   async resolve(parent, args, context) {
     try {
       if (args.form && args.resource) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t(
             'mutations.layout.add.errors.invalidAddPageArguments'
           )
@@ -27,7 +28,7 @@ export default {
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -39,7 +40,7 @@ export default {
           .getFilter();
         const resource: Resource = await Resource.findOne(filters);
         if (!resource) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
@@ -53,7 +54,7 @@ export default {
           .getFilter();
         const form: Form = await Form.findOne(filters);
         if (!form) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
@@ -62,6 +63,10 @@ export default {
         return form.layouts.pop();
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addPage.mutation.ts
+++ b/src/schema/mutation/addPage.mutation.ts
@@ -5,6 +5,7 @@ import { PageType } from '../types';
 import { ContentEnumType } from '@const/enumTypes';
 import extendAbilityForPage from '@security/extendAbilityForPage';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Create a new page linked to an existing application.
@@ -24,25 +25,27 @@ export default {
       // check user
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
       // check inputs
       if (!args.application || !(args.type in contentType)) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('mutations.page.add.errors.invalidArguments')
         );
       }
       // check data
       const application = await Application.findById(args.application);
       if (!application) {
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        throw new GraphQLHandlingError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
       }
       // check permission
       const ability = await extendAbilityForPage(user, application);
       if (ability.cannot('create', 'Page')) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -73,7 +76,7 @@ export default {
         case contentType.form: {
           const form = await Form.findById(content);
           if (!form) {
-            throw new GraphQLError(
+            throw new GraphQLHandlingError(
               context.i18next.t('common.errors.dataNotFound')
             );
           }
@@ -105,6 +108,10 @@ export default {
       await application.updateOne(update);
       return page;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addReferenceData.mutation.ts
+++ b/src/schema/mutation/addReferenceData.mutation.ts
@@ -4,6 +4,7 @@ import { ReferenceDataType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { validateGraphQLTypeName } from '@utils/validators';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Creates a new referenceData.
@@ -18,7 +19,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -32,7 +33,7 @@ export default {
             (await Form.hasDuplicate(graphQLTypeName)) ||
             (await ReferenceData.hasDuplicate(graphQLTypeName))
           ) {
-            throw new GraphQLError(
+            throw new GraphQLHandlingError(
               context.i18next.t('common.errors.duplicatedGraphQLTypeName')
             );
           }
@@ -57,15 +58,19 @@ export default {
           });
           return await referenceData.save();
         }
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('mutations.reference.add.errors.invalidArguments')
         );
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addSubscription.mutation.ts
+++ b/src/schema/mutation/addSubscription.mutation.ts
@@ -10,6 +10,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import { createAndConsumeQueue } from '../../server/subscriberSafe';
 import { SubscriptionType } from '../types/subscription.type';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Creates a new subscription
@@ -28,19 +29,21 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
       const ability: AppAbility = user.ability;
       const application = await Application.findById(args.application);
       if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        throw new GraphQLHandlingError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
 
       if (args.convertTo) {
         const form = await Form.findById(args.convertTo);
         if (!form)
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.dataNotFound')
           );
       }
@@ -52,7 +55,7 @@ export default {
         };
         const channel = await Channel.findOne(filters);
         if (!channel)
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.dataNotFound')
           );
       }
@@ -79,6 +82,10 @@ export default {
       createAndConsumeQueue(args.routingKey);
       return subscription;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/addTemplate.mutation.ts
+++ b/src/schema/mutation/addTemplate.mutation.ts
@@ -5,6 +5,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import TemplateInputType from '../inputs/template.input';
 import extendAbilityForApplications from '@security/extendAbilityForApplication';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Mutation to add a new template.
@@ -19,7 +20,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -28,7 +29,7 @@ export default {
         args.application
       );
       if (ability.cannot('update', 'Template')) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -51,6 +52,10 @@ export default {
 
       return application.templates.pop();
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteAggregation.mutation.ts
+++ b/src/schema/mutation/deleteAggregation.mutation.ts
@@ -3,6 +3,7 @@ import { Resource } from '@models';
 import { AggregationType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Delete existing aggregation.
@@ -17,7 +18,7 @@ export default {
   async resolve(parent, args, context) {
     try {
       if (!args.resource) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t(
             'mutations.aggregation.delete.errors.invalidArguments'
           )
@@ -25,7 +26,7 @@ export default {
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -37,7 +38,7 @@ export default {
           .getFilter();
         const resource: Resource = await Resource.findOne(filters);
         if (!resource) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
@@ -47,6 +48,10 @@ export default {
         return aggregation;
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteChannel.mutation.ts
+++ b/src/schema/mutation/deleteChannel.mutation.ts
@@ -3,6 +3,7 @@ import { Channel, Role } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { ChannelType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Delete a channel from its id and all linked notifications.
@@ -18,7 +19,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -36,11 +37,15 @@ export default {
         }
         return await Channel.findByIdAndDelete(args.id);
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteCustomNotification.mutation.ts
+++ b/src/schema/mutation/deleteCustomNotification.mutation.ts
@@ -5,6 +5,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import extendAbilityForApplications from '@security/extendAbilityForApplication';
 import { unscheduleCustomNotificationJob } from '../../server/customNotificationScheduler';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Mutation to delete custom notification.
@@ -19,7 +20,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -28,7 +29,7 @@ export default {
         args.application
       );
       if (ability.cannot('delete', 'CustomNotification')) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -50,6 +51,10 @@ export default {
 
       return notificationDetail;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteDashboard.mutation.ts
+++ b/src/schema/mutation/deleteDashboard.mutation.ts
@@ -3,6 +3,7 @@ import { DashboardType } from '../types';
 import { Dashboard, Page, Step } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Finds dashboard from its id and delete it, if user is authorized.
@@ -19,7 +20,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -37,11 +38,15 @@ export default {
         if (page || step) {
           return await Dashboard.findByIdAndDelete(args.id);
         }
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteDistributionList.mutation.ts
+++ b/src/schema/mutation/deleteDistributionList.mutation.ts
@@ -4,6 +4,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import extendAbilityForApplications from '@security/extendAbilityForApplication';
 import { DistributionListType } from '@schema/types/distributionList.type';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Mutation to delete distribution list.
@@ -18,7 +19,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -27,7 +28,7 @@ export default {
         args.application
       );
       if (ability.cannot('update', 'DistributionList')) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -45,6 +46,10 @@ export default {
         (x) => x.id.toString() === args.id
       );
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteForm.mutation.ts
+++ b/src/schema/mutation/deleteForm.mutation.ts
@@ -4,6 +4,7 @@ import { Form, Resource } from '@models';
 import { buildTypes } from '@utils/schema';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Find form from its id and delete it, and all records associated, if user is authorized.
@@ -19,7 +20,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -32,7 +33,7 @@ export default {
         .getFilter();
       const form = await Form.findOne(filters);
       if (!form) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -46,6 +47,10 @@ export default {
       buildTypes();
       return form;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteGroup.mutation.ts
+++ b/src/schema/mutation/deleteGroup.mutation.ts
@@ -3,6 +3,7 @@ import { Group } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { GroupType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Deletes a group.
@@ -18,7 +19,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -31,11 +32,15 @@ export default {
       if (group) {
         return group;
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteLayout.mutation.ts
+++ b/src/schema/mutation/deleteLayout.mutation.ts
@@ -3,6 +3,7 @@ import { Resource, Form } from '@models';
 import { LayoutType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Deletes an existing layout.
@@ -18,13 +19,13 @@ export default {
   async resolve(parent, args, context) {
     try {
       if (args.form && args.resource) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('mutations.layout.delete.errors.invalidArguments')
         );
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -36,7 +37,7 @@ export default {
           .getFilter();
         const resource: Resource = await Resource.findOne(filters);
         if (!resource) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
@@ -50,7 +51,7 @@ export default {
           .getFilter();
         const form: Form = await Form.findOne(filters);
         if (!form) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
@@ -59,6 +60,10 @@ export default {
         return layout;
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/deletePositionAttributeCategory.mutation.ts
@@ -3,6 +3,7 @@ import { Application, PositionAttributeCategory } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { PositionAttributeCategoryType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Delete a position attribute category.
@@ -19,22 +20,28 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
       const ability: AppAbility = context.user.ability;
       const application = await Application.findById(args.application);
       if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        throw new GraphQLHandlingError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
       if (ability.can('update', application)) {
         return await PositionAttributeCategory.findByIdAndDelete(args.id);
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteRecords.mutation.ts
+++ b/src/schema/mutation/deleteRecords.mutation.ts
@@ -9,6 +9,7 @@ import {
 import { Record } from '@models';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Delete multiple records.
@@ -25,7 +26,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -63,6 +64,10 @@ export default {
         return result.nModified;
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteReferenceData.mutation.ts
+++ b/src/schema/mutation/deleteReferenceData.mutation.ts
@@ -4,6 +4,7 @@ import { ReferenceDataType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { buildTypes } from '@utils/schema';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Delete the passed referenceData if authorized.
@@ -18,7 +19,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -28,7 +29,7 @@ export default {
         .getFilter();
       const referenceData = await ReferenceData.findOneAndDelete(filters);
       if (!referenceData) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -37,6 +38,10 @@ export default {
       buildTypes();
       return referenceData;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteResource.mutation.ts
+++ b/src/schema/mutation/deleteResource.mutation.ts
@@ -4,6 +4,7 @@ import { Resource } from '@models';
 import { buildTypes } from '@utils/schema';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Delete a resource from its id.
@@ -19,7 +20,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -32,7 +33,7 @@ export default {
 
       /// Resource is not deleted, user does not have permission to do the deletion
       if (!deletedResource) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -40,6 +41,10 @@ export default {
       buildTypes();
       return deletedResource;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteRole.mutation.ts
+++ b/src/schema/mutation/deleteRole.mutation.ts
@@ -3,6 +3,7 @@ import { Role } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { RoleType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Deletes a role.
@@ -18,7 +19,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -31,11 +32,15 @@ export default {
       if (role) {
         return role;
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteSubscription.mutation.ts
+++ b/src/schema/mutation/deleteSubscription.mutation.ts
@@ -9,6 +9,7 @@ import { ApplicationType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { deleteQueue } from '../../server/subscriberSafe';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Delete a subscription.
@@ -25,7 +26,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -36,7 +37,9 @@ export default {
         .getFilter();
       const application = await Application.findOne(filters);
       if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        throw new GraphQLHandlingError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
       application.subscriptions = await application.subscriptions.filter(
         (sub) => sub.routingKey !== args.routingKey
       );
@@ -46,6 +49,10 @@ export default {
       deleteQueue(args.routingKey);
       return application;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteTemplate.mutation.ts
+++ b/src/schema/mutation/deleteTemplate.mutation.ts
@@ -4,6 +4,7 @@ import { TemplateType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import extendAbilityForApplications from '@security/extendAbilityForApplication';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Mutation to delete template.
@@ -18,7 +19,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -27,7 +28,7 @@ export default {
         args.application
       );
       if (ability.cannot('update', 'Template')) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -43,6 +44,10 @@ export default {
 
       return application.templates.find((x) => x.id.toString() === args.id);
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteUsers.mutation.ts
+++ b/src/schema/mutation/deleteUsers.mutation.ts
@@ -8,6 +8,7 @@ import {
 import { User } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Delete a user.
@@ -23,7 +24,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -32,11 +33,15 @@ export default {
         const result = await User.deleteMany({ _id: { $in: args.ids } });
         return result.deletedCount;
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteUsersFromApplication.mutation.ts
+++ b/src/schema/mutation/deleteUsersFromApplication.mutation.ts
@@ -4,6 +4,7 @@ import { PositionAttributeCategory, Role, User } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { UserType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Delete a user from application.
@@ -20,7 +21,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -36,7 +37,7 @@ export default {
             )
         );
         if (!canDelete) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
@@ -62,6 +63,10 @@ export default {
       );
       return await User.find({ _id: { $in: args.ids } });
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/deleteWorkflow.mutation.ts
+++ b/src/schema/mutation/deleteWorkflow.mutation.ts
@@ -3,6 +3,7 @@ import { WorkflowType } from '../types';
 import { Workflow, Page, Step } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Delete a workflow from its id and recursively delete steps.
@@ -18,7 +19,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -39,11 +40,15 @@ export default {
         }
       }
       if (!workflow)
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       return workflow;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editApiConfiguration.mutation.ts
+++ b/src/schema/mutation/editApiConfiguration.mutation.ts
@@ -14,6 +14,7 @@ import { buildTypes } from '@utils/schema';
 import { validateApi } from '@utils/validators/validateApi';
 import config from 'config';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Edit the passed apiConfiguration if authorized.
@@ -36,7 +37,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -51,7 +52,7 @@ export default {
         !args.settings &&
         !args.permissions
       ) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t(
             'mutations.apiConfiguration.edit.errors.invalidArguments'
           )
@@ -91,11 +92,15 @@ export default {
         }
         return apiConfiguration;
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editApplication.mutation.ts
+++ b/src/schema/mutation/editApplication.mutation.ts
@@ -14,6 +14,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import { StatusEnumType } from '@const/enumTypes';
 import { isEmpty, isNil } from 'lodash';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Find application from its id and update it, if user is authorized.
@@ -38,14 +39,14 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
       const ability: AppAbility = context.user.ability;
       // Check that args were provided and object is not empty
       if (!args || isEmpty(args)) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t(
             'mutations.application.duplicate.errors.invalidArguments'
           )
@@ -56,7 +57,7 @@ export default {
         .getFilter();
       let application = await Application.findOne(filters);
       if (!application) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -64,7 +65,9 @@ export default {
         application.lockedBy &&
         application.lockedBy.toString() !== user._id.toString()
       ) {
-        throw new GraphQLError('Please unlock application for edition.');
+        throw new GraphQLHandlingError(
+          'Please unlock application for edition.'
+        );
       }
       const update = {
         // lockedBy: user._id,
@@ -97,6 +100,10 @@ export default {
       });
       return application;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editDistributionList.mutation.ts
+++ b/src/schema/mutation/editDistributionList.mutation.ts
@@ -6,6 +6,7 @@ import extendAbilityForApplications from '@security/extendAbilityForApplication'
 import DistributionListInputType from '@schema/inputs/distributionList.input';
 import { validateEmail } from '@utils/validators';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Mutation to edit distribution list.
@@ -21,7 +22,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -30,7 +31,7 @@ export default {
         args.application
       );
       if (ability.cannot('update', 'DistributionList')) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -38,7 +39,7 @@ export default {
       if (
         args.distributionList.emails.filter((x) => !validateEmail(x)).length > 0
       ) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.invalidEmailsInput')
         );
       }
@@ -60,6 +61,10 @@ export default {
         (distributionList) => distributionList.id.toString() === args.id
       );
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editLayout.mutation.ts
+++ b/src/schema/mutation/editLayout.mutation.ts
@@ -4,6 +4,7 @@ import { LayoutType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import LayoutInputType from '../../schema/inputs/layout.input';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Edits an existing layout.
@@ -19,7 +20,7 @@ export default {
   async resolve(parent, args, context) {
     try {
       if (args.form && args.resource) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t(
             'mutations.layout.edit.errors.invalidAddPageArguments'
           )
@@ -27,7 +28,7 @@ export default {
       }
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -39,7 +40,7 @@ export default {
           .getFilter();
         const resource: Resource = await Resource.findOne(filters);
         if (!resource) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
@@ -55,7 +56,7 @@ export default {
           .getFilter();
         const form: Form = await Form.findOne(filters);
         if (!form) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.permissionNotGranted')
           );
         }
@@ -66,6 +67,10 @@ export default {
         return form.layouts.id(args.id);
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editPage.mutation.ts
+++ b/src/schema/mutation/editPage.mutation.ts
@@ -57,7 +57,9 @@ export default {
       // get data
       let page = await Page.findById(args.id);
       if (!page) {
-        throw new GraphQLHandlingError(context.i18next.t('common.errors.dataNotFound'));
+        throw new GraphQLHandlingError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
       }
       // check permission
       const ability = await extendAbilityForPage(user, page);

--- a/src/schema/mutation/editPageContext.mutation.ts
+++ b/src/schema/mutation/editPageContext.mutation.ts
@@ -5,6 +5,7 @@ import extendAbilityForPage from '@security/extendAbilityForPage';
 import { PageContextInputType } from '@schema/inputs';
 import { Types } from 'mongoose';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  *  Finds a page from its id and update it's context, if user is authorized.
@@ -21,7 +22,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -32,7 +33,7 @@ export default {
         (!args?.context?.refData && !!args?.context?.resource);
 
       if (!args || !validSource)
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t(
             'mutations.page.edit.context.errors.invalidArguments'
           )
@@ -41,13 +42,15 @@ export default {
       // get data
       const page = await Page.findById(args.id);
       if (!page) {
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        throw new GraphQLHandlingError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
       }
 
       // check permission
       const ability = await extendAbilityForPage(user, page);
       if (ability.cannot('update', page)) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -76,6 +79,10 @@ export default {
       await page.save();
       return page;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editPositionAttributeCategory.mutation.ts
+++ b/src/schema/mutation/editPositionAttributeCategory.mutation.ts
@@ -8,6 +8,7 @@ import { Application, PositionAttributeCategory } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { PositionAttributeCategoryType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Edit a position attribute category.
@@ -25,14 +26,16 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
       const ability: AppAbility = context.user.ability;
       const application = await Application.findById(args.application);
       if (!application)
-        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+        throw new GraphQLHandlingError(
+          context.i18next.t('common.errors.dataNotFound')
+        );
       if (ability.can('update', application)) {
         return await PositionAttributeCategory.findByIdAndUpdate(
           args.id,
@@ -42,11 +45,15 @@ export default {
           { new: true }
         );
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editRole.mutation.ts
+++ b/src/schema/mutation/editRole.mutation.ts
@@ -11,6 +11,7 @@ import { Role } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { RoleType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Edit a role's admin permissions, providing its id and the list of admin permissions.
@@ -33,7 +34,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -86,12 +87,16 @@ export default {
         { new: true }
       );
       if (!role) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
       return role;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editSubscription.mutation.ts
+++ b/src/schema/mutation/editSubscription.mutation.ts
@@ -12,6 +12,7 @@ import {
   deleteQueue,
 } from '../../server/subscriberSafe';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Edit a subscription.
@@ -32,7 +33,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -43,7 +44,7 @@ export default {
         .getFilter();
       const application = await Application.findOne(filters);
       if (!application) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -73,6 +74,10 @@ export default {
       }
       return subscription;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editTemplate.mutation.ts
+++ b/src/schema/mutation/editTemplate.mutation.ts
@@ -5,6 +5,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import TemplateInputType from '../inputs/template.input';
 import extendAbilityForApplications from '@security/extendAbilityForApplication';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Mutation to edit template.
@@ -20,7 +21,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -29,7 +30,7 @@ export default {
         args.application
       );
       if (ability.cannot('update', 'Template')) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -51,6 +52,10 @@ export default {
         (template) => template.id.toString() === args.id
       );
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/editWorkflow.mutation.ts
+++ b/src/schema/mutation/editWorkflow.mutation.ts
@@ -9,6 +9,7 @@ import { WorkflowType } from '../types';
 import { Workflow, Page, Step } from '@models';
 import extendAbilityForContent from '@security/extendAbilityForContent';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Find a workflow from its id and update it, if user is authorized.
@@ -26,14 +27,14 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
 
       // check inputs
       if (!args || (!args.name && !args.steps)) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('mutations.workflow.edit.errors.invalidArguments')
         );
       }
@@ -42,7 +43,7 @@ export default {
       let workflow = await Workflow.findById(args.id);
       const ability = await extendAbilityForContent(user, workflow);
       if (ability.cannot('update', workflow)) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -65,6 +66,10 @@ export default {
 
       return workflow;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/seeNotification.mutation.ts
+++ b/src/schema/mutation/seeNotification.mutation.ts
@@ -3,6 +3,7 @@ import { NotificationType } from '../types';
 import { Notification } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Find notification from its id and update it.
@@ -18,7 +19,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -31,6 +32,10 @@ export default {
         $push: { seenBy: user._id },
       });
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/seeNotifications.mutation.ts
+++ b/src/schema/mutation/seeNotifications.mutation.ts
@@ -8,6 +8,7 @@ import {
 import { Notification } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Find multiple notifications and mark them as read.
@@ -23,14 +24,14 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
 
       const ability: AppAbility = context.user.ability;
       if (!args) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t(
             'mutations.notification.see.errors.invalidArguments'
           )
@@ -44,6 +45,10 @@ export default {
       });
       return result.ok === 1;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/toggleApplicationLock.mutation.ts
+++ b/src/schema/mutation/toggleApplicationLock.mutation.ts
@@ -9,6 +9,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import pubsub from '../../server/pubsub';
 import { Application } from '@models';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Toggle application lock, to prevent other users to edit the application at the same time.
@@ -23,7 +24,7 @@ export default {
     try {
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -33,7 +34,7 @@ export default {
         .getFilter();
       let application = await Application.findOne(filters);
       if (!application) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -51,6 +52,10 @@ export default {
       });
       return application;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/uploadApplicationStyle.ts
+++ b/src/schema/mutation/uploadApplicationStyle.ts
@@ -9,6 +9,7 @@ import { Application } from '@models';
 import { uploadFile } from '@utils/files';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Upload application style File.
@@ -24,7 +25,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -35,7 +36,7 @@ export default {
       const file = await args.file;
       const application = await Application.findOne(filters);
       if (!application) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -56,6 +57,10 @@ export default {
 
       return path;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/mutation/uploadFile.mutation.ts
+++ b/src/schema/mutation/uploadFile.mutation.ts
@@ -9,6 +9,7 @@ import { Form } from '@models';
 import { uploadFile } from '@utils/files';
 import i18next from 'i18next';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Upload File in Form.
@@ -25,11 +26,15 @@ export default {
       const file = await args.file;
       const form = await Form.findById(args.form);
       if (!form) {
-        throw new GraphQLError(i18next.t('common.errors.dataNotFound'));
+        throw new GraphQLHandlingError(i18next.t('common.errors.dataNotFound'));
       }
       const path = await uploadFile('forms', args.form, file.file);
       return path;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/apiConfiguration.query.ts
+++ b/src/schema/query/apiConfiguration.query.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { ApiConfigurationType } from '../types';
 import { ApiConfiguration } from '@models';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Return api configuration from id if available for the logged user.
@@ -17,7 +18,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -26,11 +27,15 @@ export default {
       if (ability.can('read', 'ApiConfiguration')) {
         return await ApiConfiguration.findById(args.id);
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/apiConfigurations.query.ts
+++ b/src/schema/query/apiConfigurations.query.ts
@@ -8,6 +8,7 @@ import { ApiConfiguration } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
 import checkPageSize from '@utils/schema/errors/checkPageSize.util';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -23,14 +24,14 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // Make sure that the page size is not too important
-    const first = args.first || DEFAULT_FIRST;
-    checkPageSize(first);
     try {
+      // Make sure that the page size is not too important
+      const first = args.first || DEFAULT_FIRST;
+      checkPageSize(first);
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -73,6 +74,10 @@ export default {
         totalCount: await ApiConfiguration.countDocuments({ $and: filters }),
       };
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/application.query.ts
+++ b/src/schema/query/application.query.ts
@@ -3,6 +3,7 @@ import { ApplicationType } from '../types';
 import mongoose from 'mongoose';
 import { Application, Page } from '@models';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Returns application from id if available for the logged user.
@@ -20,7 +21,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -50,12 +51,16 @@ export default {
         application.pages = pages.map((x) => x._id);
       }
       if (!application) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
       return application;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/channels.query.ts
+++ b/src/schema/query/channels.query.ts
@@ -2,6 +2,7 @@ import { GraphQLError, GraphQLID, GraphQLList } from 'graphql';
 import { Channel } from '@models';
 import { ChannelType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * List all channels available.
@@ -17,7 +18,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -29,6 +30,10 @@ export default {
           })
         : Channel.accessibleBy(ability, 'read');
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/dashboards.query.ts
+++ b/src/schema/query/dashboards.query.ts
@@ -3,6 +3,7 @@ import { contentType } from '@const/enumTypes';
 import { Page, Step, Dashboard } from '@models';
 import { DashboardType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * List all dashboards available for the logged user.
@@ -18,7 +19,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -40,6 +41,10 @@ export default {
         return await Dashboard.find(filters);
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/group.query.ts
+++ b/src/schema/query/group.query.ts
@@ -3,6 +3,7 @@ import { Group } from '@models';
 import { GroupType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Get Query by ID.
@@ -18,7 +19,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -30,22 +31,26 @@ export default {
             _id: args.id,
           });
           if (!group) {
-            throw new GraphQLError(
+            throw new GraphQLHandlingError(
               context.i18next.t('common.errors.dataNotFound')
             );
           }
           return group;
         } catch {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.dataNotFound')
           );
         }
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/groups.query.ts
+++ b/src/schema/query/groups.query.ts
@@ -3,6 +3,7 @@ import { Group } from '@models';
 import { GroupType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Lists groups.
@@ -19,7 +20,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -27,6 +28,10 @@ export default {
       const ability: AppAbility = context.user.ability;
       return Group.accessibleBy(ability, 'read');
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/me.query.ts
+++ b/src/schema/query/me.query.ts
@@ -1,6 +1,7 @@
 import { GraphQLError } from 'graphql';
 import { UserType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Return user from logged user id.
@@ -14,11 +15,15 @@ export default {
       if (user) {
         return user;
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/page.query.ts
+++ b/src/schema/query/page.query.ts
@@ -3,6 +3,7 @@ import { PageType } from '../types';
 import { Page } from '@models';
 import extendAbilityForPage from '@security/extendAbilityForPage';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Return page from id if available for the logged user.
@@ -18,7 +19,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -29,13 +30,17 @@ export default {
       // check ability
       const ability = await extendAbilityForPage(user, page);
       if (ability.cannot('read', page)) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
 
       return page;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/pages.query.ts
+++ b/src/schema/query/pages.query.ts
@@ -4,6 +4,7 @@ import { Application, Page } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import extendAbilityForPage from '@security/extendAbilityForPage';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * List all pages available for the logged user.
@@ -16,7 +17,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -34,6 +35,10 @@ export default {
       // return the pages
       return await Page.accessibleBy(ability, 'read').find();
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/permissions.query.ts
+++ b/src/schema/query/permissions.query.ts
@@ -2,6 +2,7 @@ import { GraphQLList, GraphQLBoolean, GraphQLError } from 'graphql';
 import { Permission } from '@models';
 import { PermissionType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * List permissions.
@@ -21,11 +22,15 @@ export default {
         }
         return Permission.find({ global: true });
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/positionAttributes.query.ts
+++ b/src/schema/query/positionAttributes.query.ts
@@ -3,6 +3,7 @@ import { User } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { PositionAttributeType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Return position attributes from category id.
@@ -18,13 +19,13 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
       const ability: AppAbility = context.user.ability;
       if (ability.cannot('read', 'User')) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
@@ -52,6 +53,10 @@ export default {
       }
       return positionAttributes;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/pullJobs.query.ts
+++ b/src/schema/query/pullJobs.query.ts
@@ -4,6 +4,7 @@ import { PullJob } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
 import checkPageSize from '@utils/schema/errors/checkPageSize.util';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /** Default page size */
 const DEFAULT_FIRST = 10;
@@ -19,14 +20,14 @@ export default {
     afterCursor: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // Make sure that the page size is not too important
-    const first = args.first || DEFAULT_FIRST;
-    checkPageSize(first);
     try {
+      // Make sure that the page size is not too important
+      const first = args.first || DEFAULT_FIRST;
+      checkPageSize(first);
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -66,6 +67,10 @@ export default {
         totalCount: await PullJob.countDocuments({ $and: filters }),
       };
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -10,6 +10,7 @@ import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import { RecordHistory } from '@utils/history';
 import { Record } from '@models';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Gets the record history for a record.
@@ -31,7 +32,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.i18n.t('common.errors.userNotLogged')
         );
       }
@@ -64,7 +65,7 @@ export default {
         ability.cannot('read', record) ||
         ability.cannot('read', record.form)
       ) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.i18n.t('common.errors.permissionNotGranted')
         );
       }
@@ -83,6 +84,10 @@ export default {
       }
       return history;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/records.query.ts
+++ b/src/schema/query/records.query.ts
@@ -4,6 +4,7 @@ import { Record } from '@models';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import { getAccessibleFields } from '@utils/form';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * List all records available for the logged user.
@@ -16,7 +17,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -26,6 +27,10 @@ export default {
       const records = await Record.accessibleBy(ability, 'read').find();
       return getAccessibleFields(records, ability);
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/referenceData.query.ts
+++ b/src/schema/query/referenceData.query.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { ReferenceDataType } from '../types';
 import { ReferenceData } from '@models';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Return Reference Data from id if available for the logged user.
@@ -17,12 +18,16 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
       return await ReferenceData.findById(args.id);
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/role.query.ts
+++ b/src/schema/query/role.query.ts
@@ -3,6 +3,7 @@ import { Role } from '@models';
 import { RoleType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Get Query by ID.
@@ -18,7 +19,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -30,22 +31,26 @@ export default {
             _id: args.id,
           });
           if (!role) {
-            throw new GraphQLError(
+            throw new GraphQLHandlingError(
               context.i18next.t('common.errors.dataNotFound')
             );
           }
           return role;
         } catch {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t('common.errors.dataNotFound')
           );
         }
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/roles.query.ts
+++ b/src/schema/query/roles.query.ts
@@ -3,6 +3,7 @@ import { Role } from '@models';
 import { RoleType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * List roles if logged user has admin permission.
@@ -19,7 +20,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -40,11 +41,15 @@ export default {
           }
         }
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/rolesFromApplications.query.ts
+++ b/src/schema/query/rolesFromApplications.query.ts
@@ -2,6 +2,7 @@ import { GraphQLList, GraphQLID, GraphQLError, GraphQLNonNull } from 'graphql';
 import { Role } from '@models';
 import { RoleType } from '../types';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * List passed applications roles if user is logged, but only title and id.
@@ -17,7 +18,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -26,6 +27,10 @@ export default {
         'id title application'
       );
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/step.query.ts
+++ b/src/schema/query/step.query.ts
@@ -3,6 +3,7 @@ import { StepType } from '../types';
 import { Step } from '@models';
 import extendAbilityForStep from '@security/extendAbilityForStep';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Returns step from id if available for the logged user.
@@ -18,7 +19,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -27,13 +28,17 @@ export default {
       const step = await Step.findById(args.id);
       const ability = await extendAbilityForStep(user, step);
       if (ability.cannot('read', step)) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
 
       return step;
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/steps.query.ts
+++ b/src/schema/query/steps.query.ts
@@ -3,6 +3,7 @@ import { StepType } from '../types';
 import { Step } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * List all steps available for the logged user.
@@ -15,7 +16,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -23,6 +24,10 @@ export default {
       const ability: AppAbility = context.user.ability;
       return Step.accessibleBy(ability, 'read');
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/users.query.ts
+++ b/src/schema/query/users.query.ts
@@ -4,6 +4,7 @@ import { UserType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import mongoose from 'mongoose';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * List back-office users if logged user has admin permission.
@@ -19,7 +20,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -68,11 +69,15 @@ export default {
           return User.aggregate(aggregations);
         }
       } else {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
       }
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/schema/query/workflows.query.ts
+++ b/src/schema/query/workflows.query.ts
@@ -3,6 +3,7 @@ import { Workflow } from '@models';
 import { WorkflowType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * List all workflows available for the logged user.
@@ -15,7 +16,7 @@ export default {
       // Authentication check
       const user = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -23,6 +24,10 @@ export default {
       const ability: AppAbility = context.user.ability;
       return Workflow.accessibleBy(ability, 'read');
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -1,4 +1,3 @@
-import { GraphQLError } from 'graphql';
 import { Resource } from '@models';
 import {
   forbiddenKeywords,
@@ -7,6 +6,7 @@ import {
 } from '@const/aggregation';
 import getFilter from '../schema/resolvers/Query/getFilter';
 import { isEmpty } from 'lodash';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Builds a addFields pipeline stage.
@@ -145,7 +145,7 @@ const buildPipeline = (
       case PipelineStage.CUSTOM: {
         const custom: string = stage.form.raw;
         if (forbiddenKeywords.some((x: string) => custom.includes(x))) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t(
               'utils.aggregation.buildPipeline.errors.invalidCustomStage'
             )
@@ -154,7 +154,7 @@ const buildPipeline = (
         try {
           pipeline.push(JSON.parse(custom));
         } catch {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             context.i18next.t(
               'utils.aggregation.buildPipeline.errors.invalidCustomStage'
             )

--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -1,7 +1,7 @@
-import { GraphQLError } from 'graphql/error';
 import { getFieldType } from './getFieldType';
 import i18next from 'i18next';
 import { validateGraphQLFieldName } from '@utils/validators';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /**
  * Push in fields array all detected fields in the json structure of object.
@@ -18,7 +18,7 @@ export const extractFields = async (object, fields, core): Promise<void> => {
         await extractFields(element, fields, core);
       } else {
         if (!element.valueName) {
-          throw new GraphQLError(
+          throw new GraphQLHandlingError(
             i18next.t('utils.form.extractFields.errors.missingDataField')
           );
         }
@@ -53,7 +53,7 @@ export const extractFields = async (object, fields, core): Promise<void> => {
               }
             );
           } else {
-            throw new GraphQLError(
+            throw new GraphQLHandlingError(
               i18next.t('utils.form.extractFields.errors.missingRelatedField', {
                 name: element.valueName,
               })

--- a/src/utils/form/findDuplicateFields.ts
+++ b/src/utils/form/findDuplicateFields.ts
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql/error';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 import i18next from 'i18next';
 
 /**
@@ -13,7 +13,7 @@ export const findDuplicateFields = (fields): void => {
     (item, index) => names.indexOf(item) !== index
   );
   if (duplication.length > 0) {
-    throw new GraphQLError(
+    throw new GraphQLHandlingError(
       i18next.t('utils.form.findDuplicateFields.errors.dataFieldDuplicated', {
         name: duplication[0],
       })

--- a/src/utils/schema/errors/checkPageSize.util.ts
+++ b/src/utils/schema/errors/checkPageSize.util.ts
@@ -1,6 +1,6 @@
 import config from 'config';
-import { GraphQLError } from 'graphql';
 import i18next from 'i18next';
+import { GraphQLHandlingError } from './interfaceOfErrorHandling.util';
 
 /**
  * Check pagination maximum limit of data.
@@ -11,7 +11,7 @@ import i18next from 'i18next';
 export const checkPageSize = (maxLimit: number): void => {
   const maxPaginationLimit = config.get<number>('server.pagination.limit');
   if (maxLimit > maxPaginationLimit) {
-    throw new GraphQLError(
+    throw new GraphQLHandlingError(
       i18next.t('common.errors.maximumPaginationLimit', {
         paginationLimit: maxPaginationLimit,
       })

--- a/src/utils/schema/errors/interfaceOfErrorHandling.util.ts
+++ b/src/utils/schema/errors/interfaceOfErrorHandling.util.ts
@@ -1,0 +1,10 @@
+/**
+ * Check GraphQL Handling Error of data.
+ * Throw GraphQL Handling Error than error message.
+ */
+export class GraphQLHandlingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GraphQLHandlingError';
+  }
+}

--- a/src/utils/schema/errors/interfaceOfErrorHandling.util.ts
+++ b/src/utils/schema/errors/interfaceOfErrorHandling.util.ts
@@ -1,6 +1,8 @@
 /**
  * Check GraphQL Handling Error of data.
  * Throw GraphQL Handling Error than error message.
+ *
+ * @param message error of message pass
  */
 export class GraphQLHandlingError extends Error {
   constructor(message: string) {

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -17,6 +17,7 @@ import buildCalculatedFieldPipeline from '@utils/aggregation/buildCalculatedFiel
 import { logger } from '@services/logger.service';
 import checkPageSize from '@utils/schema/errors/checkPageSize.util';
 import { flatten, get, isArray, set } from 'lodash';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 
 /** Default number for items to get */
 const DEFAULT_FIRST = 25;
@@ -270,12 +271,12 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
     context,
     info
   ) => {
-    // Make sure that the page size is not too important
-    checkPageSize(first);
     try {
+      // Make sure that the page size is not too important
+      checkPageSize(first);
       const user: User = context.user;
       if (!user) {
-        throw new GraphQLError(
+        throw new GraphQLHandlingError(
           context.i18next.t('common.errors.userNotLogged')
         );
       }
@@ -707,6 +708,10 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
         _source: id,
       };
     } catch (err) {
+      if (err instanceof GraphQLHandlingError) {
+        throw new GraphQLError(err.message);
+      }
+
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(
         context.i18next.t('common.errors.internalServerError')

--- a/src/utils/validators/validateApi.ts
+++ b/src/utils/validators/validateApi.ts
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 import i18next from 'i18next';
 
 /**
@@ -8,6 +8,8 @@ import i18next from 'i18next';
  */
 export const validateApi = (name: string): void => {
   if (!/^[A-Za-z-_]+$/i.test(name)) {
-    throw new GraphQLError(i18next.t('common.errors.invalidGraphQLName'));
+    throw new GraphQLHandlingError(
+      i18next.t('common.errors.invalidGraphQLName')
+    );
   }
 };

--- a/src/utils/validators/validateName.ts
+++ b/src/utils/validators/validateName.ts
@@ -1,5 +1,5 @@
 import protectedNames from '@const/protectedNames';
-import { GraphQLError } from 'graphql';
+import { GraphQLHandlingError } from '@utils/schema/errors/interfaceOfErrorHandling.util';
 import i18nextModule from 'i18next';
 import { camelCase, toUpper } from 'lodash';
 
@@ -27,10 +27,12 @@ export const validateGraphQLTypeName = (
   i18next = i18nextModule
 ): void => {
   if (!GRAPHQL_TYPE_NAME_REGEX.test(name)) {
-    throw new GraphQLError(i18next.t('common.errors.invalidGraphQLName'));
+    throw new GraphQLHandlingError(
+      i18next.t('common.errors.invalidGraphQLName')
+    );
   }
   if (protectedNames.indexOf(name.toLowerCase()) >= 0) {
-    throw new GraphQLError(
+    throw new GraphQLHandlingError(
       i18next.t('utils.validators.validateName.errors.usageOfProtectedName')
     );
   }
@@ -47,7 +49,7 @@ export const validateGraphQLFieldName = (
   i18next = i18nextModule
 ): void => {
   if (!GRAPHQL_TYPE_NAME_REGEX.test(name)) {
-    throw new GraphQLError(
+    throw new GraphQLHandlingError(
       i18next.t('utils.validators.validateName.errors.invalidFieldName', {
         field: name,
         err: i18next.t('common.errors.invalidGraphQLName'),


### PR DESCRIPTION
# Description
Because we put all mutations inside try / catch, some errors that should be sent by methods inside these try / catch are not visible when using the API
if possible, we should detect in the try / catch if the error is a graphQL error before sending the default 'internal error'

## Ticket
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/65380

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

