### PR TITLE
feat/HIT-261-unique-check

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -208,6 +208,9 @@
 					"invalidArguments": "Either data or version must be provided.",
 					"wrongTemplateProvided": "Template must sharing the same resource as the parent form of the edited record."
 				}
+			},
+			"errors": {
+				"missingParameters": "Missing query parameters: record id or uniqueField and uniqueValue"
 			}
 		},
 		"reference": {

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -208,6 +208,9 @@
 					"invalidArguments": "******",
 					"wrongTemplateProvided": "******"
 				}
+			},
+			"errors": {
+				"missingParameters": "******"
 			}
 		},
 		"reference": {

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -1,5 +1,4 @@
 import {
-  GraphQLNonNull,
   GraphQLID,
   GraphQLError,
   GraphQLString,
@@ -57,7 +56,9 @@ export const hasInaccessibleFields = (
 
 /** Arguments for the editRecord mutation */
 type EditRecordArgs = {
-  id: string | Types.ObjectId;
+  id?: string | Types.ObjectId;
+  uniqueField?: string;
+  uniqueValue?: string;
   data?: any;
   version?: string | Types.ObjectId;
   template?: string | Types.ObjectId;
@@ -72,7 +73,9 @@ type EditRecordArgs = {
 export default {
   type: RecordType,
   args: {
-    id: { type: new GraphQLNonNull(GraphQLID) },
+    id: { type: GraphQLID },
+    uniqueField: { type: GraphQLString },
+    uniqueValue: { type: GraphQLString },
     data: { type: GraphQLJSON },
     version: { type: GraphQLID },
     template: { type: GraphQLID },
@@ -90,10 +93,27 @@ export default {
         );
       }
 
-      const user = context.user;
+      if (!(args.uniqueField && args.uniqueValue) && !args.id) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.record.errors.missingParameters')
+        );
+      }
 
-      // Get record and form
-      const oldRecord: Record = await Record.findById(args.id);
+      const user = context.user;
+      // Get record
+      let oldRecord: Record;
+      if (args.id) {
+        oldRecord = await Record.findById(args.id);
+      } else if (args.uniqueField && args.uniqueValue) {
+        const query = {};
+        query[`data.${args.uniqueField}`] = args.uniqueValue;
+        oldRecord = await Record.findOne(query);
+      }
+      if (!oldRecord) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+      const oldRecordId = oldRecord.id;
+      // Get form
       const parentForm: Form = await Form.findById(
         oldRecord.form,
         'fields permissions resource structure'
@@ -202,7 +222,9 @@ export default {
           update,
           ownership && { createdBy: { ...oldRecord.createdBy, ...ownership } }
         );
-        const record = Record.findByIdAndUpdate(args.id, update, { new: true });
+        const record = Record.findByIdAndUpdate(oldRecordId, update, {
+          new: true,
+        });
         await version.save();
         return await record;
       } else {
@@ -233,7 +255,9 @@ export default {
           },
           $push: { versions: version._id },
         };
-        const record = Record.findByIdAndUpdate(args.id, update, { new: true });
+        const record = Record.findByIdAndUpdate(oldRecordId, update, {
+          new: true,
+        });
         await version.save();
         return await record;
       }

--- a/src/schema/query/record.query.ts
+++ b/src/schema/query/record.query.ts
@@ -1,4 +1,4 @@
-import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
+import { GraphQLID, GraphQLError, GraphQLString } from 'graphql';
 import { Form, Record } from '@models';
 import { RecordType } from '../types';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
@@ -10,7 +10,9 @@ import { Context } from '@server/apollo/context';
 
 /** Arguments for the record query */
 type RecordArgs = {
-  id: string | Types.ObjectId;
+  id?: string | Types.ObjectId;
+  uniqueField?: string;
+  uniqueValue?: string;
 };
 
 /**
@@ -20,14 +22,34 @@ type RecordArgs = {
 export default {
   type: RecordType,
   args: {
-    id: { type: new GraphQLNonNull(GraphQLID) },
+    id: { type: GraphQLID },
+    uniqueField: { type: GraphQLString },
+    uniqueValue: { type: GraphQLString },
   },
   async resolve(parent, args: RecordArgs, context: Context) {
     graphQLAuthCheck(context);
     try {
       const user = context.user;
       // Get the form and the record
-      const record = await Record.findById(args.id);
+      if (!(args.uniqueField && args.uniqueValue) && !args.id) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.record.errors.missingParameters')
+        );
+      }
+
+      let record: Record;
+      if (args.id) {
+        record = await Record.findById(args.id);
+      } else if (args.uniqueField && args.uniqueValue) {
+        const query = {};
+        query[`data.${args.uniqueField}`] = args.uniqueValue;
+        record = await Record.findOne(query);
+      }
+
+      if (!record) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+
       const form = await Form.findById(record.form);
 
       // Check ability


### PR DESCRIPTION
# Description

Updated the editRecord mutation and the record query to accept a uniqueValue and uniqueField instead of the record id to get/edit a record. The id is not longer required, but if missing, the other 2 params must be provided or a error will be raised 

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-261
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/oort-frontend/pull/62

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Using instead of record id the uniqueValue and uniqueField as params to the editRecord mutation and the record query

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
