### PR TITLE
MAB 477 Update columns of supporting documents dashboard to include country and BR ID

### DIFF
--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -81,6 +81,10 @@ export const buildProjectAggregation = (
   if (queryFields && Array.isArray(queryFields)) {
     queryFields.forEach((field) => {
       data[field.name] = 1;
+      // Also project resource fields at root level since they're populated there
+      if (field.fields && field.fields.length > 0) {
+        staticProject[field.name] = 1;
+      }
     });
     staticProject.data = data;
   }
@@ -88,7 +92,12 @@ export const buildProjectAggregation = (
     staticProject.data[field.name] = 1;
   });
   sort.forEach((item: any) => {
-    staticProject.data[item.name] = 1;
+    // For nested fields we need to project the parent field at root level
+    const fieldName = item.field
+      ? item.field.split('.')[0]
+      : item.name?.split('.')[0] || item.name;
+    staticProject.data[fieldName] = 1;
+    staticProject[fieldName] = 1;
   });
   return [{ $project: staticProject }];
 };

--- a/src/utils/schema/resolvers/Query/getSortAggregation.ts
+++ b/src/utils/schema/resolvers/Query/getSortAggregation.ts
@@ -24,11 +24,51 @@ const getSortAggregation = async (
     sortFields = [{ field: 'createdAt', order: 'asc' }];
   }
   await sortFields.forEach(async (item: { field: string; order: string }) => {
-    const field: any = fields.find((x) => x && x.name === item.field);
-    const parentField: any =
-      item.field && item.field.includes('.')
-        ? fields.find((x) => x && x.name === item.field.split('.')[0])
-        : '';
+    // Check if this is a nested field
+    const isNestedField = item.field && item.field.includes('.');
+    const fieldName = isNestedField ? item.field.split('.')[0] : item.field;
+
+    const field: any = fields.find((x) => x && x.name === fieldName);
+    const parentField: any = isNestedField
+      ? fields.find((x) => x && x.name === fieldName)
+      : '';
+    // For nested fields, use the full path as-is since the aggregation pipeline
+    // in all.ts already flattens resource fields properly
+    if (isNestedField) {
+      aggregationSort = {
+        ...aggregationSort,
+        [item.field]: getSortOrder(item.order),
+      };
+      return;
+    }
+    // Handle resource fields - after projection they're at top level with nested structure
+    if (field && (field.type === 'resource' || field.type === 'resources')) {
+      // Resource fields are projected at top level after aggregation
+      // Sort by the display field if available, otherwise fallback to 'name'
+      const sortPath = field.displayField
+        ? `${item.field}.${field.displayField}`
+        : `${item.field}.name`;
+
+      aggregationSort = {
+        ...aggregationSort,
+        [sortPath]: getSortOrder(item.order),
+      };
+      return;
+    }
+    // Handle reference data fields - these are also projected at top level
+    if (field && field.referenceData?.id) {
+      // Reference data fields are projected at top level
+      // Sort by the display field if available
+      const sortPath = field.referenceData.displayField
+        ? `${item.field}.${field.referenceData.displayField}`
+        : `${item.field}`;
+
+      aggregationSort = {
+        ...aggregationSort,
+        [sortPath]: getSortOrder(item.order),
+      };
+      return;
+    }
     // If we need to populate choices to sort on the text value
     if (field && (field.choices || field.choicesByUrl)) {
       const choices = await getFullChoices(field, context);


### PR DESCRIPTION
# Description

This PR fixes a bug in the dynamic GraphQL `all` resolver that prevented sorting on nested resource fields within dashboards. The issue was most noticeable in the "Supporting Documents" dashboard where sorting by columns like "Biosphere Reserve" or "Related form" did not work as expected.

The root cause was two-fold:

1.  The aggregation pipeline's projection stage was incorrectly discarding populated resource fields because it only preserved fields within the `data` namespace.
2.  The sort aggregation helper did not correctly handle nested field paths (e.g., `related_biosphere.a_01_1_name_in_english`) sent by the frontend for sorting.

This PR corrects the projection logic to ensure linked resource data is available for sorting and enhances the sort aggregation to correctly apply sorting on these nested fields.

## Useful links
-  Ticket: https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=29ad463fd8c4809290b9db72e6942a67&pm=s

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

This change was tested by following these steps:
1.  Navigate to the "Supporting Documents" dashboard
2.  Click on the "Biosphere Reserve" column header to sort in ascending/descending order.
3.  **Verification**: The grid now correctly sorts the records alphabetically by the biosphere reserve's name. The same test was performed for the "Related form" column.

## Screenshots

NA

# Checklist:

( \* == Mandatory )

- [x] - I have set myself as assignee of the pull request
- [x] - My code follows the style guidelines of this project
- [x] - Linting does not generate new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] - I have commented my code, particularly in hard-to-understand areas
- [x] - I have put JSDoc comment in all required places
- [x] - My changes generate no new warnings
- [ ] - I have included screenshots describing my changes if relevant
- [x] - I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation

https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
