### PR TITLE
Fix/ab#59699 default fields are breaking schema generation

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -131,6 +131,7 @@
 			"edit": {
 				"errors": {
 					"coreFieldMissing": "Core field missing : {{name}}. Please implement this field.",
+					"fieldValueNameSameAsDefaultFieldName": "The field value name is {{name}} the same as default field name. Please provide different field value name for question.",
 					"relatedNameDuplicated": "Related name duplicated : {{name}}. The target Resource already contains a field with that name. Please provide a different name."
 				}
 			}

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -131,6 +131,7 @@
 			"edit": {
 				"errors": {
 					"coreFieldMissing": "****** {{name}} ******",
+					"fieldValueNameSameAsDefaultFieldName": "****** {{name}} ******",
 					"relatedNameDuplicated": "****** {{name}} ******"
 				}
 			}

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -523,7 +523,7 @@ export default {
       update.$push = { versions: version._id };
     }
     // Return updated form
-    return await Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
+    return Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
       // Avoid to rebuild types only if permissions changed
       if (args.name || args.status || args.structure) {
         buildTypes();

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -494,7 +494,7 @@ export default {
       update.$push = { versions: version._id };
     }
     // Return updated form
-    return await Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
+    return Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
       // Avoid to rebuild types only if permissions changed
       if (args.name || args.status || args.structure) {
         buildTypes();

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -24,7 +24,24 @@ import differenceWith from 'lodash/differenceWith';
 import unionWith from 'lodash/unionWith';
 import i18next from 'i18next';
 import { isArray } from 'lodash';
-import { logger } from '@services/logger.service';
+// import { logger } from '@services/logger.service';
+
+/** The default fields */
+const DEFAULT_FIELDS = [
+  'id',
+  'incrementalId',
+  'createdAt',
+  'modifiedAt',
+  'form',
+  'createdBy',
+  'createdBy.id',
+  'createdBy.name',
+  'createdBy.username',
+  'lastUpdatedBy',
+  'lastUpdatedBy.id',
+  'lastUpdatedBy.name',
+  'lastUpdatedBy.username',
+];
 
 /**
  * List of keys of the structure's object which we want to inherit to the children forms when they are modified on the core form
@@ -79,441 +96,444 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // try {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      // Permission check
-      const ability: AppAbility = user.ability;
-      const form = await Form.findById(args.id);
-      if (ability.cannot('update', form)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-
-      // Initialize the update object --- TODO = put interface
-      /* const update: any = {
-    modifiedAt: new Date(),
-  }; */
-      const update: any = {};
-
-      // Update name
-      if (args.name) {
-        const graphQLTypeName = Form.getGraphQLTypeName(args.name);
-        validateGraphQLTypeName(
-          Form.getGraphQLTypeName(args.name),
-          context.i18next
-        );
-        if (
-          (await Form.hasDuplicate(graphQLTypeName, form.id)) ||
-          (await ReferenceData.hasDuplicate(graphQLTypeName))
-        ) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.duplicatedGraphQLTypeName')
-          );
-        }
-        update.name = args.name;
-        update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
-        if (form.core) {
-          await Resource.findByIdAndUpdate(form.resource, {
-            name: args.name,
-          });
-        }
-      }
-
-      // Update status
-      if (args.status) {
-        update.status = args.status;
-        // Activate the form.
-        if (update.status === status.active) {
-          // Create notification channel
-          const notificationChannel = new Channel({
-            title: `Form - ${form.name}`,
-            form: form._id,
-          });
-          await notificationChannel.save();
-          update.channel = notificationChannel.form;
-        } else {
-          // Deactivate the form
-          // delete channel and notifications if form not active anymore
-          const channel = await Channel.findOneAndDelete({ form: form._id });
-          if (channel) {
-            update.channel = [];
-          }
-        }
-      }
-
-      // Update permissions
-      if (args.permissions) {
-        const permissions: PermissionChange = args.permissions;
-        for (const permission in permissions) {
-          if (isArray(permissions[permission])) {
-            // if it's an array, replace the old value with the provided list
-            update['permissions.' + permission] = permissions[permission];
-          } else {
-            const obj = permissions[permission];
-            if (obj.add && obj.add.length) {
-              const pushRoles = {
-                [`permissions.${permission}`]: { $each: obj.add },
-              };
-
-              if (update.$addToSet) Object.assign(update.$addToSet, pushRoles);
-              else Object.assign(update, { $addToSet: pushRoles });
-            }
-            if (obj.remove && obj.remove.length) {
-              let pullRoles: any;
-
-              if (typeof obj.remove[0] === 'string') {
-                // CanSee, canUpdate, canDelete, canCreateRecords
-                pullRoles = {
-                  [`permissions.${permission}`]: {
-                    $in: obj.remove.map(
-                      (role: any) => new mongoose.Types.ObjectId(role)
-                    ),
-                  },
-                };
-              } else {
-                // canSeeRecords, canUpdateRecords, canDeleteRecords, recordsUnicity
-                pullRoles = {
-                  [`permissions.${permission}`]: {
-                    $in: obj.remove.map((perm: any) =>
-                      perm.access
-                        ? {
-                            role: new mongoose.Types.ObjectId(perm.role),
-                            access: perm.access,
-                          }
-                        : {
-                            role: new mongoose.Types.ObjectId(perm.role),
-                          }
-                    ),
-                  },
-                };
-              }
-
-              if (update.$pull) Object.assign(update.$pull, pullRoles);
-              else Object.assign(update, { $pull: pullRoles });
-            }
-          }
-        }
-      }
-
-      // Update fields and structure, check that structure is different
-      if (args.structure && !isEqual(form.structure, args.structure)) {
-        update.structure = args.structure;
-        const structure = JSON.parse(args.structure);
-        const fields = [];
-        for (const page of structure.pages) {
-          await extractFields(page, fields, form.core);
-          findDuplicateFields(fields);
-          for (const field of fields.filter((x) =>
-            ['resource', 'resources'].includes(x.type)
-          )) {
-            // Raises an error if the field is already used as related name for this resource
-            if (
-              await Form.findOne({
-                fields: {
-                  $elemMatch: {
-                    resource: field.resource,
-                    relatedName: field.relatedName,
-                  },
-                },
-                _id: { $ne: form.id },
-                ...(form.resource && { resource: { $ne: form.resource } }),
-              })
-            ) {
-              throw new GraphQLError(
-                i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
-                  name: field.relatedName,
-                })
-              );
-            }
-            // Raises an error if the field exists in the resource
-            if (
-              await Resource.findOne({
-                fields: { $elemMatch: { name: field.relatedName } },
-                _id: field.resource,
-              })
-            ) {
-              throw new GraphQLError(
-                i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
-                  name: field.relatedName,
-                })
-              );
-            }
-          }
-        }
-        // === Resource inheritance management ===
-        const prevStructure = JSON.parse(
-          form.structure ? form.structure : '{}'
-        ); // Get the current form's state structure
-        if (form.resource && !isEqual(prevStructure, structure)) {
-          // If the form has a resource and its structure has changed
-          const resource = await Resource.findById(form.resource);
-          const templates = await Form.find({
-            resource: form.resource,
-            _id: { $ne: mongoose.Types.ObjectId(args.id) },
-          }).select('_id structure fields');
-          const oldFields: any[] = JSON.parse(JSON.stringify(resource.fields));
-          const usedFields = templates
-            .map((x) => x.fields)
-            .flat()
-            .concat(fields);
-          // Check fields against the resource to add new ones or edit old ones
-          for (const field of fields) {
-            // For each field in the form being saved
-            const oldField = oldFields.find((x) => x.name === field.name); // Find the equivalent field in the resource's fields
-            if (!oldField) {
-              // If the field isn't found in the resource
-              const newField: any = Object.assign({}, field); // Create a copy of the form's field
-              newField.isRequired =
-                form.core && field.isRequired ? true : false; // If it's a core form and the field isRequired, copy this property
-              oldFields.push(newField); // Add this field to the list of the resource's fields
-            } else {
-              // Check if field can be updated
-              if (!oldField.isCore || (oldField.isCore && form.core)) {
-                // If resource's field isn't core or if it's core but the edited form is core too, make it writable
-                const storedFieldChanged = !isEqual(oldField, field);
-                if (storedFieldChanged) {
-                  // Inherit the field's permissions
-                  field.permissions = oldField.permissions;
-                  // If the resource's field and the current form's field are different
-                  const index = oldFields.findIndex(
-                    (x) => x.name === field.name
-                  ); // Get the index of the form's field in the resources
-                  oldFields.splice(index, 1, field); // Replace resource's field by the form's field
-                }
-                for (const template of templates) {
-                  // For each form that inherits from the same resource
-                  if (storedFieldChanged) {
-                    template.fields = template.fields.map((x) => {
-                      // For each field of the childForm
-                      return x.name === field.name // If the child field's name equals the parent field's name
-                        ? x.hasOwnProperty('defaultValue') &&
-                          !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
-                          ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
-                          : field // Else replace child's field by parent's field
-                        : x; // Else don't change the child's field
-                    });
-                  }
-                  if (!field.generated) {
-                    // Update structure
-                    const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
-                    replaceField(
-                      field.name,
-                      newStructure,
-                      structure,
-                      prevStructure
-                    ); // Replace the inheriting form's field by the edited form's field
-                    template.structure = JSON.stringify(newStructure); // Save the new structure
-                  }
-                }
-              }
-            }
-          }
-          // Check if there are unused or duplicated fields in the resource
-          for (let index = 0; index < oldFields.length; index++) {
-            const field = oldFields[index]; // Store the resource's field
-            if (!field.isCalculated) {
-              // prevent calculated fields to be deleted automatically
-              const fieldToRemove =
-                ((form.core
-                  ? !fields.some((x) => x.name === field.name)
-                  : true) && // If edited form is core, check if resource's field is absent from form's fields
-                  !usedFields.some((x) => x.name === field.name)) || // Unused -- TODO What if it's in one inherited form and not in another ?
-                oldFields.some(
-                  (x, id) => field.name === x.name && id !== index
-                ); // Duplicated If there's another field with the same name but not the same ID
-              if (fieldToRemove) {
-                oldFields.splice(index, 1);
-                index--;
-              }
-            }
-          }
-          // Check if form is a core template of a resource
-          if (!form.core) {
-            // Check if a required field is missing
-            // Keep old version and move that to extract fields ?
-            let fieldExists = false;
-            for (const field of oldFields.filter((x) => x.isCore)) {
-              // For each non-core field in the resource
-              for (const x of fields) {
-                if (x.name === field.name) {
-                  x.isCore = true;
-                  fieldExists = true;
-                }
-              }
-              if (!fieldExists) {
-                throw new GraphQLError(
-                  i18next.t('mutations.form.edit.errors.coreFieldMissing', {
-                    name: field.name,
-                  })
-                );
-              }
-              fieldExists = false;
-            }
-          } else {
-            // List deleted fields
-            const deletedFields = form.fields.filter(
-              (x) => !fields.some((y) => x.name === y.name)
-            );
-            // List new fields
-            const newFields = fields.filter(
-              (x) => !form.fields.some((y) => x.name === y.name)
-            );
-            // Detect structure updates
-            const structureUpdate = {};
-            const newStructure = structure;
-            if (form.structure) {
-              // Store the property's objects that have been removed between the new and previous versions of the form
-              for (const property of INHERITED_PROPERTIES) {
-                if (!isEqual(prevStructure[property], newStructure[property])) {
-                  structureUpdate[property] = newStructure[property]
-                    ? differenceWith(
-                        prevStructure[property],
-                        newStructure[property],
-                        isEqual
-                      )
-                    : prevStructure[property];
-                }
-              }
-            }
-
-            // Loop on templates
-            for (const template of templates) {
-              // === REFLECT DELETION ===
-              // For each old field from core form which is not anymore in the current core form fields
-              for (const field of deletedFields) {
-                // Check if we rename or delete a field used in a child form
-                if (usedFields.some((x) => x.name === field.name)) {
-                  // If this deleted / modified field was used, reflect the deletion / edition
-                  const index = template.fields.findIndex(
-                    (x) => x.name === field.name
-                  );
-                  template.fields.splice(index, 1);
-                  if (!field.generated) {
-                    // Remove from structure
-                    const templateStructure = JSON.parse(template.structure);
-                    removeField(templateStructure, field.name);
-                    template.structure = JSON.stringify(templateStructure);
-                  }
-                }
-              }
-
-              // === REFLECT ADDITION ===
-              // For each new field from core form which were not before in the old core form fields
-              for (const field of newFields) {
-                // Add to fields and structure if needed
-                if (!template.fields.some((x) => x.name === field.name)) {
-                  template.fields.unshift(field);
-
-                  if (!field.generated) {
-                    // Add to structure
-                    const templateStructure = JSON.parse(template.structure);
-                    addField(templateStructure, field.name, structure);
-                    template.structure = JSON.stringify(templateStructure);
-                  }
-                }
-              }
-
-              // REFLECT STRUCTURE CHANGES ===
-              const templateStructure = JSON.parse(template.structure);
-              for (const objectKey in structureUpdate) {
-                // In a childForm's structure, if there are property's objects that have been deleted from the core form, delete them there too
-                if (
-                  templateStructure[objectKey] &&
-                  templateStructure[objectKey].length &&
-                  structureUpdate[objectKey] &&
-                  structureUpdate[objectKey].length
-                ) {
-                  templateStructure[objectKey] = differenceWith(
-                    templateStructure[objectKey],
-                    structureUpdate[objectKey],
-                    isEqual
-                  );
-                }
-                // Merge the new property's objects to the children
-                templateStructure[objectKey] = templateStructure[objectKey]
-                  ? unionWith(
-                      templateStructure[objectKey],
-                      newStructure[objectKey],
-                      isEqual
-                    )
-                  : newStructure[objectKey];
-                // If the property is null, undefined or empty, directly remove the entry from the structure
-                if (
-                  !templateStructure[objectKey] ||
-                  !templateStructure[objectKey].length
-                ) {
-                  delete templateStructure[objectKey];
-                }
-              }
-              template.structure = JSON.stringify(templateStructure);
-            }
-
-            for (const field of deletedFields) {
-              // We remove the field from the resource
-              const index = oldFields.findIndex((x) => x.name === field.name);
-              if (index >= 0) {
-                oldFields.splice(index, 1);
-              }
-            }
-          }
-
-          // Build bulk update of non-core templates
-          const bulkUpdate = [];
-          for (const template of templates) {
-            bulkUpdate.push({
-              updateOne: {
-                filter: { _id: template._id },
-                update: {
-                  structure: template.structure,
-                  fields: template.fields,
-                },
-              },
-            });
-          }
-          if (bulkUpdate.length > 0) {
-            // Update all child form for addition/deletion/structure changes
-            await Form.bulkWrite(bulkUpdate);
-          }
-
-          // Update resource fields
-          await Resource.findByIdAndUpdate(form.resource, {
-            fields: oldFields,
-          });
-        }
-        update.fields = fields;
-        // Update version
-        const version = new Version({
-          //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
-          data: form.structure,
-        });
-        await version.save();
-        update.$push = { versions: version._id };
-      }
-      // Return updated form
-      return await Form.findByIdAndUpdate(
-        args.id,
-        update,
-        { new: true },
-        () => {
-          // Avoid to rebuild types only if permissions changed
-          if (args.name || args.status || args.structure) {
-            buildTypes();
-          }
-        }
-      );
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    // Permission check
+    const ability: AppAbility = user.ability;
+    const form = await Form.findById(args.id);
+    if (ability.cannot('update', form)) {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
+
+    // Initialize the update object --- TODO = put interface
+    /* const update: any = {
+    modifiedAt: new Date(),
+  }; */
+    const update: any = {};
+
+    // Update name
+    if (args.name) {
+      const graphQLTypeName = Form.getGraphQLTypeName(args.name);
+      validateGraphQLTypeName(
+        Form.getGraphQLTypeName(args.name),
+        context.i18next
+      );
+      if (
+        (await Form.hasDuplicate(graphQLTypeName, form.id)) ||
+        (await ReferenceData.hasDuplicate(graphQLTypeName))
+      ) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.duplicatedGraphQLTypeName')
+        );
+      }
+      update.name = args.name;
+      update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
+      if (form.core) {
+        await Resource.findByIdAndUpdate(form.resource, {
+          name: args.name,
+        });
+      }
+    }
+
+    // Update status
+    if (args.status) {
+      update.status = args.status;
+      // Activate the form.
+      if (update.status === status.active) {
+        // Create notification channel
+        const notificationChannel = new Channel({
+          title: `Form - ${form.name}`,
+          form: form._id,
+        });
+        await notificationChannel.save();
+        update.channel = notificationChannel.form;
+      } else {
+        // Deactivate the form
+        // delete channel and notifications if form not active anymore
+        const channel = await Channel.findOneAndDelete({ form: form._id });
+        if (channel) {
+          update.channel = [];
+        }
+      }
+    }
+
+    // Update permissions
+    if (args.permissions) {
+      const permissions: PermissionChange = args.permissions;
+      for (const permission in permissions) {
+        if (isArray(permissions[permission])) {
+          // if it's an array, replace the old value with the provided list
+          update['permissions.' + permission] = permissions[permission];
+        } else {
+          const obj = permissions[permission];
+          if (obj.add && obj.add.length) {
+            const pushRoles = {
+              [`permissions.${permission}`]: { $each: obj.add },
+            };
+
+            if (update.$addToSet) Object.assign(update.$addToSet, pushRoles);
+            else Object.assign(update, { $addToSet: pushRoles });
+          }
+          if (obj.remove && obj.remove.length) {
+            let pullRoles: any;
+
+            if (typeof obj.remove[0] === 'string') {
+              // CanSee, canUpdate, canDelete, canCreateRecords
+              pullRoles = {
+                [`permissions.${permission}`]: {
+                  $in: obj.remove.map(
+                    (role: any) => new mongoose.Types.ObjectId(role)
+                  ),
+                },
+              };
+            } else {
+              // canSeeRecords, canUpdateRecords, canDeleteRecords, recordsUnicity
+              pullRoles = {
+                [`permissions.${permission}`]: {
+                  $in: obj.remove.map((perm: any) =>
+                    perm.access
+                      ? {
+                          role: new mongoose.Types.ObjectId(perm.role),
+                          access: perm.access,
+                        }
+                      : {
+                          role: new mongoose.Types.ObjectId(perm.role),
+                        }
+                  ),
+                },
+              };
+            }
+
+            if (update.$pull) Object.assign(update.$pull, pullRoles);
+            else Object.assign(update, { $pull: pullRoles });
+          }
+        }
+      }
+    }
+
+    // Update fields and structure, check that structure is different
+    if (args.structure && !isEqual(form.structure, args.structure)) {
+      update.structure = args.structure;
+      const structure = JSON.parse(args.structure);
+
+      //check field value name same as default field name
+      structure.pages.map(function (items) {
+        items.elements.map(function (result) {
+          if (DEFAULT_FIELDS.includes(result.valueName)) {
+            throw new GraphQLError(
+              i18next.t(
+                'mutations.form.edit.errors.fieldValueNameSameAsDefaultFieldName',
+                {
+                  name: result.valueName,
+                }
+              )
+            );
+          }
+        });
+      });
+
+      const fields = [];
+      for (const page of structure.pages) {
+        await extractFields(page, fields, form.core);
+        findDuplicateFields(fields);
+        for (const field of fields.filter((x) =>
+          ['resource', 'resources'].includes(x.type)
+        )) {
+          // Raises an error if the field is already used as related name for this resource
+          if (
+            await Form.findOne({
+              fields: {
+                $elemMatch: {
+                  resource: field.resource,
+                  relatedName: field.relatedName,
+                },
+              },
+              _id: { $ne: form.id },
+              ...(form.resource && { resource: { $ne: form.resource } }),
+            })
+          ) {
+            throw new GraphQLError(
+              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
+                name: field.relatedName,
+              })
+            );
+          }
+          // Raises an error if the field exists in the resource
+          if (
+            await Resource.findOne({
+              fields: { $elemMatch: { name: field.relatedName } },
+              _id: field.resource,
+            })
+          ) {
+            throw new GraphQLError(
+              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
+                name: field.relatedName,
+              })
+            );
+          }
+        }
+      }
+      // === Resource inheritance management ===
+      const prevStructure = JSON.parse(form.structure ? form.structure : '{}'); // Get the current form's state structure
+      if (form.resource && !isEqual(prevStructure, structure)) {
+        // If the form has a resource and its structure has changed
+        const resource = await Resource.findById(form.resource);
+        const templates = await Form.find({
+          resource: form.resource,
+          _id: { $ne: mongoose.Types.ObjectId(args.id) },
+        }).select('_id structure fields');
+        const oldFields: any[] = JSON.parse(JSON.stringify(resource.fields));
+        const usedFields = templates
+          .map((x) => x.fields)
+          .flat()
+          .concat(fields);
+        // Check fields against the resource to add new ones or edit old ones
+        for (const field of fields) {
+          // For each field in the form being saved
+          const oldField = oldFields.find((x) => x.name === field.name); // Find the equivalent field in the resource's fields
+          if (!oldField) {
+            // If the field isn't found in the resource
+            const newField: any = Object.assign({}, field); // Create a copy of the form's field
+            newField.isRequired = form.core && field.isRequired ? true : false; // If it's a core form and the field isRequired, copy this property
+            oldFields.push(newField); // Add this field to the list of the resource's fields
+          } else {
+            // Check if field can be updated
+            if (!oldField.isCore || (oldField.isCore && form.core)) {
+              // If resource's field isn't core or if it's core but the edited form is core too, make it writable
+              const storedFieldChanged = !isEqual(oldField, field);
+              if (storedFieldChanged) {
+                // Inherit the field's permissions
+                field.permissions = oldField.permissions;
+                // If the resource's field and the current form's field are different
+                const index = oldFields.findIndex((x) => x.name === field.name); // Get the index of the form's field in the resources
+                oldFields.splice(index, 1, field); // Replace resource's field by the form's field
+              }
+              for (const template of templates) {
+                // For each form that inherits from the same resource
+                if (storedFieldChanged) {
+                  template.fields = template.fields.map((x) => {
+                    // For each field of the childForm
+                    return x.name === field.name // If the child field's name equals the parent field's name
+                      ? x.hasOwnProperty('defaultValue') &&
+                        !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
+                        ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
+                        : field // Else replace child's field by parent's field
+                      : x; // Else don't change the child's field
+                  });
+                }
+                if (!field.generated) {
+                  // Update structure
+                  const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
+                  replaceField(
+                    field.name,
+                    newStructure,
+                    structure,
+                    prevStructure
+                  ); // Replace the inheriting form's field by the edited form's field
+                  template.structure = JSON.stringify(newStructure); // Save the new structure
+                }
+              }
+            }
+          }
+        }
+        // Check if there are unused or duplicated fields in the resource
+        for (let index = 0; index < oldFields.length; index++) {
+          const field = oldFields[index]; // Store the resource's field
+          if (!field.isCalculated) {
+            // prevent calculated fields to be deleted automatically
+            const fieldToRemove =
+              ((form.core
+                ? !fields.some((x) => x.name === field.name)
+                : true) && // If edited form is core, check if resource's field is absent from form's fields
+                !usedFields.some((x) => x.name === field.name)) || // Unused -- TODO What if it's in one inherited form and not in another ?
+              oldFields.some((x, id) => field.name === x.name && id !== index); // Duplicated If there's another field with the same name but not the same ID
+            if (fieldToRemove) {
+              oldFields.splice(index, 1);
+              index--;
+            }
+          }
+        }
+        // Check if form is a core template of a resource
+        if (!form.core) {
+          // Check if a required field is missing
+          // Keep old version and move that to extract fields ?
+          let fieldExists = false;
+          for (const field of oldFields.filter((x) => x.isCore)) {
+            // For each non-core field in the resource
+            for (const x of fields) {
+              if (x.name === field.name) {
+                x.isCore = true;
+                fieldExists = true;
+              }
+            }
+            if (!fieldExists) {
+              throw new GraphQLError(
+                i18next.t('mutations.form.edit.errors.coreFieldMissing', {
+                  name: field.name,
+                })
+              );
+            }
+            fieldExists = false;
+          }
+        } else {
+          // List deleted fields
+          const deletedFields = form.fields.filter(
+            (x) => !fields.some((y) => x.name === y.name)
+          );
+          // List new fields
+          const newFields = fields.filter(
+            (x) => !form.fields.some((y) => x.name === y.name)
+          );
+          // Detect structure updates
+          const structureUpdate = {};
+          const newStructure = structure;
+          if (form.structure) {
+            // Store the property's objects that have been removed between the new and previous versions of the form
+            for (const property of INHERITED_PROPERTIES) {
+              if (!isEqual(prevStructure[property], newStructure[property])) {
+                structureUpdate[property] = newStructure[property]
+                  ? differenceWith(
+                      prevStructure[property],
+                      newStructure[property],
+                      isEqual
+                    )
+                  : prevStructure[property];
+              }
+            }
+          }
+
+          // Loop on templates
+          for (const template of templates) {
+            // === REFLECT DELETION ===
+            // For each old field from core form which is not anymore in the current core form fields
+            for (const field of deletedFields) {
+              // Check if we rename or delete a field used in a child form
+              if (usedFields.some((x) => x.name === field.name)) {
+                // If this deleted / modified field was used, reflect the deletion / edition
+                const index = template.fields.findIndex(
+                  (x) => x.name === field.name
+                );
+                template.fields.splice(index, 1);
+                if (!field.generated) {
+                  // Remove from structure
+                  const templateStructure = JSON.parse(template.structure);
+                  removeField(templateStructure, field.name);
+                  template.structure = JSON.stringify(templateStructure);
+                }
+              }
+            }
+
+            // === REFLECT ADDITION ===
+            // For each new field from core form which were not before in the old core form fields
+            for (const field of newFields) {
+              // Add to fields and structure if needed
+              if (!template.fields.some((x) => x.name === field.name)) {
+                template.fields.unshift(field);
+
+                if (!field.generated) {
+                  // Add to structure
+                  const templateStructure = JSON.parse(template.structure);
+                  addField(templateStructure, field.name, structure);
+                  template.structure = JSON.stringify(templateStructure);
+                }
+              }
+            }
+
+            // REFLECT STRUCTURE CHANGES ===
+            const templateStructure = JSON.parse(template.structure);
+            for (const objectKey in structureUpdate) {
+              // In a childForm's structure, if there are property's objects that have been deleted from the core form, delete them there too
+              if (
+                templateStructure[objectKey] &&
+                templateStructure[objectKey].length &&
+                structureUpdate[objectKey] &&
+                structureUpdate[objectKey].length
+              ) {
+                templateStructure[objectKey] = differenceWith(
+                  templateStructure[objectKey],
+                  structureUpdate[objectKey],
+                  isEqual
+                );
+              }
+              // Merge the new property's objects to the children
+              templateStructure[objectKey] = templateStructure[objectKey]
+                ? unionWith(
+                    templateStructure[objectKey],
+                    newStructure[objectKey],
+                    isEqual
+                  )
+                : newStructure[objectKey];
+              // If the property is null, undefined or empty, directly remove the entry from the structure
+              if (
+                !templateStructure[objectKey] ||
+                !templateStructure[objectKey].length
+              ) {
+                delete templateStructure[objectKey];
+              }
+            }
+            template.structure = JSON.stringify(templateStructure);
+          }
+
+          for (const field of deletedFields) {
+            // We remove the field from the resource
+            const index = oldFields.findIndex((x) => x.name === field.name);
+            if (index >= 0) {
+              oldFields.splice(index, 1);
+            }
+          }
+        }
+
+        // Build bulk update of non-core templates
+        const bulkUpdate = [];
+        for (const template of templates) {
+          bulkUpdate.push({
+            updateOne: {
+              filter: { _id: template._id },
+              update: {
+                structure: template.structure,
+                fields: template.fields,
+              },
+            },
+          });
+        }
+        if (bulkUpdate.length > 0) {
+          // Update all child form for addition/deletion/structure changes
+          await Form.bulkWrite(bulkUpdate);
+        }
+
+        // Update resource fields
+        await Resource.findByIdAndUpdate(form.resource, {
+          fields: oldFields,
+        });
+      }
+      update.fields = fields;
+      // Update version
+      const version = new Version({
+        //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
+        data: form.structure,
+      });
+      await version.save();
+      update.$push = { versions: version._id };
+    }
+    // Return updated form
+    return await Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
+      // Avoid to rebuild types only if permissions changed
+      if (args.name || args.status || args.structure) {
+        buildTypes();
+      }
+    });
+    // } catch (err) {
+    //   logger.error(err.message, { stack: err.stack });
+    //   throw new GraphQLError(
+    //     context.i18next.t('common.errors.internalServerError')
+    //   );
+    // }
   },
 };

--- a/src/utils/form/checkFieldValueName.ts
+++ b/src/utils/form/checkFieldValueName.ts
@@ -1,0 +1,42 @@
+import { GraphQLError } from 'graphql/error';
+import i18next from 'i18next';
+
+/** The default fields */
+const DEFAULT_FIELDS = [
+  'id',
+  'incrementalId',
+  'createdAt',
+  'modifiedAt',
+  'form',
+  'createdBy',
+  'createdBy.id',
+  'createdBy.name',
+  'createdBy.username',
+  'lastUpdatedBy',
+  'lastUpdatedBy.id',
+  'lastUpdatedBy.name',
+  'lastUpdatedBy.username',
+];
+
+/**
+ * Checks field value name same as default field name in form.
+ * Throw error if name exists in default field name.
+ *
+ * @param structure form structure.
+ */
+export const checkFieldValueName = (structure): void => {
+  structure.pages.map(function (items) {
+    items.elements.map(function (result) {
+      if (DEFAULT_FIELDS.includes(result.valueName)) {
+        throw new GraphQLError(
+          i18next.t(
+            'mutations.form.edit.errors.fieldValueNameSameAsDefaultFieldName',
+            {
+              name: result.valueName,
+            }
+          )
+        );
+      }
+    });
+  });
+};

--- a/src/utils/form/index.ts
+++ b/src/utils/form/index.ts
@@ -13,3 +13,4 @@ export * from './getNextId';
 export * from './getDisplayText';
 export * from './checkRecordValidation';
 export * from './getAccessibleFields';
+export * from './checkFieldValueName';


### PR DESCRIPTION
# Description
When creating a form we can give protected value names to questions such as form, then it breaks the schema generation. We should add all the default fields name to the list of protected value names.

## Ticket
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/59699

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

