### PR TITLE
fixed dashboard name when context

### DIFF
--- a/src/schema/mutation/addDashboardWithContext.mutation.ts
+++ b/src/schema/mutation/addDashboardWithContext.mutation.ts
@@ -41,10 +41,10 @@ const getNewDashboardName = async (
       : referenceData.data;
 
     const item = data.find((x) => x[referenceData.valueField] === id);
-    return `${dashboard.name} (${item?.[context.displayField]})`;
+    return `${item?.[context.displayField]}`;
   } else if ('resource' in context && context.resource) {
     const record = await Record.findById(id);
-    return `${dashboard.name} (${record.data[context.displayField]})`;
+    return `${record.data[context.displayField]}`;
   }
 
   // Default return, should never happen


### PR DESCRIPTION
# Description

Allowed display record field in front-office, when seeing a contextual dashboard.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/74443)
[frontend](https://github.com/ReliefApplications/oort-frontend/pull/1802)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested verifying if we go to a contextual dashboard in front-office the tittle of the record appears.

## Screenshots

![Peek 06-09-2023 11-19](https://github.com/ReliefApplications/oort-frontend/assets/56398308/666ce46b-f767-4468-b23e-bc2a7a54d1b0)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
