### PR TITLE
Check if isCalculated is set to true

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -68,8 +68,12 @@ class SafeServer {
           data.updateDescription.updatedFields
         );
         if (
-          updatedDocFields.some((f) =>
-            fieldsThatRequireSchemaUpdate.includes(f)
+          updatedDocFields.some(
+            (f) =>
+              fieldsThatRequireSchemaUpdate.includes(f) &&
+              data.updateDescription.updatedFields[f].some(
+                (field) => field.isCalculated === true
+              )
           )
         ) {
           this.update();


### PR DESCRIPTION
Restart if the field has the "isCalculated" property set to true.

# Description

The server was crashing on a calculated field update

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/73153

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

### Before

https://github.com/ReliefApplications/oort-backend/assets/15035750/204d6c53-71ee-432b-a39a-6cd8bf1d69da

### After

https://github.com/ReliefApplications/oort-backend/assets/15035750/2c129b0c-c42e-4a97-a83a-8876670d8788

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules