### PR TITLE
fix/HIT-332-Resources-question-details-showing-empty-table-in-grid

### DIFF
--- a/migrations/1720191357-check-ref-data-fields-uppercase-lowercase.ts
+++ b/migrations/1720191357-check-ref-data-fields-uppercase-lowercase.ts
@@ -1,0 +1,96 @@
+import { Resource } from '@models';
+import { startDatabaseForMigration } from '@utils/migrations/database.helper';
+
+/**
+ * Because of the recent update of the reference data fields name, check for layouts
+ * and aggregations ths used these fields and need to be updated ad well.
+ *
+ * @returns just migrate data.
+ */
+export const up = async () => {
+  await startDatabaseForMigration();
+  const resources = await Resource.find().select('layouts aggregations fields');
+
+  for (const resource of resources) {
+    const fields = resource.fields;
+    const refDataFields = [];
+    // Find reference data fields
+    fields.forEach((field: any) => {
+      if (field.referenceData) {
+        refDataFields.push(field);
+      }
+    });
+    if (refDataFields.length) {
+      let updatedLayouts = false;
+      let updatedAggregations = false;
+      // Check layouts
+      for (const layout of resource.layouts) {
+        // Check if layout use any of the refDataFields
+        for (const refDataField of refDataFields) {
+          const fieldIndex = layout.query.fields.findIndex(
+            (field: any) =>
+              field.name.toLowerCase() === refDataField.name.toLowerCase()
+          );
+          if (fieldIndex !== -1) {
+            // Rename the field in the layout query fields
+            layout.query.fields[fieldIndex] = {
+              ...layout.query.fields[fieldIndex],
+              fields: layout.query.fields[fieldIndex].fields.map(
+                (field: any) => {
+                  if (
+                    refDataField.name.toLowerCase() === field.name.toLowerCase()
+                  ) {
+                    return {
+                      ...field,
+                      name: refDataField.name,
+                    };
+                  } else {
+                    return field;
+                  }
+                }
+              ),
+            };
+            updatedLayouts = true;
+            break;
+          }
+        }
+      }
+      for (const aggregation of resource.aggregations) {
+        for (const refDataField of refDataFields) {
+          const fieldIndex = aggregation.sourceFields.findIndex(
+            (field: any) =>
+              field.toLowerCase() === refDataField.name.toLowerCase()
+          );
+          if (fieldIndex !== -1) {
+            aggregation.sourceFields[fieldIndex] = refDataField.name;
+            updatedAggregations = true;
+            break;
+          }
+        }
+      }
+
+      if (updatedLayouts) {
+        // Necessary because mongoose can't detect the modifications in the nested property layouts
+        resource.markModified('layouts');
+      }
+      if (updatedAggregations) {
+        // Necessary because mongoose can't detect the modifications in the nested property aggregations
+        resource.markModified('aggregations');
+      }
+      if (updatedAggregations || updatedLayouts) {
+        await resource.save();
+      }
+    }
+  }
+};
+
+/**
+ * Sample function of down migration
+ *
+ * @returns just migrate data.
+ */
+export const down = async () => {
+  /*
+      Code you downgrade script here!
+   */
+};

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -208,7 +208,7 @@ const sortRecords = (records: any[], sortArgs: any): void => {
  * @returns true if field is used to sorting
  */
 const isSortField = (sortFields: any[], fieldName: string): boolean =>
-  sortFields.includes((item: any) => item.field === fieldName);
+  sortFields?.includes((item: any) => item.field === fieldName);
 
 /**
  * Returns a resolver that fetches records from resources/forms


### PR DESCRIPTION
# Description
Added a null check on the isSortField, because it was failing when param sort is not sent. Also created a migration to check the ref data field names on layouts and aggregations, because of the recent update of the reference data fields name. Migration was tested on local db using lift dump.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-332

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
As described in the attached video

## Screenshots
[video.webm](https://github.com/ReliefApplications/oort-backend/assets/28535394/b1a04168-5712-4307-89f0-adaff65f2d6c)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
