### PR TITLE
HIT-229 dashboard filter doesnt work on widgets that dont have the field to be filtered from in its aggregation

### DIFF
--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -102,7 +102,7 @@ const extractSourceFields = (
   } else if (filter.field) {
     if (
       typeof filter.field === 'string' &&
-      !fields.includes(filter.field) &&
+      !fields.includes(filter.field.split('.')[0]) &&
       allFields.concat(DEFAULT_FIELDS).includes(filter.field.split('.')[0])
     ) {
       fields.push(filter.field.split('.')[0]);


### PR DESCRIPTION
# Description

Setting a dashboard filter for a reference data field would crash the widget when the widget aggregation included the field because extractSourceFields would append the field twice, causing problems.

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-229

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Set a widget that uses an aggregation which includes a field. Set a dashboard filter regarding the same field. It should work now for widgets that includes that field or not.

## Screenshots

![chrome-capture-2024-0-29](https://github.com/ReliefApplications/oort-backend/assets/39497117/888dc02e-6da3-4f4d-83f1-578a0ee5a5c5)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
