### PR TITLE
fix/AB#76616_ABC-api-configuration-edition-issues-backend

### DIFF
--- a/src/schema/mutation/editApiConfiguration.mutation.ts
+++ b/src/schema/mutation/editApiConfiguration.mutation.ts
@@ -15,6 +15,7 @@ import config from 'config';
 import { logger } from '@services/logger.service';
 import { accessibleBy } from '@casl/mongoose';
 import { graphQLAuthCheck } from '@schema/shared';
+import { isEmpty } from 'lodash';
 
 /**
  * Edit the passed apiConfiguration if authorized.
@@ -66,12 +67,6 @@ export default {
         args.endpoint && { endpoint: args.endpoint },
         args.graphQLEndpoint && { graphQLEndpoint: args.graphQLEndpoint },
         args.pingUrl && { pingUrl: args.pingUrl },
-        args.settings && {
-          settings: CryptoJS.AES.encrypt(
-            JSON.stringify(args.settings),
-            config.get('encryption.key')
-          ).toString(),
-        },
         args.permissions && { permissions: args.permissions }
       );
       const filters = ApiConfiguration.find(
@@ -79,39 +74,37 @@ export default {
       )
         .where({ _id: args.id })
         .getFilter();
-      let apiConfiguration;
-      apiConfiguration = await ApiConfiguration.findOne(filters);
-      // If there is a currently existing API configuration, get the previous value
-      // so we don't lost any other configuration that is not edited
-      if (apiConfiguration) {
-        const decrypt = await CryptoJS.AES.decrypt(
-          apiConfiguration.settings,
-          config.get('encryption.key')
-        );
-        const data = CryptoJS.enc.Utf8.stringify(decrypt);
-        const previousSettings = JSON.parse(data);
-        // Then merge current settings with the incoming ones, so they'll be overwritten the ones incoming
-        const newSettings = {
-          ...previousSettings,
-          ...args.settings,
-        };
-        // Encrypt again and add to the new update object
-        const encryptedNewSettings = CryptoJS.AES.encrypt(
-          JSON.stringify(newSettings),
-          config.get('encryption.key')
-        ).toString();
+      const api = await ApiConfiguration.findOne(filters);
+      if (api) {
+        if (args.settings) {
+          // Merge old settings & new settings to prevent some fields to be lost
+          const prevSettings = !isEmpty(api.settings)
+            ? JSON.parse(
+                CryptoJS.AES.decrypt(
+                  api.settings,
+                  config.get('encryption.key')
+                ).toString(CryptoJS.enc.Utf8)
+              )
+            : {};
+          console.log({
+            ...prevSettings,
+            ...args.settings,
+          });
+          // Encrypt again and add to the new update object, merging old and new settings
+          Object.assign(update, {
+            settings: CryptoJS.AES.encrypt(
+              JSON.stringify({
+                ...prevSettings,
+                ...args.settings,
+              }),
+              config.get('encryption.key')
+            ).toString(),
+          });
+        }
 
-        Object.assign(update, {
-          settings: encryptedNewSettings,
+        return await ApiConfiguration.findOneAndUpdate(filters, update, {
+          new: true,
         });
-      }
-      apiConfiguration = await ApiConfiguration.findOneAndUpdate(
-        filters,
-        update,
-        { new: true }
-      );
-      if (apiConfiguration) {
-        return apiConfiguration;
       } else {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')


### PR DESCRIPTION
# Description

fix: settings deletion from the db on updating just one value from the settings field by checking if the api configuration exists previously and fetching any other not edited properties so they don't get lost

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/76616)
- [Link to front-end branch if any](https://github.com/ReliefApplications/oort-frontend/pull/1937)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
