### PR TITLE
Oort feat/im 32 new notification when a user with a specific role is created

### DIFF
--- a/migrations/1694801175524-create-channel-to-role-without.ts
+++ b/migrations/1694801175524-create-channel-to-role-without.ts
@@ -1,19 +1,32 @@
 import { startDatabaseForMigration } from '../src/utils/migrations/database.helper';
 import { Role, Channel } from '@models';
 import { logger } from '../src/services/logger.service';
-/**
- * Sample function of up migration
- *
- * @returns just migrate data.
- */
+
+/** Create channel to each role that doesn't have a channel yet */
 const createChannel = async () => {
   try {
-    const queryExistingRoleChannels = { role: { $exists: true, $ne: null } };
-    const existingRoleChannels = await Channel.find(queryExistingRoleChannels);
+    // Gets all existing channels linked to a role
+    const existingRoleChannels = await Channel.find({
+      role: { $exists: true, $ne: null },
+    });
     const existingRoleIds = existingRoleChannels.map((channel) => channel._id);
 
-    const queryRole = { application: null, _id: { $nin: existingRoleIds } };
-    const role = await Role.find(queryRole);
+    // Find all roles that are not linked to a channel yet
+    const role = await Role.find({
+      application: null,
+      _id: { $nin: existingRoleIds },
+    });
+
+    if (!role.length) {
+      logger.info('No roles without a channel found');
+      return;
+    }
+
+    logger.info(
+      `Found ${role.length} roles without a channel, creating channels...`
+    );
+
+    const channelsToAdd: Channel[] = [];
 
     for (const roles of role) {
       const channel = new Channel({
@@ -21,13 +34,17 @@ const createChannel = async () => {
         role: roles._id,
       });
 
-      await channel.save();
+      channelsToAdd.push(channel);
     }
+
+    await Channel.insertMany(channelsToAdd);
+    logger.info('Channels created successfully');
   } catch (err) {
     logger.error('Error trying to execute migration', err);
   }
 };
 
+/** Starts the DB and starts migration */
 export const up = async () => {
   await startDatabaseForMigration();
   await createChannel();

--- a/src/models/channel.model.ts
+++ b/src/models/channel.model.ts
@@ -9,7 +9,7 @@ export interface Channel extends Document {
   title?: string;
   application?: any;
   form?: any;
-  role?: string;
+  role?: mongoose.Types.ObjectId;
 }
 
 /** Mongoose channel schema declaration */

--- a/src/schema/mutation/addRole.mutation.ts
+++ b/src/schema/mutation/addRole.mutation.ts
@@ -8,7 +8,6 @@ import { Role, Application, Channel } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { RoleType } from '../types';
 import { logger } from '@services/logger.service';
-import { update } from 'lodash';
 
 /**
  * Create a new role.
@@ -39,19 +38,10 @@ export default {
           title: args.title,
         });
 
-        const channel = new Channel({
-          title: `Role - ${role.title}`,
-          role: role._id,
-        });
-
         if (!application)
           throw new GraphQLError(
             context.i18next.t('common.errors.dataNotFound')
           );
-
-        if (ability.can('create', channel)) {
-          await channel.save();
-        }
 
         role.application = args.application;
         if (ability.can('create', role)) {
@@ -67,11 +57,8 @@ export default {
           role: role._id,
         });
 
-        if (ability.can('create', channel)) {
-          await channel.save();
-        }
-
         if (ability.can('create', role)) {
+          await channel.save();
           return await role.save();
         }
       }

--- a/src/schema/mutation/addRole.mutation.ts
+++ b/src/schema/mutation/addRole.mutation.ts
@@ -4,10 +4,11 @@ import {
   GraphQLID,
   GraphQLError,
 } from 'graphql';
-import { Role, Application } from '@models';
+import { Role, Application, Channel } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { RoleType } from '../types';
 import { logger } from '@services/logger.service';
+import { update } from 'lodash';
 
 /**
  * Create a new role.

--- a/src/schema/mutation/editUser.mutation.ts
+++ b/src/schema/mutation/editUser.mutation.ts
@@ -1,10 +1,4 @@
-import {
-  GraphQLNonNull,
-  GraphQLID,
-  GraphQLList,
-  GraphQLError,
-  GraphQLString,
-} from 'graphql';
+import { GraphQLNonNull, GraphQLID, GraphQLList, GraphQLError } from 'graphql';
 import permissions from '@const/permissions';
 import { Channel, Role, User, Notification } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
@@ -21,7 +15,6 @@ export default {
   type: UserType,
   args: {
     id: { type: new GraphQLNonNull(GraphQLID) },
-    name: { type: GraphQLString },
     roles: { type: new GraphQLList(GraphQLID) },
     groups: { type: new GraphQLList(GraphQLID) },
     application: { type: GraphQLID },
@@ -88,35 +81,84 @@ export default {
         }
         const update = {};
         if (args.roles) {
-          const appRoles = await User.findById(args.id).populate({
+          const editedUser = await User.findById(args.id).populate({
             path: 'roles',
-            match: { application: { $ne: null } }, // Returns roles attached to any application
+            model: 'Role',
           });
-          roles = appRoles.roles.map((x) => x._id).concat(roles);
+
+          // Need to check which roles were added and which were removed
+          // to send notifications to the respective channels
+          const originalBackOfficeRoles = editedUser.roles
+            .filter((r) => !r.application)
+            .map((r) => r._id);
+
+          // Roles not found in the original user's roles
+          const addedRoles = roles.filter(
+            (r) => !originalBackOfficeRoles.find((x) => x.equals(r))
+          );
+
+          // Roles not found in the new roles list
+          const removedRoles = originalBackOfficeRoles.filter(
+            (r) => !roles.find((x) => r.equals(x))
+          );
+
+          // Join FO and BO roles to be updated
+          roles = editedUser.roles
+            ?.filter((r) => !!r.application)
+            .map((x) => x._id)
+            .concat(roles);
           Object.assign(update, { roles: roles });
-          const userName = (await User.findById(args.id)).name;
-          const roleTitles = (
-            await Promise.all(
-              roles.map(async (role) => {
-                const roleDocument = await Role.findById(role);
-                return roleDocument.title;
-              })
-            )
-          ).join(', ');
-          roles.forEach(async (role) => {
-            const channel = await Channel.findOne({ role: role });
-            if (channel) {
+
+          // Get all roles and channels to send notifications to
+          const allRoles = await Role.find({
+            _id: { $in: addedRoles.concat(removedRoles) },
+          });
+          const allChannels = await Channel.find({
+            role: { $in: addedRoles.concat(removedRoles) },
+          });
+
+          const notifications: {
+            notification: Notification;
+            channel: Channel;
+          }[] = [];
+
+          addedRoles.forEach((r) => {
+            const role = allRoles.find((x) => x._id.equals(r));
+            const channel = allChannels.find((x) => x.role.equals(r));
+            if (role && channel) {
+              // Create notifications to role channel
               const notification = new Notification({
-                // Sending notifications when an user's back-office roles are changed for all roles involved
-                action: `${user.name} has changed the roles assigned to ${userName}: ${roleTitles}`,
-                content: user,
+                action: `New ${role.title} added: ${editedUser.username}`,
+                content: user._id,
                 channel: channel.id,
               });
-              await notification.save();
-              const publisher = await pubsub();
-              publisher.publish(channel.id, { notification });
+              notifications.push({ notification, channel });
             }
           });
+
+          removedRoles.forEach((r) => {
+            const role = allRoles.find((x) => x._id.equals(r));
+            const channel = allChannels.find((x) => x.role.equals(r));
+            if (role && channel) {
+              // Create notifications to role channel
+              const notification = new Notification({
+                action: `${role.title} removed: ${editedUser.username}`,
+                content: user._id,
+                channel: channel.id,
+              });
+              notifications.push({ notification, channel });
+            }
+          });
+
+          if (notifications.length > 0) {
+            await Notification.insertMany(
+              notifications.map((x) => x.notification)
+            );
+            const publisher = await pubsub();
+            notifications.forEach((x) => {
+              publisher.publish(x.channel.id, { notification: x.notification });
+            });
+          }
         }
         if (args.groups) {
           Object.assign(update, { groups: args.groups });


### PR DESCRIPTION
# Description

## Migration
A migration was carried out that creates a channel for roles that respect the rule below:

- There must be no channel associated with this function;
- A role must not have an `application` field associated with any (equal to null or not exist).

Name creation pattern:
- `Role - ${role.title}`

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=IM-32

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
