### PR TITLE
fix/AB#68744_graphQL_endpoint_apiConfig_not_working_correctly

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -67,7 +67,7 @@
 			},
 			"edit": {
 				"errors": {
-					"invalidArguments": "Either name, status, authType, endpoint, pingUrl, settings or permissions must be provided."
+					"invalidArguments": "Either name, status, authType, endpoint, graphqlEndpoint, pingUrl, settings or permissions must be provided."
 				}
 			}
 		},

--- a/src/schema/mutation/editApiConfiguration.mutation.ts
+++ b/src/schema/mutation/editApiConfiguration.mutation.ts
@@ -41,15 +41,17 @@ export default {
         );
       }
       const ability: AppAbility = user.ability;
+
+      console.log(args);
       if (
-        !args.name &&
-        !args.status &&
-        !args.authType &&
-        !args.endpoint &&
-        !args.pingUrl &&
-        !args.graphQLEndpoint &&
-        !args.settings &&
-        !args.permissions
+        !args.hasOwnProperty('name') &&
+        !args.hasOwnProperty('status') &&
+        !args.hasOwnProperty('authType') &&
+        !args.hasOwnProperty('endpoint') &&
+        !args.hasOwnProperty('pingUrl') &&
+        !args.hasOwnProperty('graphQLEndpoint') &&
+        !args.hasOwnProperty('settings') &&
+        !args.hasOwnProperty('permissions')
       ) {
         throw new GraphQLError(
           context.i18next.t(
@@ -67,7 +69,7 @@ export default {
         args.status && { status: args.status },
         args.authType && { authType: args.authType },
         args.endpoint && { endpoint: args.endpoint },
-        args.graphQLEndpoint && { graphQLEndpoint: args.graphQLEndpoint },
+        { graphQLEndpoint: args.graphQLEndpoint },
         args.pingUrl && { pingUrl: args.pingUrl },
         args.settings && {
           settings: CryptoJS.AES.encrypt(
@@ -77,6 +79,8 @@ export default {
         },
         args.permissions && { permissions: args.permissions }
       );
+
+      console.log(update);
       const filters = ApiConfiguration.accessibleBy(ability, 'update')
         .where({ _id: args.id })
         .getFilter();

--- a/src/schema/mutation/editApiConfiguration.mutation.ts
+++ b/src/schema/mutation/editApiConfiguration.mutation.ts
@@ -14,6 +14,7 @@ import { buildTypes } from '@utils/schema';
 import { validateApi } from '@utils/validators/validateApi';
 import config from 'config';
 import { logger } from '@services/logger.service';
+import { cloneDeep, isEmpty, omit } from 'lodash';
 
 /**
  * Edit the passed apiConfiguration if authorized.
@@ -42,44 +43,32 @@ export default {
       }
       const ability: AppAbility = user.ability;
 
-      if (
-        !args.hasOwnProperty('name') &&
-        !args.hasOwnProperty('status') &&
-        !args.hasOwnProperty('authType') &&
-        !args.hasOwnProperty('endpoint') &&
-        !args.hasOwnProperty('pingUrl') &&
-        !args.hasOwnProperty('graphQLEndpoint') &&
-        !args.hasOwnProperty('settings') &&
-        !args.hasOwnProperty('permissions')
-      ) {
+      // Check if any of required arguments for a valid update are provided.
+      // Else, send error
+      // cloneDeep coupled with omit allows to filter out the 'id' field
+      if (isEmpty(cloneDeep(omit(args, ['id'])))) {
         throw new GraphQLError(
           context.i18next.t(
             'mutations.apiConfiguration.edit.errors.invalidArguments'
           )
         );
       }
-      const update = {};
+      // See if API name is usable
       if (args.name) {
         validateApi(args.name);
       }
-      Object.assign(
-        update,
-        args.name && { name: args.name },
-        args.status && { status: args.status },
-        args.authType && { authType: args.authType },
-        args.endpoint && { endpoint: args.endpoint },
-        { graphQLEndpoint: args.graphQLEndpoint },
-        args.pingUrl && { pingUrl: args.pingUrl },
-        args.settings && {
+      // Create the update document
+      const update = {
+        ...cloneDeep(omit(args, ['id'])),
+        ...(args.settings && {
           settings: CryptoJS.AES.encrypt(
             JSON.stringify(args.settings),
             config.get('encryption.key')
           ).toString(),
-        },
-        args.permissions && { permissions: args.permissions }
-      );
+        }),
+      };
 
-      console.log(update);
+      // Find API configuration and update it using User permissions
       const filters = ApiConfiguration.accessibleBy(ability, 'update')
         .where({ _id: args.id })
         .getFilter();

--- a/src/schema/mutation/editApiConfiguration.mutation.ts
+++ b/src/schema/mutation/editApiConfiguration.mutation.ts
@@ -42,7 +42,6 @@ export default {
       }
       const ability: AppAbility = user.ability;
 
-      console.log(args);
       if (
         !args.hasOwnProperty('name') &&
         !args.hasOwnProperty('status') &&


### PR DESCRIPTION
# Description

Fixed when api configuration is edited and a "GraphQL endpoint" is added if saved, it's not possible remove it afterward.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68744

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested verifying in the application if now it's possible to remove the field GraphQL endpoint after edit and fill it.

## Screenshots

![Peek 05-07-2023 18-18](https://github.com/ReliefApplications/oort-backend/assets/56398308/4a6ebb6b-0145-4556-ba9b-2334fdd6bc5c)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

