### PR TITLE
fix: interrupted cascade deletion of resources

### DIFF
--- a/migrations/1687184194639-remove-old-forms.ts
+++ b/migrations/1687184194639-remove-old-forms.ts
@@ -1,0 +1,48 @@
+import { Form, Record, Resource } from '@models';
+import { startDatabaseForMigration } from '../src/utils/migrations/database.helper';
+import { deleteFolder } from '@utils/files/deleteFolder';
+import { logger } from '@services/logger.service';
+
+/** This migration removes forms that are not linked to any resources */
+export const up = async () => {
+  await startDatabaseForMigration();
+
+  const forms = await Form.find({});
+  const resources = await Resource.find({});
+
+  const formsToDelete = forms.filter(
+    (f) => !resources.find((r) => r._id.equals(f.resource))
+  );
+
+  try {
+    for (const form of forms) {
+      await deleteFolder('forms', form.id || form._id);
+      logger.info(`Files from form ${form.id} successfully removed.`);
+    }
+  } catch (err) {
+    logger.error(`Deletion of files from forms failed: ${err.message}`);
+  }
+
+  // delete and log how many forms were deleted
+  const { deletedCount } = await Form.deleteMany({
+    _id: { $in: formsToDelete.map((f) => f._id) },
+  });
+  logger.info(`${deletedCount} forms were deleted.`);
+
+  // delete records that are linked to the deleted forms and log how many were deleted
+  const { deletedCount: deletedRecordsCount } = await Record.deleteMany({
+    form: { $in: formsToDelete.map((f) => f._id) },
+  });
+  logger.info(`${deletedRecordsCount} records were deleted.`);
+};
+
+/**
+ * Sample function of down migration
+ *
+ * @returns just migrate data.
+ */
+export const down = async () => {
+  /*
+      Code you downgrade script here!
+   */
+};

--- a/src/models/resource.model.ts
+++ b/src/models/resource.model.ts
@@ -115,15 +115,23 @@ const resourceSchema = new Schema<Resource>(
 
 // handle cascading deletion for resources
 addOnBeforeDeleteMany(resourceSchema, async (resources) => {
+  const resourcesIds = resources.map((r) => r._id);
   try {
-    const forms = await Form.find({ resource: { $in: resources } });
-    for (const form of forms) {
-      await deleteFolder('forms', form.id);
-      logger.info(`Files from form ${form.id} successfully removed.`);
+    const forms = await Form.find({ resource: { $in: resourcesIds } });
+
+    // adding try catch because on envs without storage this was throwing an error
+    // and preventing the deletion of forms and records
+    try {
+      for (const form of forms) {
+        await deleteFolder('forms', form.id);
+        logger.info(`Files from form ${form.id} successfully removed.`);
+      }
+    } catch (err) {
+      logger.error(`Deletion of files from forms failed: ${err.message}`);
     }
 
-    await Form.deleteMany({ resource: { $in: resources } });
-    await Record.deleteMany({ resource: { $in: resources } });
+    await Form.deleteMany({ resource: { $in: resourcesIds } });
+    await Record.deleteMany({ resource: { $in: resourcesIds } });
   } catch (err) {
     logger.error(`Deletion of resources failed: ${err.message}`);
   }

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -607,6 +607,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
         const relatedFilters = [];
         for (const item of items as any) {
           item._relatedRecords = {};
+          item.data = item.data || {};
           for (const field of resourcesFields) {
             if (field.type === 'resource') {
               const record = item.data[field.name];


### PR DESCRIPTION
# Description

This PR fixes an issue where the cascade deletion of resources would be stopped when there's no storage setup, causing forms and records to be left in the DB when resources were deleted. Also, added a migration to delete those.

## Ticket
No ticket linked to this PR

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By deleting a resource on an environment without blob storage setup


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

