### PR TITLE
HIT-211: Added 'in', 'notin', 'issubset', 'isnotsubset' operators for context filters

### DIFF
--- a/src/security/extendAbilityForContent.ts
+++ b/src/security/extendAbilityForContent.ts
@@ -48,11 +48,16 @@ export default async function extendAbilityForContent(
             $in: [
               content._id,
               {
-                $map: {
-                  input: '$contentWithContext',
-                  as: 'c',
-                  in: '$$c.content',
-                },
+                $ifNull: [
+                  {
+                    $map: {
+                      input: '$contentWithContext',
+                      as: 'c',
+                      in: '$$c.content',
+                    },
+                  },
+                  [],
+                ],
               },
             ],
           },

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -232,10 +232,6 @@ const buildMongoFilter = (
           return { [fieldName]: { $regex: '^' + v, $options: 'i' } };
         case 'endswith':
           return { [fieldName]: { $regex: v + '$', $options: 'i' } };
-        case 'inArray':
-          return { [fieldName]: { $in: v } };
-        case 'notInArray':
-          return { [fieldName]: { $not: { $in: v } } };
         case 'in':
         case 'contains':
           return { [fieldName]: { $regex: v, $options: 'i' } };
@@ -372,10 +368,15 @@ const buildMongoFilter = (
           return {
             [fieldName]: { $not: { $size: v.length, $all: v } },
           };
-        case 'inArray':
+        case 'in':
+        case 'intersects':
           return { [fieldName]: { $in: v } };
-        case 'notInArray':
-          return { [fieldName]: { $not: { $in: v } } };
+        case 'notin':
+          return { [fieldName]: { $nin: v } };
+        case 'issubset':
+          return { [fieldName]: { $all: v } };
+        case 'isnotsubset':
+          return { $not: { [fieldName]: { $all: v } } };
         case 'contains':
           return { [fieldName]: { $all: v } };
         case 'doesnotcontain':

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -373,10 +373,9 @@ const buildMongoFilter = (
           return { [fieldName]: { $in: v } };
         case 'notin':
           return { [fieldName]: { $nin: v } };
-        case 'issubset':
-          return { [fieldName]: { $all: v } };
         case 'isnotsubset':
           return { $not: { [fieldName]: { $all: v } } };
+        case 'issubset':
         case 'contains':
           return { [fieldName]: { $all: v } };
         case 'doesnotcontain':

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -232,6 +232,10 @@ const buildMongoFilter = (
           return { [fieldName]: { $regex: '^' + v, $options: 'i' } };
         case 'endswith':
           return { [fieldName]: { $regex: v + '$', $options: 'i' } };
+        case 'inArray':
+          return { [fieldName]: { $in: v } };
+        case 'notInArray':
+          return { [fieldName]: { $not: { $in: v } } };
         case 'in':
         case 'contains':
           return { [fieldName]: { $regex: v, $options: 'i' } };
@@ -368,6 +372,10 @@ const buildMongoFilter = (
           return {
             [fieldName]: { $not: { $size: v.length, $all: v } },
           };
+        case 'inArray':
+          return { [fieldName]: { $in: v } };
+        case 'notInArray':
+          return { [fieldName]: { $not: { $in: v } } };
         case 'contains':
           return { [fieldName]: { $all: v } };
         case 'doesnotcontain':


### PR DESCRIPTION
# Description

Added the operators 'in' ('intersects'), 'notin', 'issubset' and 'isnotsubset' for context filters for arrays.

- 'in' or 'intersects' returns any records containing any value specified directly or in the dashboard filter.
- 'notin' returns any records not containing any value specified directly or in the dashboard filter.
- 'issubset' returns any records containing all values specified directly or in the dashboard filter.
- 'isnotsubset' returns any records that do not contain all values specified directly or in the dashboard filter.

It is worth mentioning that these operators are just for arrays and won't work for singular inputs such as string. Any records created before a question type is changed from singular input to array in the form will not work properly with these (such as the region field from staff in LIFT demo).

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-211
- Frontend pull request: https://github.com/ReliefApplications/oort-frontend/pull/33

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested by setting up a dropdown question and a multi-select dropdown question and a corresponding dropdown and multi-select dropdown dashboard filter, using both direct string and non-string values and values from reference data.
- Tested by setting up boolean and numeric questions and their corresponding dashboard filter questions.

## Screenshots

![image](https://github.com/ReliefApplications/oort-backend/assets/39497117/8f0510f6-991c-49b3-a1ec-7ddb004c89ff)
![image](https://github.com/ReliefApplications/oort-backend/assets/39497117/4509f4d4-f2f8-41cb-9b9f-c32cc921b8a4)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
