### PR TITLE
fix/search-grid-calculated-field-in-resource

### DIFF
--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -624,7 +624,10 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
           item.data = item.data || {};
           for (const field of resourcesFields) {
             if (field.type === 'resource') {
-              const record = item.data[field.name];
+              // If resource field is a calculated field, should use record _id and
+              // not the calculated field saved in the field name
+              const record =
+                item.data[field.name + '_id'] ?? item.data[field.name];
               if (record) {
                 itemsToUpdate.push({ item, record, field });
               }


### PR DESCRIPTION
# Description
Custom query breaking for any search in grid if we have in the grid layout a resource question as reference data with a calculated field, because even if the resource field is a calculated field, it was using the calculated field saved in the field name, when the record id that should be used was being kept in the field_name_id, like in this case:

```
set_family: { incrementalidstring: '2023-F00000006code' },
set_family_id: 64a2aaa1eae9f87a41927fc8
```
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Searching for texts field in the grid when its layout has a resource question with a calculated field selected.

## Screenshots
Search breaking:
![breaks](https://github.com/ReliefApplications/oort-backend/assets/28535394/38ccca3f-a9b9-4d13-bd23-e7faf36d8034)

Search working:
![works](https://github.com/ReliefApplications/oort-backend/assets/28535394/74e06eea-327c-4731-b74f-4ae54033af43)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

