### PR TITLE
HIT-71-still-an-error-message-when-saving-register-a-complaint-although-changes-are-still-saved

### DIFF
--- a/src/utils/form/preserveChildProperties.ts
+++ b/src/utils/form/preserveChildProperties.ts
@@ -41,7 +41,7 @@ export const preserveChildProperties = (
   // so the hasOwnProperty doesn't always work correctly
   propertiesToPreserve.forEach((property: string) => {
     // If the child has its own property
-    if (!isEqual(childField[property], oldField[property])) {
+    if (!isEqual(childField?.[property], oldField?.[property])) {
       // Replace child's field by parent's field with child's field property's value
       newField = { ...newField, [property]: childField[property] };
       preserve = true;


### PR DESCRIPTION
# Description
Looks like the problem was when saving the fields for the child forms

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-71

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Saving the form

## Screenshots
[video2.webm](https://github.com/ReliefApplications/oort-backend/assets/28535394/57d1fa4e-6aad-4b5f-9b64-befb0ef20940)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
