### PR TITLE
Fix/hit 166 error trying to duplicate resources

### DIFF
--- a/src/schema/mutation/duplicateResource.mutation.ts
+++ b/src/schema/mutation/duplicateResource.mutation.ts
@@ -121,7 +121,7 @@ export default {
       for (const form of forms) {
         // Add a random string at the end of the name to make it unique
         const randomString = Math.random().toString(36).substring(7);
-        let newNameForm = form.name.split('-')[0] + '-' + randomString;
+        const newNameForm = form.name.split('-')[0] + '-' + randomString;
 
         const duplicatedForm = new Form({
           name: newNameForm,

--- a/src/schema/mutation/duplicateResource.mutation.ts
+++ b/src/schema/mutation/duplicateResource.mutation.ts
@@ -119,9 +119,13 @@ export default {
 
       // Duplicate forms with new resource id
       for (const form of forms) {
+        // Add a random string at the end of the name to make it unique
+        const randomString = Math.random().toString(36).substring(7);
+        let newNameForm = form.name.split('-')[0] + '-' + randomString;
+
         const duplicatedForm = new Form({
-          name: newName,
-          graphQLTypeName: newName,
+          name: newNameForm,
+          graphQLTypeName: newNameForm,
           core: form.core,
           status: 'pending',
           permissions: [],


### PR DESCRIPTION
# Description

The issue arose when duplicating a resource with multiple linked forms; the code do not generate new graphQLTypeName for each form, resulting in a "E11000 duplicate key error collection." The resolution involved creating a distinct newFormName for each duplicated form.

<img width="1088" alt="Screenshot 2023-11-14 at 23 16 38" src="https://github.com/ReliefApplications/ems-backend/assets/24783896/29ca5d37-2343-4d76-97b9-57d70253c710">


## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-166
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/ems-frontend/pull/2072
- Original PR: https://github.com/ReliefApplications/ems-backend/pull/831

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verifying the duplication of resources, whether when has a single or multiple forms.

## Screenshots

Before:

https://github.com/ReliefApplications/ems-backend/assets/24783896/4b9a14aa-6ae0-428c-a37d-4c51b3ef20ac



After:

https://github.com/ReliefApplications/ems-backend/assets/24783896/6f079d67-1038-4bec-9ae5-0ae4974a0e57








# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
