### PR TITLE
HIT-338-RefData-semicolon-transformed-into-comma-of-CSV-input

### DIFF
--- a/src/models/referenceData.model.ts
+++ b/src/models/referenceData.model.ts
@@ -63,6 +63,7 @@ interface ReferenceDataDocument extends Document {
   path: string;
   data: any;
   graphQLFilter: string;
+  separator?: string;
   permissions?: {
     canSee?: any[];
     canUpdate?: any[];
@@ -136,6 +137,7 @@ const schema = new Schema<ReferenceData>(
     path: String,
     data: mongoose.Schema.Types.Mixed,
     graphQLFilter: String,
+    separator: String,
     permissions: {
       canSee: [
         {

--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -35,6 +35,7 @@ type EditReferenceDataArgs = {
   path?: string;
   data?: any;
   graphQLFilter?: string;
+  separator?: string;
   permissions?: any;
   graphQLTypeName?: string;
 };
@@ -56,6 +57,7 @@ export default {
     path: { type: GraphQLString },
     data: { type: GraphQLJSON },
     graphQLFilter: { type: GraphQLString },
+    separator: { type: GraphQLString },
     permissions: { type: GraphQLJSON },
     pageInfo: {
       type: new GraphQLInputObjectType({

--- a/src/schema/types/referenceData.type.ts
+++ b/src/schema/types/referenceData.type.ts
@@ -47,6 +47,7 @@ export const ReferenceDataType = new GraphQLObjectType({
     path: { type: GraphQLString },
     data: { type: GraphQLJSON },
     graphQLFilter: { type: GraphQLString },
+    separator: { type: GraphQLString },
     permissions: {
       type: AccessType,
       resolve(parent, args, context) {


### PR DESCRIPTION
# Description
Updated ReferenceData model, type and edit mutation to also save the separator property. 

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-338
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/oort-frontend/pull/102

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
