### PR TITLE
HIT-423 add config for user invite expiration

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -76,6 +76,8 @@ module.exports = {
    * Paths should be in jsonpath syntax: https://github.com/dchester/jsonpath.
    */
   user: {
+    /** Invites not accepted after this many days are revoked */
+    invitationExpiryDays: 7,
     /**
      * Settings for groups.
      */

--- a/config/lift.js
+++ b/config/lift.js
@@ -1,0 +1,9 @@
+/**
+ * Configuration of back-office
+ * Use https://www.npmjs.com/package/config package.
+ */
+module.exports = {
+  user: {
+    invitationExpiryDays: 14,
+  },
+};

--- a/config/lift.js
+++ b/config/lift.js
@@ -3,7 +3,16 @@
  * Use https://www.npmjs.com/package/config package.
  */
 module.exports = {
+  email: {
+    sendInvite: true,
+  },
   user: {
     invitationExpiryDays: 14,
+    groups: {
+      local: true,
+    },
+    attributes: {
+      local: true,
+    },
   },
 };

--- a/src/schema/mutation/addUsers.mutation.ts
+++ b/src/schema/mutation/addUsers.mutation.ts
@@ -86,9 +86,11 @@ export default {
           if (x.positionAttributes) {
             newUser.positionAttributes = x.positionAttributes;
           }
-          // remove after 7 days if the user does not activate the account
+          // remove after 7 days (by default) if the user does not activate the account
+          const invitationExpiryDays: number =
+            config.get('user.invitationExpiryDays') ?? 7;
           const date = new Date();
-          date.setDate(date.getDate() + 7);
+          date.setDate(date.getDate() + invitationExpiryDays);
           newUser.deleteAt = date;
           invitedUsers.push(newUser);
         });

--- a/src/schema/mutation/addUsers.mutation.ts
+++ b/src/schema/mutation/addUsers.mutation.ts
@@ -87,8 +87,9 @@ export default {
             newUser.positionAttributes = x.positionAttributes;
           }
           // remove after 7 days (by default) if the user does not activate the account
-          const invitationExpiryDays: number =
-            config.get('user.invitationExpiryDays') ?? 7;
+          const invitationExpiryDays: number = config.get(
+            'user.invitationExpiryDays'
+          );
           const date = new Date();
           date.setDate(date.getDate() + invitationExpiryDays);
           newUser.deleteAt = date;


### PR DESCRIPTION
# Description

This PR makes so that the invitation acceptance period is now determined by a config instead of a hardcoded value. By default it's still 7 days, also includes a configuration file for lift to extend that period by another week.

## Useful links

- [Please insert link to ticket](https://oortcloud.atlassian.net/browse/HIT-423?atlOrigin=eyJpIjoiMjk0NTRkN2EzNjQ3NDdlY2I4NDA5NTY0M2U0YzRkZWUiLCJwIjoiaiJ9)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* Set the NODE_CONFIG_ENV to `lift` 
* Invited a new user
* Check deleteAt on the DB


## Screenshots

<img width="343" alt="image" src="https://github.com/user-attachments/assets/eb2dea3b-f376-46a3-a232-fd33f0fbd5b6" />


# Checklist:

( \* == Mandatory )

- [x] - I have set myself as assignee of the pull request
- [x] - My code follows the style guidelines of this project
- [x] - Linting does not generate new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] - I have commented my code, particularly in hard-to-understand areas
- [x] - I have put JSDoc comment in all required places
- [x] - My changes generate no new warnings
- [x] - I have included screenshots describing my changes if relevant
- [x] - I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
