### PR TITLE
fix/AB#68079_aggregation-from-refData

### DIFF
--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -1,8 +1,8 @@
 import { GraphQLError, GraphQLID, GraphQLInt, GraphQLNonNull } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import mongoose from 'mongoose';
-import { cloneDeep, get, isEqual } from 'lodash';
-import { Form, Record, ReferenceData, Resource } from '@models';
+import { cloneDeep, get, isEqual, set, unset } from 'lodash';
+import { Form, Record as RecordModel, ReferenceData, Resource } from '@models';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import buildPipeline from '@utils/aggregation/buildPipeline';
 import buildReferenceDataAggregation from '@utils/aggregation/buildReferenceDataAggregation';
@@ -80,7 +80,7 @@ export default {
 
       // Check abilities
       const ability = await extendAbilityForRecords(user);
-      const permissionFilters = Record.accessibleBy(
+      const permissionFilters = RecordModel.accessibleBy(
         ability,
         'read'
       ).getFilter();
@@ -89,6 +89,45 @@ export default {
       const aggregation = resource.aggregations.find((x) =>
         isEqual(x.id, args.aggregation)
       );
+
+      const refDataNameMap: Record<string, string> = {};
+      if (aggregation?.sourceFields && aggregation.pipeline) {
+        // Go through the aggregation source fields to update possible refData field names
+        for (const field of aggregation.sourceFields) {
+          // find field in resource fields
+          const resourceField = resource.fields.find((x) => x.name === field);
+
+          // check if field is a refData field
+          if (resourceField?.referenceData?.id) {
+            const refData = await ReferenceData.findById(
+              resourceField.referenceData.id
+            );
+
+            // if so, update the map
+            if (refData)
+              refData.fields.forEach((f) => {
+                refDataNameMap[
+                  `${field}.${f.graphQLFieldName}`
+                ] = `${field}.${f.name}`;
+              });
+          }
+        }
+
+        const hasRefDataField = Object.keys(refDataNameMap).length > 0;
+        if (hasRefDataField) {
+          // update the aggregation pipeline with the actual field names from the refData
+          let strPipeline = JSON.stringify(aggregation.pipeline);
+          for (const [key, value] of Object.entries(refDataNameMap)) {
+            strPipeline = strPipeline.replace(
+              `"field":"${key}"`,
+              `"field":"${value}"`
+            );
+          }
+
+          aggregation.pipeline = JSON.parse(strPipeline);
+        }
+      }
+
       const mongooseFilter = {};
       // Check if resource exists and aggregation exists
       if (resource && aggregation) {
@@ -430,7 +469,8 @@ export default {
         });
       }
       // Get aggregated data
-      const recordAggregation = await Record.aggregate(pipeline);
+      const recordAggregation = await RecordModel.aggregate(pipeline);
+
       let items;
       let totalCount;
       if (args.mapping) {
@@ -440,7 +480,19 @@ export default {
         items = recordAggregation[0].items;
         totalCount = recordAggregation[0]?.totalCount[0]?.count || 0;
       }
-      const copiedItems = cloneDeep(items);
+      let copiedItems = cloneDeep(items);
+
+      // If we have refData fields, revert back to the graphql names of the fields
+      for (const [graphqlName, name] of Object.entries(refDataNameMap)) {
+        copiedItems = copiedItems.map((item: any) => {
+          const currVal = get(item, name);
+          if (currVal) {
+            set(item, graphqlName, currVal);
+            unset(item, name);
+          }
+          return item;
+        });
+      }
 
       // For each detected field with choices, set the value of each entry to be display text value and then return
       try {
@@ -458,7 +510,7 @@ export default {
           await setDisplayText(mappedFields, copiedItems, resource, context);
           return copiedItems;
         } else {
-          const mappedFields = Object.keys(items[0]).map((key) => ({
+          const mappedFields = Object.keys(items[0] || {}).map((key) => ({
             key,
             value: key,
           }));

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -440,13 +440,23 @@ export default {
       }
       // Build mapping step
       if (args.mapping) {
+        // Also check if any of the mapped fields are from referenceData
+        let mappingStr = JSON.stringify(args.mapping);
+        const hasRefDataField = Object.keys(refDataNameMap).length > 0;
+        if (hasRefDataField) {
+          // update the aggregation pipeline with the actual field names from the refData
+          for (const [key, value] of Object.entries(refDataNameMap)) {
+            mappingStr = mappingStr.replace(`:"${key}"`, `:"${value}"`);
+          }
+        }
+        const mapping = JSON.parse(mappingStr);
         pipeline.push({
           $project: {
-            category: `$${args.mapping.category}`,
-            field: `$${args.mapping.field}`,
+            category: `$${mapping.category}`,
+            field: `$${mapping.field}`,
             id: '$_id',
-            ...(args.mapping.series && {
-              series: `$${args.mapping.series}`,
+            ...(mapping.series && {
+              series: `$${mapping.series}`,
             }),
           },
         });


### PR DESCRIPTION
# Description

This PR fixes the issue we had with aggreagations that used refData fields. In the end, I scrapped all the work I had done to try to get the correct field names from the refData in the frontend and instead, am just getting it in the aggregation mutations instead.

As for the wrong values, turns out I was just using a string field thinking it was a number :sweat_smile: 

## Ticket
[ABC - Aggregations using refData are broken](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68079)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By setting up an aggregation that uses reference data fields

## Screenshots
![image](https://github.com/ReliefApplications/oort-backend/assets/102038450/71faf7cb-e707-4ae8-a3be-6173f9517abb)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

