### PR TITLE
feat/HIT-274-add-new-type-of-permission-to-delete-application

### DIFF
--- a/src/const/permissions.ts
+++ b/src/const/permissions.ts
@@ -7,6 +7,7 @@ const permissions = {
   canSeeGroups: 'can_see_groups',
   canSeeApplications: 'can_see_applications',
   canCreateApplications: 'can_create_applications',
+  canDeleteApplications: 'can_delete_applications',
   canCreateForms: 'can_create_forms',
   canCreateResources: 'can_create_resources',
   canManageApiConfigurations: 'can_manage_api_configurations',

--- a/src/schema/mutation/deleteApplication.mutation.ts
+++ b/src/schema/mutation/deleteApplication.mutation.ts
@@ -30,6 +30,12 @@ export default {
     try {
       // Delete the application
       const ability: AppAbility = context.user.ability;
+      if (!ability.can('delete', 'Application')) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
       const filters = Application.find(
         accessibleBy(ability, 'delete').Application
       )

--- a/src/security/defineUserAbility.ts
+++ b/src/security/defineUserAbility.ts
@@ -162,6 +162,13 @@ export default function defineUserAbility(user: User | Client): AppAbility {
   }
 
   /* ===
+    Deletion of applications
+  === */
+  if (userGlobalPermissions.includes(permissions.canDeleteApplications)) {
+    can('delete', 'Application');
+  }
+
+  /* ===
     Creation / Access / Edition / Deletion of applications
   === */
   if (userGlobalPermissions.includes(permissions.canManageApplications)) {
@@ -181,7 +188,7 @@ export default function defineUserAbility(user: User | Client): AppAbility {
     );
   } else {
     can('update', ['Application', 'Page', 'Step'], filters('canUpdate', user));
-    can('delete', ['Application', 'Page', 'Step'], filters('canDelete', user));
+    can('delete', ['Page', 'Step'], filters('canDelete', user));
   }
 
   /* ===

--- a/src/server/database.ts
+++ b/src/server/database.ts
@@ -95,6 +95,7 @@ export const initDatabase = async () => {
       'can_create_resources',
       'can_manage_resources',
       'can_manage_applications',
+      'can_delete_applications',
       'can_manage_api_configurations',
       'can_create_applications',
       'can_manage_layer',


### PR DESCRIPTION
# Description
Created the permission can_delete_applications. Please remember to run `npm run buid` to created the permission in the db

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-274
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/oort-frontend/pull/83

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Trying to deleting applications with and without the permission (and without the can_manage_applications permission)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
