### PR TITLE
feat/HIT-315_uploading_records_with_columns_out_of_order

### DIFF
--- a/src/routes/upload/index.ts
+++ b/src/routes/upload/index.ts
@@ -131,7 +131,9 @@ async function insertRecords(
       string,
       { ids: unknown[]; fields: any[] }
     >();
-    const resourcePerColumn = columns.map((column, idx) => {
+    // sort columns by index
+    const sortedColumns = columns.sort((a, b) => a.index - b.index);
+    const resourcePerColumn = sortedColumns.map((column) => {
       // Extract all the question info from the form structure
       const question = form.fields.find((field) => field.name === column.name);
 
@@ -144,7 +146,7 @@ async function insertRecords(
 
         // The ids are the values on the rows of the column that corresponds to resource questions
         const ids = worksheet
-          .getColumn(idx + 1)
+          .getColumn(column.index)
           ?.values.map((x) => x.valueOf());
 
         oldObj.fields.push(question);
@@ -165,6 +167,9 @@ async function insertRecords(
 
     const idsMap = new Map<string, string>();
     const recordsPromises: any[] = [];
+    const resourcesIds = linkedResources.map((lr: any) => {
+      return lr._id;
+    });
     linkedResources.forEach((resource) => {
       const colImportField = resource.importField;
       if (!colImportField) {
@@ -174,7 +179,7 @@ async function insertRecords(
       // If using an import field, we map the ids to the new ids, which are the objectIds
       const { ids } = resourceQuestionsMap.get(resource._id.toString());
       const recordsFromIds = Record.find({
-        resource: resource._id,
+        resource: { $in: resourcesIds },
         [`data.${colImportField}`]: { $in: ids.filter(Boolean) },
       }).then((records) => {
         records.forEach((record) => {


### PR DESCRIPTION
# Description
Fixed: Uploading records with columns out of order if some of the columns are for resource questions.

## Useful links

[ticket](https://oortcloud.atlassian.net/browse/HIT-315)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

As the attached video.

## Screenshots

![Peek 22-04-2024 14-26](https://github.com/ReliefApplications/ems-backend/assets/56398308/299c126d-ceff-45b0-80b8-d2c2d0d22a5d)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
