### PR TITLE
Fix/ab#73366 user with permission cannot download file

### DIFF
--- a/src/routes/download/index.ts
+++ b/src/routes/download/index.ts
@@ -507,7 +507,11 @@ router.get('/file/:form/:blob', async (req, res) => {
   try {
     const ability: AppAbility = req.context.user.ability;
     const form: Form = await Form.findById(req.params.form);
-    const formAbility = await extendAbilityForRecords(req.context.user, form, ability);
+    const formAbility = await extendAbilityForRecords(
+      req.context.user,
+      form,
+      ability
+    );
     if (!form) {
       return res.status(404).send(i18next.t('common.errors.dataNotFound'));
     }

--- a/src/routes/download/index.ts
+++ b/src/routes/download/index.ts
@@ -507,10 +507,11 @@ router.get('/file/:form/:blob', async (req, res) => {
   try {
     const ability: AppAbility = req.context.user.ability;
     const form: Form = await Form.findById(req.params.form);
+    const formAbility = await extendAbilityForRecords(req.context.user, form, ability);
     if (!form) {
       return res.status(404).send(i18next.t('common.errors.dataNotFound'));
     }
-    if (ability.cannot('read', form)) {
+    if (formAbility.cannot('read', form)) {
       return res
         .status(403)
         .send(i18next.t('common.errors.permissionNotGranted'));


### PR DESCRIPTION
# Description

Fixed user with records view permission can not download file of a record

## Useful links

[link](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/73366)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested verying if now the user with view permission can download a file of  a record.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
