### PR TITLE
fix/AB#73344_number_filter_not_considering_string_numbers

### DIFF
--- a/src/utils/filter/getFilter.ts
+++ b/src/utils/filter/getFilter.ts
@@ -81,7 +81,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                   $or: [
                     { [fieldName]: { $eq: value } },
                     { [fieldName]: { $eq: intValue } },
-                    { [fieldName]: { $eq: '' + parseInt(value) } }
+                    { [fieldName]: { $eq: '' + parseInt(value) } },
                   ],
                 };
               }
@@ -100,7 +100,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                   $or: [
                     { [fieldName]: { $ne: value } },
                     { [fieldName]: { $ne: intValue } },
-                    { [fieldName]: { $ne: '' + parseInt(value) } }
+                    { [fieldName]: { $ne: '' + parseInt(value) } },
                   ],
                 };
               }
@@ -125,7 +125,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                 $or: [
                   { [fieldName]: { $lt: value } },
                   { [fieldName]: { $lt: intValue } },
-                  { [fieldName]: { $lt: '' + parseInt(value) } }
+                  { [fieldName]: { $lt: '' + parseInt(value) } },
                 ],
               };
             }
@@ -138,7 +138,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                 $or: [
                   { [fieldName]: { $lte: value } },
                   { [fieldName]: { $lte: intValue } },
-                  { [fieldName]: { $lte: '' + parseInt(value) } }
+                  { [fieldName]: { $lte: '' + parseInt(value) } },
                 ],
               };
             }
@@ -151,7 +151,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                 $or: [
                   { [fieldName]: { $gt: value } },
                   { [fieldName]: { $gt: intValue } },
-                  { [fieldName]: { $gt: '' + parseInt(value) } }
+                  { [fieldName]: { $gt: '' + parseInt(value) } },
                 ],
               };
             }
@@ -164,7 +164,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                 $or: [
                   { [fieldName]: { $gte: value } },
                   { [fieldName]: { $gte: intValue } },
-                  { [fieldName]: { $gte: '' + parseInt(value) } }
+                  { [fieldName]: { $gte: '' + parseInt(value) } },
                 ],
               };
             }

--- a/src/utils/filter/getFilter.ts
+++ b/src/utils/filter/getFilter.ts
@@ -66,8 +66,6 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
               break;
             }
         }
-        console.log(value);
-        console.log(intValue);
         switch (filter.operator) {
           case 'eq': {
             if (MULTISELECT_TYPES.includes(field.type)) {

--- a/src/utils/filter/getFilter.ts
+++ b/src/utils/filter/getFilter.ts
@@ -81,6 +81,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                   $or: [
                     { [fieldName]: { $eq: value } },
                     { [fieldName]: { $eq: intValue } },
+                    { [fieldName]: { $eq: '' + parseInt(value) } }
                   ],
                 };
               }
@@ -99,6 +100,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                   $or: [
                     { [fieldName]: { $ne: value } },
                     { [fieldName]: { $ne: intValue } },
+                    { [fieldName]: { $ne: '' + parseInt(value) } }
                   ],
                 };
               }
@@ -123,6 +125,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                 $or: [
                   { [fieldName]: { $lt: value } },
                   { [fieldName]: { $lt: intValue } },
+                  { [fieldName]: { $lt: '' + parseInt(value) } }
                 ],
               };
             }
@@ -135,6 +138,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                 $or: [
                   { [fieldName]: { $lte: value } },
                   { [fieldName]: { $lte: intValue } },
+                  { [fieldName]: { $lte: '' + parseInt(value) } }
                 ],
               };
             }
@@ -147,6 +151,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                 $or: [
                   { [fieldName]: { $gt: value } },
                   { [fieldName]: { $gt: intValue } },
+                  { [fieldName]: { $gt: '' + parseInt(value) } }
                 ],
               };
             }
@@ -159,6 +164,7 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
                 $or: [
                   { [fieldName]: { $gte: value } },
                   { [fieldName]: { $gte: intValue } },
+                  { [fieldName]: { $gte: '' + parseInt(value) } }
                 ],
               };
             }

--- a/src/utils/filter/getFilter.ts
+++ b/src/utils/filter/getFilter.ts
@@ -66,6 +66,8 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
               break;
             }
         }
+        console.log(value);
+        console.log(intValue);
         switch (filter.operator) {
           case 'eq': {
             if (MULTISELECT_TYPES.includes(field.type)) {
@@ -79,9 +81,9 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
               } else {
                 return {
                   $or: [
-                    { [fieldName]: { $eq: value } },
+                    // Make sure that we check on number & string values
+                    { [fieldName]: { $eq: String(value) } },
                     { [fieldName]: { $eq: intValue } },
-                    { [fieldName]: { $eq: '' + parseInt(value) } },
                   ],
                 };
               }
@@ -98,9 +100,8 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
               } else {
                 return {
                   $or: [
-                    { [fieldName]: { $ne: value } },
+                    { [fieldName]: { $ne: String(value) } },
                     { [fieldName]: { $ne: intValue } },
-                    { [fieldName]: { $ne: '' + parseInt(value) } },
                   ],
                 };
               }
@@ -123,9 +124,8 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
             } else {
               return {
                 $or: [
-                  { [fieldName]: { $lt: value } },
+                  { [fieldName]: { $lt: String(value) } },
                   { [fieldName]: { $lt: intValue } },
-                  { [fieldName]: { $lt: '' + parseInt(value) } },
                 ],
               };
             }
@@ -136,9 +136,8 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
             } else {
               return {
                 $or: [
-                  { [fieldName]: { $lte: value } },
+                  { [fieldName]: { $lte: String(value) } },
                   { [fieldName]: { $lte: intValue } },
-                  { [fieldName]: { $lte: '' + parseInt(value) } },
                 ],
               };
             }
@@ -149,9 +148,8 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
             } else {
               return {
                 $or: [
-                  { [fieldName]: { $gt: value } },
+                  { [fieldName]: { $gt: String(value) } },
                   { [fieldName]: { $gt: intValue } },
-                  { [fieldName]: { $gt: '' + parseInt(value) } },
                 ],
               };
             }
@@ -162,9 +160,8 @@ const buildMongoFilter = (filter: any, fields: any[]): any => {
             } else {
               return {
                 $or: [
-                  { [fieldName]: { $gte: value } },
+                  { [fieldName]: { $gte: String(value) } },
                   { [fieldName]: { $gte: intValue } },
-                  { [fieldName]: { $gte: '' + parseInt(value) } },
                 ],
               };
             }

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -243,6 +243,7 @@ const buildMongoFilter = (
                   $or: [
                     { [fieldName]: { $eq: value } },
                     { [fieldName]: { $eq: intValue } },
+                    { [fieldName]: { $eq: '' + parseInt(value) } }
                   ],
                 };
               }
@@ -264,6 +265,7 @@ const buildMongoFilter = (
                   $and: [
                     { [fieldName]: { $ne: value } },
                     { [fieldName]: { $ne: intValue } },
+                    { [fieldName]: { $ne: '' + parseInt(value) } }
                   ],
                 };
               }
@@ -288,6 +290,7 @@ const buildMongoFilter = (
                 $or: [
                   { [fieldName]: { $lt: value } },
                   { [fieldName]: { $lt: intValue } },
+                  { [fieldName]: { $lt: '' + parseInt(value) } }
                 ],
               };
             }
@@ -300,6 +303,7 @@ const buildMongoFilter = (
                 $or: [
                   { [fieldName]: { $lte: value } },
                   { [fieldName]: { $lte: intValue } },
+                  { [fieldName]: { $lte: '' + parseInt(value) } }
                 ],
               };
             }
@@ -312,6 +316,7 @@ const buildMongoFilter = (
                 $or: [
                   { [fieldName]: { $gt: value } },
                   { [fieldName]: { $gt: intValue } },
+                  { [fieldName]: { $gt: '' + parseInt(value) } }
                 ],
               };
             }
@@ -324,6 +329,7 @@ const buildMongoFilter = (
                 $or: [
                   { [fieldName]: { $gte: value } },
                   { [fieldName]: { $gte: intValue } },
+                  { [fieldName]: { $gte: '' + parseInt(value) } }
                 ],
               };
             }

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -243,7 +243,7 @@ const buildMongoFilter = (
                   $or: [
                     { [fieldName]: { $eq: value } },
                     { [fieldName]: { $eq: intValue } },
-                    { [fieldName]: { $eq: '' + parseInt(value) } }
+                    { [fieldName]: { $eq: '' + parseInt(value) } },
                   ],
                 };
               }
@@ -265,7 +265,7 @@ const buildMongoFilter = (
                   $and: [
                     { [fieldName]: { $ne: value } },
                     { [fieldName]: { $ne: intValue } },
-                    { [fieldName]: { $ne: '' + parseInt(value) } }
+                    { [fieldName]: { $ne: '' + parseInt(value) } },
                   ],
                 };
               }
@@ -290,7 +290,7 @@ const buildMongoFilter = (
                 $or: [
                   { [fieldName]: { $lt: value } },
                   { [fieldName]: { $lt: intValue } },
-                  { [fieldName]: { $lt: '' + parseInt(value) } }
+                  { [fieldName]: { $lt: '' + parseInt(value) } },
                 ],
               };
             }
@@ -303,7 +303,7 @@ const buildMongoFilter = (
                 $or: [
                   { [fieldName]: { $lte: value } },
                   { [fieldName]: { $lte: intValue } },
-                  { [fieldName]: { $lte: '' + parseInt(value) } }
+                  { [fieldName]: { $lte: '' + parseInt(value) } },
                 ],
               };
             }
@@ -316,7 +316,7 @@ const buildMongoFilter = (
                 $or: [
                   { [fieldName]: { $gt: value } },
                   { [fieldName]: { $gt: intValue } },
-                  { [fieldName]: { $gt: '' + parseInt(value) } }
+                  { [fieldName]: { $gt: '' + parseInt(value) } },
                 ],
               };
             }
@@ -329,7 +329,7 @@ const buildMongoFilter = (
                 $or: [
                   { [fieldName]: { $gte: value } },
                   { [fieldName]: { $gte: intValue } },
-                  { [fieldName]: { $gte: '' + parseInt(value) } }
+                  { [fieldName]: { $gte: '' + parseInt(value) } },
                 ],
               };
             }

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -225,6 +225,8 @@ const buildMongoFilter = (
               break;
             }
         }
+        console.log(typeof value);
+        console.log(typeof intValue);
         switch (filter.operator) {
           case 'eq': {
             // user attributes
@@ -241,9 +243,9 @@ const buildMongoFilter = (
               } else {
                 return {
                   $or: [
-                    { [fieldName]: { $eq: value } },
+                    // Make sure that we compare both strings & numbers
+                    { [fieldName]: { $eq: String(value) } },
                     { [fieldName]: { $eq: intValue } },
-                    { [fieldName]: { $eq: '' + parseInt(value) } },
                   ],
                 };
               }
@@ -263,9 +265,8 @@ const buildMongoFilter = (
               } else {
                 return {
                   $and: [
-                    { [fieldName]: { $ne: value } },
+                    { [fieldName]: { $ne: String(value) } },
                     { [fieldName]: { $ne: intValue } },
-                    { [fieldName]: { $ne: '' + parseInt(value) } },
                   ],
                 };
               }
@@ -288,9 +289,8 @@ const buildMongoFilter = (
             } else {
               return {
                 $or: [
-                  { [fieldName]: { $lt: value } },
+                  { [fieldName]: { $lt: String(value) } },
                   { [fieldName]: { $lt: intValue } },
-                  { [fieldName]: { $lt: '' + parseInt(value) } },
                 ],
               };
             }
@@ -301,9 +301,8 @@ const buildMongoFilter = (
             } else {
               return {
                 $or: [
-                  { [fieldName]: { $lte: value } },
+                  { [fieldName]: { $lte: String(value) } },
                   { [fieldName]: { $lte: intValue } },
-                  { [fieldName]: { $lte: '' + parseInt(value) } },
                 ],
               };
             }
@@ -314,9 +313,8 @@ const buildMongoFilter = (
             } else {
               return {
                 $or: [
-                  { [fieldName]: { $gt: value } },
+                  { [fieldName]: { $gt: String(value) } },
                   { [fieldName]: { $gt: intValue } },
-                  { [fieldName]: { $gt: '' + parseInt(value) } },
                 ],
               };
             }
@@ -327,9 +325,8 @@ const buildMongoFilter = (
             } else {
               return {
                 $or: [
-                  { [fieldName]: { $gte: value } },
+                  { [fieldName]: { $gte: String(value) } },
                   { [fieldName]: { $gte: intValue } },
-                  { [fieldName]: { $gte: '' + parseInt(value) } },
                 ],
               };
             }

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -225,8 +225,6 @@ const buildMongoFilter = (
               break;
             }
         }
-        console.log(typeof value);
-        console.log(typeof intValue);
         switch (filter.operator) {
           case 'eq': {
             // user attributes


### PR DESCRIPTION
# Description

Fixed: In the grids when we have a field type number and try to filter, it only considers number values, now we also check for string numbers like "1".

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/73344)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested creating a form with number type question, and then filling the database with a string type value instead of number, and then trying to filter it.

## Screenshots

![Peek 12-10-2023 16-02](https://github.com/ReliefApplications/oort-backend/assets/56398308/b1263761-f935-4e2c-b350-9fdc0bad723b)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
