### PR TITLE
getFilter is now async

### DIFF
--- a/src/schema/mutation/addRecord.mutation.ts
+++ b/src/schema/mutation/addRecord.mutation.ts
@@ -50,7 +50,7 @@ export default {
         form.permissions.recordsUnicity.length > 0 &&
         form.permissions.recordsUnicity[0].role
       ) {
-        const unicityFilters = getFormPermissionFilter(
+        const unicityFilters = await getFormPermissionFilter(
           user,
           form,
           'recordsUnicity'

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -397,7 +397,7 @@ export default {
       );
       // Build pipeline stages
       if (aggregation.pipeline && aggregation.pipeline.length) {
-        buildPipeline(pipeline, aggregation.pipeline, resource, context);
+        await buildPipeline(pipeline, aggregation.pipeline, resource, context);
       }
       // Build mapping step
       if (args.mapping) {

--- a/src/schema/types/form.type.ts
+++ b/src/schema/types/form.type.ts
@@ -88,7 +88,7 @@ export const FormType = new GraphQLObjectType({
         if (args.filter) {
           mongooseFilter = {
             ...mongooseFilter,
-            ...getFilter(args.filter, parent.fields),
+            ...(await getFilter(args.filter, parent.fields)),
           };
         }
         // PAGINATION
@@ -183,14 +183,14 @@ export const FormType = new GraphQLObjectType({
     },
     uniqueRecord: {
       type: RecordType,
-      resolve(parent, args, context) {
+      async resolve(parent, args, context) {
         const user = context.user;
         if (
           parent.permissions.recordsUnicity &&
           parent.permissions.recordsUnicity.length > 0 &&
           parent.permissions.recordsUnicity[0].role
         ) {
-          const unicityFilters = getFormPermissionFilter(
+          const unicityFilters = await getFormPermissionFilter(
             user,
             parent,
             'recordsUnicity'

--- a/src/schema/types/resource.type.ts
+++ b/src/schema/types/resource.type.ts
@@ -167,7 +167,7 @@ export const ResourceType = new GraphQLObjectType({
         if (args.filter) {
           mongooseFilter = {
             ...mongooseFilter,
-            ...getFilter(args.filter, parent.fields),
+            ...(await getFilter(args.filter, parent.fields)),
           };
         }
         // PAGINATION

--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -37,17 +37,17 @@ const addFields = (
  * @param resource Current resource.
  * @param context request context.
  */
-const buildPipeline = (
+const buildPipeline = async (
   pipeline: any[],
   settings: any[],
   resource: Resource,
   context
-): any => {
+): Promise<any> => {
   for (const stage of settings) {
     switch (stage.type) {
       case PipelineStage.FILTER: {
         pipeline.push({
-          $match: getFilter(stage.form, resource.fields, context, ''),
+          $match: await getFilter(stage.form, resource.fields, context, ''),
         });
         break;
       }

--- a/src/utils/filter/getFormPermissionFilter.ts
+++ b/src/utils/filter/getFormPermissionFilter.ts
@@ -10,25 +10,25 @@ import getFilter from '../schema/resolvers/Query/getFilter';
  * @param permission name of the permission to get filter for
  * @returns Mongo permission filter.
  */
-export const getFormPermissionFilter = (
+export const getFormPermissionFilter = async (
   user: User,
   object: Form | Resource,
   permission: string
-): any[] => {
+): Promise<any[]> => {
   const roles = user.roles.map((x) => mongoose.Types.ObjectId(x._id));
   const permissionFilters = [];
   const permissionArray = object.permissions[permission];
   if (permissionArray && permissionArray.length) {
-    permissionArray.forEach((x) => {
+    for (const x of permissionArray) {
       if (!x.role || roles.some((role) => role.equals(x.role))) {
         const filter = {};
         Object.assign(
           filter,
-          x.access && getFilter(x.access, object.fields, { user })
+          x.access && (await getFilter(x.access, object.fields, { user }))
         );
         permissionFilters.push(filter);
       }
-    });
+    }
   }
   return permissionFilters;
 };

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -85,7 +85,7 @@ export const getEntityResolver = (
         const relatedFields =
           data[Object.keys(ids).find((x) => ids[x] == field.resource)];
         return Object.assign({}, resolvers, {
-          [field.name]: (
+          [field.name]: async (
             entity,
             args = {
               sortField: null,
@@ -104,7 +104,7 @@ export const getEntityResolver = (
             }
             // Else, do db query
             const mongooseFilter = args.filter
-              ? getFilter(args.filter, relatedFields)
+              ? await getFilter(args.filter, relatedFields)
               : {};
             try {
               const recordIds = get(
@@ -118,7 +118,7 @@ export const getEntityResolver = (
                   { _id: { $in: recordIds } },
                   { archived: { $ne: true } }
                 );
-                return Record.find(mongooseFilter)
+                return await Record.find(mongooseFilter)
                   .sort([[getSortField(args.sortField), args.sortOrder]])
                   .limit(args.first);
                 // if (args.first !== null) {
@@ -241,7 +241,7 @@ export const getEntityResolver = (
               mappedRelatedFields.push(x.relatedName);
               return [
                 x.relatedName,
-                (
+                async (
                   entity,
                   args = {
                     sortField: null,
@@ -263,7 +263,7 @@ export const getEntityResolver = (
                   }
                   // Else, do db query
                   const mongooseFilter = args.filter
-                    ? getFilter(args.filter, data[entityName])
+                    ? await getFilter(args.filter, data[entityName])
                     : {};
                   Object.assign(
                     mongooseFilter,

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -447,7 +447,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
       );
 
       // Filter from the query definition
-      const mongooseFilter = getFilter(filter, fields, context);
+      const mongooseFilter = await getFilter(filter, fields, context);
       // Additional filter on objects such as CreatedBy, LastUpdatedBy or Form
       // Must be applied after lookups in the aggregation
       const afterLookupsFilters = getAfterLookupsFilter(
@@ -707,7 +707,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
         // Create the filter for each style
         const recordsIds = items.map((x) => x.id || x._id);
         for (const style of styles) {
-          const styleFilter = getFilter(style.filter, fields, context);
+          const styleFilter = await getFilter(style.filter, fields, context);
           // Get the records corresponding to the style filter
           const itemsToStyle = await Record.aggregate([
             {

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 import { getDateForMongo } from '@utils/filter/getDateForMongo';
 import { getTimeForMongo } from '@utils/filter/getTimeForMongo';
 import { MULTISELECT_TYPES, DATE_TYPES } from '@const/fieldTypes';
+import { Resource } from '@models';
 
 /** The default fields */
 const DEFAULT_FIELDS = [
@@ -64,16 +65,20 @@ export const extractFilterFields = (filter: any): string[] => {
  * @param prefix prefix to access field
  * @returns Mongo filter.
  */
-const buildMongoFilter = (
+const buildMongoFilter = async (
   filter: any,
   fields: any[],
   context: any,
   prefix = ''
-): any => {
+): Promise<any> => {
   if (filter.filters) {
-    const filters = filter.filters
-      .map((x: any) => buildMongoFilter(x, fields, context, prefix))
-      .filter((x) => x);
+    const filters = (
+      await Promise.all(
+        filter.filters.map((x: any) =>
+          buildMongoFilter(x, fields, context, prefix)
+        )
+      )
+    ).filter((x) => x);
     if (filters.length > 0) {
       switch (filter.logic) {
         case 'and': {
@@ -101,6 +106,28 @@ const buildMongoFilter = (
           (x) =>
             x.name === filter.field || x.name === filter.field.split('.')[0]
         )?.type || '';
+
+      // If type is resource and refers to a nested field, get the type of the nested field
+      if (type === 'resource') {
+        // find the resource field
+        const resourceField = fields.find(
+          (x) => x.name === filter.field.split('.')[0]
+        );
+
+        if (resourceField?.resource) {
+          const nestedResource = await Resource.findById(
+            resourceField.resource
+          );
+
+          // find the nested field
+          const nestedField = nestedResource?.fields.find(
+            (x) => x.name === filter.field.split('.')[1]
+          );
+
+          // get the type of the nested field
+          type = nestedField?.type || type;
+        }
+      }
       if (filter.field === 'ids') {
         return {
           _id: { $in: filter.value.map((x) => mongoose.Types.ObjectId(x)) },
@@ -374,7 +401,7 @@ const buildMongoFilter = (
  * @param prefix prefix to access field
  * @returns Mongo filter.
  */
-export default (
+export default async (
   filter: any,
   fields: any[],
   context?: any,
@@ -382,6 +409,6 @@ export default (
 ) => {
   const expandedFields = fields.concat(DEFAULT_FIELDS);
   const mongooseFilter =
-    buildMongoFilter(filter, expandedFields, context, prefix) || {};
+    (await buildMongoFilter(filter, expandedFields, context, prefix)) || {};
   return mongooseFilter;
 };


### PR DESCRIPTION
# Description

This PR copies the changes from #642 and fixes the bug it introduced. The issue was I forgot to await the function on the default export, and since it's now also async, had to change a bunch of other functions to also be async
![image](https://github.com/ReliefApplications/oort-backend/assets/102038450/b7b4b87b-2534-4bcb-94fd-f51133bd225f)


## Ticket
No ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is weird because when I first tested this it was giving the correct filters, even though I was not awaiting it. So I'm not even sure what made you realize this issue. This time around I tested with simple filters and coming from resources. Seems to work fine, but I'm not sure what else to test.

## Sreenshots
![Peek 2023-05-29 13-51](https://github.com/ReliefApplications/oort-backend/assets/102038450/33c28652-8f08-4595-9c72-3ccfbc97eb9a)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

