### PR TITLE
OORT-fix/IM-14_invisible-fields-get-back-to-visible

### DIFF
--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -25,6 +25,7 @@ import i18next from 'i18next';
 import { get, isArray } from 'lodash';
 import { logger } from '@services/logger.service';
 import checkDefaultFields from '@utils/form/checkDefaultFields';
+import { preserveChildProperties } from '@utils/form/preserveChildProperties';
 
 /**
  * List of keys of the structure's object which we want to inherit to the children forms when they are modified on the core form
@@ -309,10 +310,14 @@ export default {
                   if (storedFieldChanged) {
                     template.fields = template.fields.map((x) => {
                       // For each field of the childForm
+                      const preserveChild = preserveChildProperties(
+                        field,
+                        oldField,
+                        x
+                      );
                       return x.name === field.name // If the child field's name equals the parent field's name
-                        ? x.hasOwnProperty('defaultValue') &&
-                          !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
-                          ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
+                        ? preserveChild.preserve // If the child possesses properties that must be preserved
+                          ? preserveChild.field // Replace child's field by parent's field with child's field value
                           : field // Else replace child's field by parent's field
                         : x; // Else don't change the child's field
                     });

--- a/src/utils/form/preserveChildProperties.ts
+++ b/src/utils/form/preserveChildProperties.ts
@@ -1,0 +1,52 @@
+import { isEqual } from 'lodash';
+
+/**
+ * List of questions boolean properties that shouldn't be overwritten by updates in the parent form.
+ */
+const propertiesToPreserve = [
+  'visible', // default value is true
+  'readOnly', // default value is false
+  'isRequired', // default value is false
+];
+
+/**
+ * Checks if a child form possesses properties that must be preserved
+ * ("defaultValue" and the ones listed in the propertiesToPreserve above)
+ * by checking if the previous version of the  parent form structure field (oldField)
+ * has different properties values than the child form's structure (childField),
+ * and these will not be overwritten by updates in the parent form.
+ *
+ * @param newField parent form updated field
+ * @param oldField parent form old field saved on child previously
+ * @param childField child field
+ * @returns boolean indicating whether to preserve any child property value and the field updated
+ */
+export const preserveChildProperties = (
+  newField: any,
+  oldField: any,
+  childField: any
+): { preserve: boolean; field: any } => {
+  let preserve = false;
+  // If the child has its own "defaultValue" property
+  if (
+    childField.hasOwnProperty('defaultValue') &&
+    !isEqual(childField.defaultValue, oldField?.defaultValue)
+  ) {
+    // Replace child's field by parent's field with child's field defaultValue's value
+    newField = { ...newField, defaultValue: childField.defaultValue };
+    preserve = true;
+  }
+  // Properties where the value can be true or false, don't appear in the field
+  // if it's value is the default value (unless it is being updated),
+  // so the hasOwnProperty doesn't always work correctly
+  propertiesToPreserve.forEach((property: string) => {
+    // If the child has its own property
+    if (!isEqual(childField[property], oldField[property])) {
+      // Replace child's field by parent's field with child's field property's value
+      newField = { ...newField, [property]: childField[property] };
+      preserve = true;
+    }
+  });
+
+  return { preserve, field: newField };
+};

--- a/src/utils/form/replaceField.ts
+++ b/src/utils/form/replaceField.ts
@@ -1,5 +1,5 @@
 import { getQuestion } from './getQuestion';
-import isEqual from 'lodash/isEqual';
+import { preserveChildProperties } from './preserveChildProperties';
 
 /**
  * Check if the structure is correct and replace the chosen field by the corresponding one in the referenceStructure.
@@ -51,17 +51,17 @@ export const replaceField = (
               prevReferenceStructure,
               fieldName
             );
-            // If the edited structure's field has a defaultValue, and this defaultValue
-            // isn't equal to the previous version of the reference structure's field's defaultValue
-            if (
-              element.hasOwnProperty('defaultValue') &&
-              !isEqual(element.defaultValue, prevReferenceField?.defaultValue)
-            ) {
-              // Copy the reference structure's field into the edited structure's field, except for its defaultValue
-              editedStructure.elements[elementIndex] = {
-                ...referenceField,
-                defaultValue: element.defaultValue,
-              };
+            // If the edited structure's field has different properties than
+            // the previous version of the reference structure's field's
+            const preserveChild = preserveChildProperties(
+              referenceField,
+              prevReferenceField,
+              element
+            );
+            if (preserveChild.preserve) {
+              // Copy the reference structure's field into the edited structure's field,
+              // except for the properties it must preserve
+              editedStructure.elements[elementIndex] = preserveChild.field;
             } else {
               // Completely replace the edited structure's field by the reference structure's field
               editedStructure.elements[elementIndex] = referenceField;


### PR DESCRIPTION
# Description
Core form overwriting settings in child form: with the exception of the `defaultValue` property which was preserved during the editForm mutation, updated this and created a new method to preserve more question properties (such as invisible, readOnly and isRequired).

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/IM/boards/5?selectedIssue=IM-14

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Created a core form A and a child form B: set the question in B to invisible or required, and when updating anything in A, these changes won't be overwritenn

## Screenshots
[child.webm](https://github.com/ReliefApplications/oort-backend/assets/28535394/9ba77069-6270-45ab-a7da-b14e79f7ee67)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
