### PR TITLE
reference data layer get records using geoField or longitudeField and latitudeField

### DIFF
--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -136,14 +136,6 @@ router.get('/feature', async (req, res) => {
   const latitudeField = get(req, 'query.latitudeField');
   const longitudeField = get(req, 'query.longitudeField');
   const geoField = get(req, 'query.geoField');
-  console.log('latitudeField ==========>>', latitudeField);
-  console.log('longitudeField ==========>>', longitudeField);
-  console.log('geoField ==========>>', geoField);
-
-  console.log(
-    "mongoose.Types.ObjectId(get(req, 'query.refData')==========",
-    mongoose.Types.ObjectId(get(req, 'query.refData'))
-  );
 
   // const tolerance = get(req, 'query.tolerance', 1);
   // const highQuality = get(req, 'query.highquality', true);
@@ -151,18 +143,16 @@ router.get('/feature', async (req, res) => {
   //   tolerance: tolerance,
   //   highQuality: highQuality,
   // });
-  // if (!geoField || !(latitudeField && longitudeField)) {
-  //   return res
-  //     .status(400)
-  //     .send(i18next.t('routes.gis.feature.errors.invalidFields'));
-  // }
+  if (!geoField || !(latitudeField && longitudeField)) {
+    return res
+      .status(400)
+      .send(i18next.t('routes.gis.feature.errors.invalidFields'));
+  }
   const mapping = {
     geoField,
     longitudeField,
     latitudeField,
   };
-
-  // console.log("mapping ==========>>", mapping);
 
   try {
     // todo(gis): also implement reference data

--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -135,13 +135,17 @@ router.get('/feature', async (req, res) => {
   const latitudeField = get(req, 'query.latitudeField');
   const longitudeField = get(req, 'query.longitudeField');
   const geoField = get(req, 'query.geoField');
+  // console.log("latitudeField ==========>>", latitudeField);
+  // console.log("longitudeField ==========>>", longitudeField);
+  // console.log("geoField ==========>>", geoField);
+
   // const tolerance = get(req, 'query.tolerance', 1);
   // const highQuality = get(req, 'query.highquality', true);
   // turf.simplify(geoJsonData, {
   //   tolerance: tolerance,
   //   highQuality: highQuality,
   // });
-  if (!geoField && !(latitudeField && longitudeField)) {
+  if (!geoField || !(latitudeField && longitudeField)) {
     return res
       .status(400)
       .send(i18next.t('routes.gis.feature.errors.invalidFields'));
@@ -151,6 +155,9 @@ router.get('/feature', async (req, res) => {
     longitudeField,
     latitudeField,
   };
+
+  // console.log("mapping ==========>>", mapping);
+
   try {
     // todo(gis): also implement reference data
     if (get(req, 'query.resource')) {
@@ -248,6 +255,8 @@ router.get('/feature', async (req, res) => {
         }
       });
       await Promise.all([gqlQuery]);
+    } else if (get(req, 'query.refData')) {
+      // console.log("refData ====>>", req);
     } else {
       return res.status(404).send(i18next.t('common.errors.dataNotFound'));
     }


### PR DESCRIPTION
# Description
Geofields or latitudefields and longitudefields in referendata can be used to get records.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

