### PR TITLE
fix: fields permissions incorrectly being reset

### DIFF
--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -288,16 +288,12 @@ export default {
                   );
                   // Inherit the field's permissions
                   field.permissions = {
-                    canSee: oldCanSee.length
-                      ? typeof oldCanSee[0] === 'string'
-                        ? [new mongoose.Types.ObjectId(oldCanSee[0])]
-                        : oldCanSee
-                      : [],
-                    canUpdate: oldCanUpdate.length
-                      ? typeof oldCanUpdate[0] === 'string'
-                        ? [new mongoose.Types.ObjectId(oldCanUpdate[0])]
-                        : oldCanUpdate
-                      : [],
+                    canSee: oldCanSee.map((p) =>
+                      typeof p === 'string' ? new mongoose.Types.ObjectId(p) : p
+                    ),
+                    canUpdate: oldCanUpdate.map((p) =>
+                      typeof p === 'string' ? new mongoose.Types.ObjectId(p) : p
+                    ),
                   };
                   // If the resource's field and the current form's field are different
                   const index = oldFields.findIndex(


### PR DESCRIPTION
# Description

This PR fixes an issue where previously, some fields permission's would be lost when saving changes on a form

## Ticket
[ABC - Saving form removes resets field level permissions](https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By setting field-level permissions on a role, changing a form from that resource, and checking if the fields permissions would remain.

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

