### PR TITLE
refactor/AB#71447_embed-version-docs

### DIFF
--- a/migrations/1690918595994-embed-version-documents.ts
+++ b/migrations/1690918595994-embed-version-documents.ts
@@ -1,0 +1,139 @@
+import { Form, Record, Version } from '@models';
+import { startDatabaseForMigration } from '../src/utils/migrations/database.helper';
+import { logger } from '@services/logger.service';
+import { Types } from 'mongoose';
+
+/**
+ * Gets the ObjectId from a BSON object
+ *
+ * @param bson BSON object
+ * @returns The ObjectId of the BSON object
+ */
+const getOidFromBson = (bson: any) =>
+  new Types.ObjectId(bson._doc.id.toString('hex'));
+
+/** Migrates forms to have the version docs embedded instead of just ids */
+const migrateForms = async () => {
+  // Get forms that have not been migrated yet
+  const forms = await Form.find({
+    versions: { $not: { $size: 0 } },
+    $expr: {
+      $eq: [{ $type: { $arrayElemAt: ['$versions', 0] } }, 'objectId'],
+    },
+  });
+  if (!!forms.length)
+    logger.info(`Embedding versions into ${forms.length} forms...`);
+  else logger.info('No forms to migrate, skipping...');
+
+  const allVersionsToQuery: Types.ObjectId[] = [];
+  forms.forEach((f) => {
+    // Since schema was updated, we need to convert the ids to ObjectIds
+    f.versions.forEach((v) => {
+      allVersionsToQuery.push(getOidFromBson(v));
+    });
+  });
+
+  // Remove duplicates from the array (not sure why there are duplicates sometimes)
+  const versionsToQuery = [];
+  allVersionsToQuery.forEach((v) => {
+    if (!versionsToQuery.find((v2) => v2.equals(v))) versionsToQuery.push(v);
+  });
+
+  const versions = await Version.find({
+    _id: { $in: versionsToQuery },
+  });
+
+  forms.forEach((f) => {
+    const versionsToEmbed = versions.filter((v) =>
+      f.versions.find((v2) => getOidFromBson(v2).equals(v._id))
+    );
+
+    f.versions = versionsToEmbed;
+  });
+
+  // Update forms with the versions embedded
+  await Form.bulkSave(forms);
+
+  // Remove the version docs from the database
+  await Version.deleteMany({
+    _id: { $in: versionsToQuery },
+  });
+
+  logger.info('Finished embedding versions into forms.');
+};
+
+/** Migrates records to have the version docs embedded instead of just ids */
+const migrateRecords = async () => {
+  // Get records that have not been migrated yet
+  const records = await Record.find({
+    versions: { $not: { $size: 0 } },
+    $expr: {
+      $eq: [{ $type: { $arrayElemAt: ['$versions', 0] } }, 'objectId'],
+    },
+  });
+
+  if (!!records.length)
+    logger.info(`Embedding versions into ${records.length} records...`);
+  else logger.info('No records to migrate, skipping...');
+
+  const allVersionsToQuery: Types.ObjectId[] = [];
+  records.forEach((r) => {
+    // Since schema was updated, we need to convert the ids to ObjectIds
+    r.versions.forEach((v) => {
+      allVersionsToQuery.push(getOidFromBson(v));
+    });
+  });
+
+  // Remove duplicates from the array (not sure why there are duplicates sometimes)
+  const versionsToQuery = [];
+  allVersionsToQuery.forEach((v) => {
+    if (!versionsToQuery.find((v2) => v2.equals(v))) versionsToQuery.push(v);
+  });
+
+  const versions = await Version.find({
+    _id: { $in: versionsToQuery },
+  });
+
+  records.forEach((r) => {
+    const versionsToEmbed = versions.filter((v) =>
+      r.versions.find((v2) => getOidFromBson(v2).equals(v._id))
+    );
+
+    r.versions = versionsToEmbed;
+  });
+
+  // Update records with the versions embedded
+  await Record.bulkSave(records);
+
+  // Remove the version docs from the database
+  await Version.deleteMany({
+    _id: { $in: versionsToQuery },
+  });
+
+  logger.info('Finished embedding versions into records.');
+};
+
+/** This migration embeds the version docs into forms/records */
+export const up = async () => {
+  await startDatabaseForMigration();
+
+  // Migration of forms
+  await migrateForms();
+
+  // Migration of records
+  await migrateRecords();
+
+  // Drop the version collection (should we do this?)
+  // await Version.collection.drop();
+};
+
+/**
+ * Sample function of down migration
+ *
+ * @returns just migrate data.
+ */
+export const down = async () => {
+  /*
+      Code you downgrade script here!
+   */
+};

--- a/src/models/form.model.ts
+++ b/src/models/form.model.ts
@@ -4,7 +4,7 @@ import { addOnBeforeDeleteMany } from '@utils/models/deletion';
 import { status } from '@const/enumTypes';
 import { Channel } from './channel.model';
 import { layoutSchema } from './layout.model';
-import { Version } from './version.model';
+import { versionSchema } from './version.model';
 import { Record } from './record.model';
 import { getGraphQLTypeName } from '@utils/validators';
 import { deleteFolder } from '@utils/files/deleteFolder';
@@ -130,10 +130,7 @@ const schema = new Schema<Form>(
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Resource',
     },
-    versions: {
-      type: [mongoose.Schema.Types.ObjectId],
-      ref: 'Version',
-    },
+    versions: [versionSchema],
     channel: {
       type: [mongoose.Schema.Types.ObjectId],
       ref: 'Channel',
@@ -169,10 +166,8 @@ addOnBeforeDeleteMany(schema, async (forms) => {
       logger.info(`Files from form ${form.id} successfully removed.`);
     }
 
-    const versions = forms.reduce((acc, form) => acc.concat(form.versions), []);
     await Record.deleteMany({ form: { $in: forms } });
     await Channel.deleteMany({ form: { $in: forms } });
-    await Version.deleteMany({ _id: { $in: versions } });
   } catch (err) {
     logger.error(`Deletion of forms failed: ${err.message}`);
   }

--- a/src/models/record.model.ts
+++ b/src/models/record.model.ts
@@ -7,7 +7,7 @@ import {
 } from '@casl/mongoose';
 import mongoose, { Schema } from 'mongoose';
 import { addOnBeforeDeleteMany } from '@utils/models/deletion';
-import { Version } from './version.model';
+import { Version, versionSchema } from './version.model';
 import { Form } from './form.model';
 import { User } from './user.model';
 
@@ -22,7 +22,7 @@ export interface Record extends AccessibleFieldsDocument {
   modifiedAt: Date;
   archived: boolean;
   data: any;
-  versions: any;
+  versions: Version[];
   permissions: {
     canSee?: any[];
     // {
@@ -100,10 +100,7 @@ const recordSchema = new Schema<Record>(
       type: mongoose.Schema.Types.Mixed,
       required: true,
     },
-    versions: {
-      type: [mongoose.Schema.Types.ObjectId],
-      ref: 'Version',
-    },
+    versions: [versionSchema],
   },
   {
     timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },

--- a/src/models/version.model.ts
+++ b/src/models/version.model.ts
@@ -2,7 +2,7 @@ import { AccessibleRecordModel, accessibleRecordsPlugin } from '@casl/mongoose';
 import mongoose, { Schema, Document } from 'mongoose';
 
 /** Mongoose version schema declaration */
-const versionSchema = new Schema(
+export const versionSchema = new Schema(
   {
     data: mongoose.Schema.Types.Mixed,
     createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -507,7 +507,10 @@ export default {
           data: form.structure,
           createdBy: context.user._id,
         });
-        update.$push = { versions: version };
+
+        if (update.$addToSet)
+          Object.assign(update.$addToSet, { versions: version });
+        else Object.assign(update, { $addToSet: { versions: version } });
       }
       // Return updated form
       return await Form.findByIdAndUpdate(

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -504,11 +504,10 @@ export default {
         update.fields = fields;
         // Update version
         const version = new Version({
-          //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
           data: form.structure,
+          createdBy: context.user._id,
         });
-        await version.save();
-        update.$push = { versions: version._id };
+        update.$push = { versions: version };
       }
       // Return updated form
       return await Form.findByIdAndUpdate(

--- a/src/schema/mutation/editRecords.mutation.ts
+++ b/src/schema/mutation/editRecords.mutation.ts
@@ -118,7 +118,7 @@ export default {
                   username: user.username,
                 },
               },
-              $push: { versions: version._id },
+              $push: { versions: version },
             };
             const ownership = getOwnership(record.form.fields, args.data); // Update with template during merge
             Object.assign(
@@ -132,7 +132,6 @@ export default {
                 new: true,
               }
             );
-            await version.save();
             records.push(newRecord);
           }
         }

--- a/src/schema/types/form.type.ts
+++ b/src/schema/types/form.type.ts
@@ -16,7 +16,7 @@ import {
   LayoutConnectionType,
   FieldMetaDataType,
 } from '.';
-import { Resource, Record, Version, Form } from '@models';
+import { Resource, Record, Form } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { getFormPermissionFilter } from '@utils/filter';
 import { StatusEnumType } from '@const/enumTypes';
@@ -148,14 +148,11 @@ export const FormType = new GraphQLObjectType({
     versionsCount: {
       type: GraphQLInt,
       resolve(parent) {
-        return Version.find().where('_id').in(parent.versions).count();
+        return parent.versions.length;
       },
     },
     versions: {
       type: new GraphQLList(VersionType),
-      resolve(parent) {
-        return Version.find().where('_id').in(parent.versions);
-      },
     },
     fields: { type: GraphQLJSON },
     canSee: {

--- a/src/schema/types/record.type.ts
+++ b/src/schema/types/record.type.ts
@@ -8,7 +8,7 @@ import {
 import { AppAbility } from '@security/defineUserAbility';
 import GraphQLJSON from 'graphql-type-json';
 import { FormType, UserType, VersionType } from '.';
-import { Form, Resource, Record, Version, User } from '@models';
+import { Form, Resource, Record, User } from '@models';
 import { Connection } from './pagination.type';
 import getDisplayText from '@utils/form/getDisplayText';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
@@ -80,9 +80,6 @@ export const RecordType = new GraphQLObjectType({
     },
     versions: {
       type: new GraphQLList(VersionType),
-      resolve(parent) {
-        return Version.find().where('_id').in(parent.versions);
-      },
     },
     createdBy: {
       type: UserType,
@@ -98,7 +95,7 @@ export const RecordType = new GraphQLObjectType({
       type: UserType,
       async resolve(parent) {
         if (parent.versions && parent.versions.length > 0) {
-          const lastVersion = await Version.findById(parent.versions.pop());
+          const lastVersion = parent.versions.pop();
           if (lastVersion) {
             return User.findById(lastVersion.createdBy);
           }

--- a/src/schema/types/version.type.ts
+++ b/src/schema/types/version.type.ts
@@ -18,7 +18,7 @@ export const VersionType = new GraphQLObjectType({
     data: { type: GraphQLJSON },
     createdBy: {
       type: UserType,
-      resolve(parent, args, context) {
+      resolve(parent, _, context) {
         const ability: AppAbility = context.user.ability;
         return User.findById(parent.createdBy).accessibleBy(ability, 'read');
       },

--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -1,4 +1,4 @@
-import { Record, User, Role, ReferenceData } from '@models';
+import { Record, User, Role, ReferenceData, Version } from '@models';
 import {
   Change,
   RecordHistory as RecordHistoryType,
@@ -363,7 +363,7 @@ export class RecordHistory {
       createdAt: versions[0].createdAt,
       createdBy: this.record.createdBy?.user?.name,
       changes: difference,
-      version: versions[0],
+      version: new Version(versions[0]),
     });
 
     for (let i = 1; i < versions.length; i++) {
@@ -372,7 +372,7 @@ export class RecordHistory {
         createdAt: versions[i].createdAt,
         createdBy: versions[i - 1].createdBy?.name,
         changes: difference,
-        version: versions[i],
+        version: new Version(versions[i]),
       });
     }
     difference = this.getDifference(
@@ -385,16 +385,16 @@ export class RecordHistory {
       changes: difference,
     });
 
-    const formated = await this.formatValues(res.reverse());
-    return formated;
+    const formatted = await this.formatValues(res.reverse());
+    return formatted;
   }
 
   /**
    * Formats and sets the display values for every question
    * of each version of the history
    *
-   * @param history Record history to be formated
-   * @returns The record history with formated values
+   * @param history Record history to be formatted
+   * @returns The record history with formatted values
    */
   private async formatValues(history: RecordHistoryType) {
     const getOptionFromChoices = (
@@ -634,7 +634,7 @@ export class RecordHistory {
           case 'matrixdynamic':
             ['new', 'old'].forEach((state) => {
               if (change[state] !== undefined) {
-                const formatedState = [];
+                const formattedState = [];
                 for (const entry of change[state]) {
                   const newEntry = {};
                   for (const key in entry) {
@@ -645,11 +645,11 @@ export class RecordHistory {
                     );
                     Object.assign(newEntry, { [newKey]: newVal });
                   }
-                  formatedState.push(newEntry);
+                  formattedState.push(newEntry);
                 }
 
                 const res: string[] = [];
-                formatedState.forEach((entry, i) => {
+                formattedState.forEach((entry, i) => {
                   let line = `[${i + 1}]`;
                   for (const key in entry) {
                     line = line.concat(`\t${key}: ${entry[key]}`).trim();


### PR DESCRIPTION
# Description

This PR refactors the code so the versions of previous forms / records are stored in their respective documents instead to improve performance.

## Useful links
[ABC - Remove 'versions' collection, and store versions of form / records in the document directly](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/71447)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Updating existing records and checking that a new version is created in the record doc
- [x] Updating existing form and checking that a new version is created in the form doc
- [x] Reverting to an older version of a record
- [x] Checking the history of a record

# Checklist:

( * == Mandatory ) 

- [x] * The pull request is linked to an existing milestone ( if possible )
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
