### PR TITLE
Initial version of label stage (backend)

### DIFF
--- a/src/const/aggregation.ts
+++ b/src/const/aggregation.ts
@@ -7,6 +7,7 @@ export enum PipelineStage {
   ADD_FIELDS = 'addFields',
   UNWIND = 'unwind',
   CUSTOM = 'custom',
+  LABEL = 'label',
 }
 
 /** Mongoose accumulators enum definition */

--- a/src/schema/mutation/editWorkflow.mutation.ts
+++ b/src/schema/mutation/editWorkflow.mutation.ts
@@ -57,7 +57,6 @@ export default {
         args.name && { name: args.name },
         args.steps && { steps: args.steps }
       );
-      logger.info('update ==>> ', update);
       workflow = await Workflow.findByIdAndUpdate(args.id, update, {
         new: true,
       });

--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -323,8 +323,13 @@ const buildPipeline = (
                                                   (choice) => ({
                                                     case: {
                                                       $eq: [
-                                                        '$$value',
-                                                        choice.value,
+                                                        {
+                                                          $toString: '$$value',
+                                                        },
+                                                        {
+                                                          $toString:
+                                                            choice.value,
+                                                        },
                                                       ],
                                                     },
                                                     then: choice.text,

--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -278,6 +278,18 @@ const buildPipeline = (
             (item) => item.name === stage.form.field
           ).choices;
 
+          const questionMatrixChoices = [];
+          questionsWithChoices
+            .find((item) => item.name === stage.form.field)
+            .columns?.forEach((column: any) => {
+              const columnName: string = column.name;
+              if (column.choices) {
+                questionMatrixChoices[columnName] = column.choices;
+              } else {
+                questionMatrixChoices[columnName] = questionChoices;
+              }
+            });
+
           switch (questionType) {
             // Matrixdropdown is an object of objects of either arrays or single values
             case 'matrixdropdown': {
@@ -319,7 +331,7 @@ const buildPipeline = (
                                                   })
                                                 ),
                                               ],
-                                              default: 'value',
+                                              default: '$$value',
                                             },
                                           },
                                         },

--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -86,6 +86,12 @@ export const extractFields = async (object, fields, core): Promise<void> => {
                 name: x.name,
                 label: x.title,
                 type: x.cellType ? x.cellType : element.cellType,
+                choices: x.choices?.map((y) => {
+                  return {
+                    value: y.value ? y.value : y,
+                    text: y.text ? y.text : y,
+                  };
+                }),
               };
             }),
             choices: element.choices.map((x) => {
@@ -121,6 +127,12 @@ export const extractFields = async (object, fields, core): Promise<void> => {
                 name: x.name,
                 type: x.cellType,
                 label: x.title,
+                choices: x.choices?.map((y) => {
+                  return {
+                    value: y.value ? y.value : y,
+                    text: y.text ? y.text : y,
+                  };
+                }),
               };
             }),
             choices: element.choices.map((x) => {


### PR DESCRIPTION
# Description

Included "Label" stage for the aggregation builder, which replaces the values of the answers with their texts.

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-192
- https://github.com/ReliefApplications/oort-frontend/tree/HIT-192-add-label-stage-to-aggregation-builder

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Have been tested with:
      'dropdown',
      'checkbox',
      'radiogroup',
      'tagbox',
      'matrixdropdown',
      'matrixdynamic'

- Matrixdropdown and matrixdynamic only work for the matrix choices right now, not choices internal to each column

## Screenshots

![image](https://github.com/ReliefApplications/oort-backend/assets/39497117/e31be92a-f2da-43b7-a0cf-11c8ec162a3d)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings

# To do:

- Make it work for choices internal to the matrix according to questionMatrixChoices