### PR TITLE
 feat/AB#66370 Add url querystring parameters to request path

### DIFF
--- a/src/routes/proxy/index.ts
+++ b/src/routes/proxy/index.ts
@@ -40,7 +40,7 @@ const proxyAPIRequest = async (req, res, api, path) => {
     const options: any = {
       protocol,
       host: url.hostname,
-      path: url.pathname,
+      path: url.pathname + url.search,
       method: req.method,
       headers: headers,
       agent: false,


### PR DESCRIPTION
# Description

This allows Reference data to take into account the querystring parameters specified in the "Query Name" field:
![image](https://github.com/ReliefApplications/oort-backend/assets/80319175/2db9db14-65f9-4d4c-a497-d7da69d7b931) 

## Ticket

[66370 - ABC - Allow API configuration proxy to pass querystring parameters for REST reference data](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66370)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Ran with different querystring parameters

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

