### PR TITLE
fix/compare-date-fields

### DIFF
--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -33,10 +33,16 @@ export const hasInaccessibleFields = (
 ) => {
   const oldData = record.data || {};
   const k = union(keys(oldData), keys(newData));
-  const updatedKeys = filter(
-    k,
-    (key) => !isEqual(get(oldData, key), get(newData, key))
-  );
+  const updatedKeys = filter(k, (key) => {
+    let oldD = get(oldData, key);
+    let newD = get(newData, key);
+
+    // check for date objects and convert them to strings
+    if (oldD instanceof Date) oldD = oldD.toISOString();
+    if (newD instanceof Date) newD = newD.toISOString();
+
+    return !isEqual(get(oldD, key), get(newD, key));
+  });
 
   return updatedKeys.some(
     (question) =>
@@ -86,6 +92,7 @@ export default {
 
       // Check permissions with two layers
       const ability = await extendAbilityForRecords(user, parentForm);
+      console.log('has', hasInaccessibleFields(oldRecord, args.data, ability));
       if (
         ability.cannot('update', oldRecord) ||
         hasInaccessibleFields(oldRecord, args.data, ability)

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -92,7 +92,6 @@ export default {
 
       // Check permissions with two layers
       const ability = await extendAbilityForRecords(user, parentForm);
-      console.log('has', hasInaccessibleFields(oldRecord, args.data, ability));
       if (
         ability.cannot('update', oldRecord) ||
         hasInaccessibleFields(oldRecord, args.data, ability)


### PR DESCRIPTION
# Description

This PR changes the code so when comparing differences between two record versions, always try to compare them in string format, by parsing date objects into strings.


## Ticket
No ticket linked to this PR

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By trying to update a form with a date value. Previously, it would fail if don't have permission to edit that field, because the type coming from the form is a string, and the saved is an object.

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

