### PR TITLE
fix: mongoose filter from resource question

### DIFF
--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 import { getDateForMongo } from '@utils/filter/getDateForMongo';
 import { getTimeForMongo } from '@utils/filter/getTimeForMongo';
 import { MULTISELECT_TYPES, DATE_TYPES } from '@const/fieldTypes';
+import { Resource } from '@models';
 
 /** The default fields */
 const DEFAULT_FIELDS = [
@@ -64,16 +65,20 @@ export const extractFilterFields = (filter: any): string[] => {
  * @param prefix prefix to access field
  * @returns Mongo filter.
  */
-const buildMongoFilter = (
+const buildMongoFilter = async (
   filter: any,
   fields: any[],
   context: any,
   prefix = ''
-): any => {
+): Promise<any> => {
   if (filter.filters) {
-    const filters = filter.filters
-      .map((x: any) => buildMongoFilter(x, fields, context, prefix))
-      .filter((x) => x);
+    const filters = (
+      await Promise.all(
+        filter.filters.map((x: any) =>
+          buildMongoFilter(x, fields, context, prefix)
+        )
+      )
+    ).filter((x) => x);
     if (filters.length > 0) {
       switch (filter.logic) {
         case 'and': {
@@ -101,6 +106,28 @@ const buildMongoFilter = (
           (x) =>
             x.name === filter.field || x.name === filter.field.split('.')[0]
         )?.type || '';
+
+      // If type is resource and refers to a nested field, get the type of the nested field
+      if (type === 'resource') {
+        // find the resource field
+        const resourceField = fields.find(
+          (x) => x.name === filter.field.split('.')[0]
+        );
+
+        if (resourceField?.resource) {
+          const nestedResource = await Resource.findById(
+            resourceField.resource
+          );
+
+          // find the nested field
+          const nestedField = nestedResource?.fields.find(
+            (x) => x.name === filter.field.split('.')[1]
+          );
+
+          // get the type of the nested field
+          type = nestedField?.type || type;
+        }
+      }
       if (filter.field === 'ids') {
         return {
           _id: { $in: filter.value.map((x) => mongoose.Types.ObjectId(x)) },


### PR DESCRIPTION
# Description

There was an issue with the filters when the selected questions was of type resource.

* We have a form `A`, with a question `question1`, of type `users`.
* We have a form `B`, with a question `question2`, of type `resource`, linked to form `A`.
* Set a filter on form B, `question2.question1` `includes` `Current user`

That wasn't working, because in the code, the type was inferred as resource, instead of users, and include is not a valid operator for resources, causing an error

## Ticket
No ticket linked to this PR

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Same steps as in the description. 

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

