### PR TITLE
fix/HIT-219_Dashboard-filter-working-only-if-field-is-selected-in-the-aggregation

### DIFF
--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -103,9 +103,10 @@ const extractSourceFields = (
     if (
       typeof filter.field === 'string' &&
       !fields.includes(filter.field) &&
-      allFields.concat(DEFAULT_FIELDS).includes(filter.field)
-    )
-      fields.push(filter.field);
+      allFields.concat(DEFAULT_FIELDS).includes(filter.field.split('.')[0])
+    ) {
+      fields.push(filter.field.split('.')[0]);
+    }
   }
 };
 


### PR DESCRIPTION
# Description

Dashboard filter working only if field is selected in the aggregation

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-219

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Adding filter for region on context filter

## Screenshots

<img width="1440" alt="Screenshot 2024-01-18 at 08 20 58" src="https://github.com/ReliefApplications/oort-backend/assets/24783896/eab8346e-542b-47b4-9f19-555c5feee92a">


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
