### PR TITLE
HIT-249-ability-to-upload-excel-from-front-office

### DIFF
--- a/src/models/form.model.ts
+++ b/src/models/form.model.ts
@@ -40,6 +40,7 @@ interface FormDocument extends Document {
     padding: number;
   };
   importField: string;
+  allowUploadRecords: boolean;
   graphQLTypeName?: string;
   createdAt?: Date;
   modifiedAt?: Date;
@@ -90,6 +91,7 @@ const schema = new Schema<Form>(
       type: String,
       default: DEFAULT_IMPORT_FIELD.incID,
     },
+    allowUploadRecords: Boolean,
     graphQLTypeName: String,
     structure: mongoose.Schema.Types.Mixed,
     core: Boolean,

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -236,6 +236,9 @@ export default {
         update.importField =
           structure.importField || DEFAULT_IMPORT_FIELD.incID;
 
+        // Save the allowUploadRecords
+        update.allowUploadRecords = structure.allowUploadRecords ?? false;
+
         const fields = [];
         for (const page of structure.pages) {
           await extractFields(page, fields, form.core);

--- a/src/schema/types/form.type.ts
+++ b/src/schema/types/form.type.ts
@@ -48,6 +48,7 @@ export const FormType = new GraphQLObjectType({
     modifiedAt: { type: GraphQLString },
     structure: { type: GraphQLJSON },
     status: { type: StatusEnumType },
+    allowUploadRecords: { type: GraphQLBoolean },
     permissions: {
       type: AccessType,
       async resolve(parent, args, context) {


### PR DESCRIPTION
# Description
Added to the form model new propriety allowUploadRecords

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-249
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/oort-frontend/pull/53

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Using the new propriety in the front-end.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
