### PR TITLE
HIT-444 add verbose logging option

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -175,6 +175,7 @@ module.exports = {
   },
   logger: {
     keep: true,
+    verbose: false,
   },
   archive: {
     expires: 60 * 60 * 24 * 30, // Default archive time, in seconds. Set to 30 days

--- a/config/lift.js
+++ b/config/lift.js
@@ -15,4 +15,7 @@ module.exports = {
       local: true,
     },
   },
+  logger: {
+    verbose: true,
+  },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ const launchServer = async () => {
 
 startDatabase();
 mongoose.connection.once('open', () => {
-  logger.log({ level: 'info', message: '📶 Connected to database' });
+  logger.info('📶 Connected to database');
   launchServer();
   // subscriberSafe();
   pullJobScheduler();


### PR DESCRIPTION
# Description

This PR changes the console logs to 
1. Log more useful information: When a request is made to the GraphQL endpoint is made, barely no information about the request is logged. By default now we log the operation name.
2. When configured (logger.verbose option set to true) we also log the variables sent with each graphql query 

## Useful links

- Please insert link to ticket https://oortcloud.atlassian.net/browse/HIT-444?atlOrigin=eyJpIjoiZjI2NTNiYzU2ZjhiNDNjZTk0ZDNmZWI0NmFiYmY3NWYiLCJwIjoiaiJ9


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By using the platform a bit with the new option configured


# Checklist:

( \* == Mandatory )

- [x] - I have set myself as assignee of the pull request
- [x] - My code follows the style guidelines of this project
- [x] - Linting does not generate new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] - I have commented my code, particularly in hard-to-understand areas
- [x] - I have put JSDoc comment in all required places
- [x] - My changes generate no new warnings
- [x] - I have included screenshots describing my changes if relevant
- [x] - I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
