### PR TITLE
fix/HIT-210_Internal-error-when-modifying-role-permissions

### DIFF
--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -159,7 +159,7 @@ const checkFieldPermission = (
           )
         );
       }
-      if (!get(field, 'permissions.canSee', []).find((p) => p.equals(role))) {
+      if (!get(field, 'permissions.canSee', []).find((p) => p === role)) {
         throw new GraphQLError(
           context.i18next.t('mutations.resource.edit.errors.field.notVisible')
         );


### PR DESCRIPTION
# Description

The permission to allow editing of certain questions in a form creates an internal error. 
It happened with a few questions (but not all) and only for updating, not the visibility. I couldn’t identify a pattern except that it was for questions created more or less recently (in the last 2 months basically, for which I hadn’t changed the default permission yet). Some are expression questions, but not all. 
So far I had ‘question19’, ‘campaign’, ‘campaign_name’ ‘case_priority_next_action_m’ for the Register a complaint resource.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-210

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


## Screenshots

Before:

https://github.com/ReliefApplications/oort-backend/assets/24783896/078207e5-e0fc-467a-80d2-412bde13bbf6


After:

https://github.com/ReliefApplications/oort-backend/assets/24783896/a8eeb8fb-0048-4fa0-95ae-6483358879b2


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
