### PR TITLE
fix: grant field permissions

### DIFF
--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -1,4 +1,4 @@
-import mongoose from 'mongoose';
+import mongoose, { Types } from 'mongoose';
 import {
   GraphQLNonNull,
   GraphQLID,
@@ -133,6 +133,13 @@ const checkFieldPermission = (
       context.i18next.t('mutations.resource.edit.errors.field.notFound')
     );
   }
+
+  const toOID = (arr: (string | Types.ObjectId)[]) => {
+    return arr
+      .filter((p) => Types.ObjectId.isValid(p))
+      .map((p) => new Types.ObjectId(p));
+  };
+
   switch (permission) {
     case 'canSee': {
       if (
@@ -166,7 +173,9 @@ const checkFieldPermission = (
           )
         );
       }
-      if (!get(field, 'permissions.canSee', []).find((p) => p.equals(role))) {
+      if (
+        !toOID(get(field, 'permissions.canSee', [])).find((p) => p.equals(role))
+      ) {
         throw new GraphQLError(
           context.i18next.t('mutations.resource.edit.errors.field.notVisible')
         );


### PR DESCRIPTION
# Description

The issue was we were trying to call the `.equals` function in a string, which was expected to be an OID instead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By toggling the permissions Milena gave as an example


# Checklist:

( \* == Mandatory )

- [ ] - I have set myself as assignee of the pull request
- [ ] - My code follows the style guidelines of this project
- [ ] - Linting does not generate new warnings
- [ ] - I have performed a self-review of my own code
- [ ] - I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [ ] - I have commented my code, particularly in hard-to-understand areas
- [ ] - I have put JSDoc comment in all required places
- [ ] - My changes generate no new warnings
- [ ] - I have included screenshots describing my changes if relevant
- [ ] - I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation

https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
