### PR TITLE
OORT-feat/IM-28-replace-grid-actions-menu-if-single-action

### DIFF
--- a/src/schema/inputs/layout.input.ts
+++ b/src/schema/inputs/layout.input.ts
@@ -24,7 +24,7 @@ const LayoutQueryInputType = new GraphQLInputObjectType({
   }),
 });
 
-/** GraphQL layout display inpupt type definition */
+/** GraphQL layout display input type definition */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const LayoutDisplayInputType = new GraphQLInputObjectType({
   name: 'LayoutDisplayInputType',
@@ -33,6 +33,7 @@ const LayoutDisplayInputType = new GraphQLInputObjectType({
     fields: { type: GraphQLJSON },
     sort: { type: GraphQLJSON },
     showFilter: { type: GraphQLBoolean },
+    actionsColWidth: { type: GraphQLInt },
   }),
 });
 


### PR DESCRIPTION
# Description

This PR simply adds the actionsColWidth field to the LayoutDisplayInputType input, so we can store the width of the action columns.

## Useful links

- Please insert link to ticket: https://github.com/ReliefApplications/oort-frontend/pull/1788

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Check frontend PR

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
