### PR TITLE
MAB-578 Display only grid in surveyjs

### DIFF
--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -4,6 +4,86 @@ import i18next from 'i18next';
 import { validateGraphQLFieldName } from '@utils/validators';
 import { Field, Form } from '@models';
 
+/** Choice item interface for dropdown, radio, checkbox, tagbox, and matrix elements */
+interface ChoiceItem {
+  value?: string;
+  text?: string;
+}
+
+/** Row item interface for matrix elements */
+interface RowItem {
+  value?: string;
+  text?: string;
+}
+
+/** Column item interface for matrix elements */
+interface ColumnItem {
+  name?: string;
+  value?: string;
+  text?: string;
+  title?: string;
+  cellType?: string;
+  choices?: ChoiceItem[];
+}
+
+/** Multiple text item interface */
+interface MultipleTextItem {
+  name: string;
+  title?: string;
+}
+
+/** Choices by URL configuration interface */
+interface ChoicesByUrl {
+  url?: string;
+  path?: string;
+  valueName?: string;
+  titleName?: string;
+}
+
+/** Form element interface representing a SurveyJS question/element */
+interface FormElement {
+  type?: string;
+  valueName?: string;
+  omitField?: boolean;
+  unique?: boolean;
+  isRequired?: boolean;
+  omitOnXlsxTemplate?: boolean;
+  readOnly?: boolean;
+  kobo?: { type: string };
+  defaultValue?: unknown;
+  relatedName?: string;
+  resource?: string;
+  displayField?: string;
+  displayAsGrid?: boolean;
+  displayOnly?: boolean;
+  canAddNew?: boolean;
+  addTemplate?: unknown;
+  gridFieldsSettings?: unknown;
+  items?: MultipleTextItem[];
+  rows?: RowItem[];
+  columns?: ColumnItem[];
+  choices?: ChoiceItem[];
+  cellType?: string;
+  choicesExpression?: string;
+  choicesByUrl?: ChoicesByUrl | string;
+  referenceData?: string;
+  referenceDataDisplayField?: string;
+  hasOther?: boolean;
+  otherText?: string;
+  otherPlaceHolder?: string;
+  hasComment?: boolean;
+  showCommentArea?: boolean;
+  showOtherItem?: boolean;
+  applications?: unknown;
+  geometry?: string;
+  elements?: FormElement[];
+}
+
+/** Form structure object interface (page or panel) */
+interface FormStructureObject {
+  elements?: FormElement[];
+}
+
 /**
  * Push in fields array all detected fields in the json structure of object.
  * Function by induction.
@@ -13,9 +93,9 @@ import { Field, Form } from '@models';
  * @param core is the form core ?
  */
 export const extractFields = async (
-  object,
+  object: FormStructureObject,
   fields: Field[],
-  core
+  core: boolean
 ): Promise<void> => {
   if (!object.elements) {
     return;
@@ -26,7 +106,7 @@ export const extractFields = async (
       continue;
     }
     if (element.type === 'panel') {
-      await extractFields(element, fields, core);
+      await extractFields(element as FormStructureObject, fields, core);
       continue;
     }
     if (element.type === 'resources' && element.displayOnly) {
@@ -50,7 +130,7 @@ export const extractFields = async (
       readOnly: !!element.readOnly,
       isCore: core,
       kobo: element.kobo,
-      ...(element.hasOwnProperty('defaultValue')
+      ...(Object.prototype.hasOwnProperty.call(element, 'defaultValue')
         ? { defaultValue: element.defaultValue }
         : {}),
     };
@@ -83,7 +163,7 @@ export const extractFields = async (
     // ** Multiple texts **
     if (field.type === 'multipletext') {
       Object.assign(field, {
-        items: element.items.map((x) => {
+        items: (element.items ?? []).map((x: MultipleTextItem) => {
           return {
             name: x.name,
             label: x.title ? x.title : x.name,
@@ -94,18 +174,24 @@ export const extractFields = async (
     // ** Dynamic matrix **
     if (field.type === 'matrixdropdown') {
       Object.assign(field, {
-        rows: element.rows.map((x) => {
+        rows: (element.rows ?? []).map((x: RowItem | string) => {
+          if (typeof x === 'string') {
+            return { name: x, label: x };
+          }
           return {
             name: x.value ? x.value : x,
             label: x.text ? x.text : x,
           };
         }),
-        columns: element.columns.map((x) => {
+        columns: (element.columns ?? []).map((x: ColumnItem) => {
           return {
             name: x.name,
             label: x.title,
             type: x.cellType ? x.cellType : element.cellType,
-            choices: x.choices?.map((y) => {
+            choices: x.choices?.map((y: ChoiceItem | string) => {
+              if (typeof y === 'string') {
+                return { value: y, text: y };
+              }
               return {
                 value: y.value ? y.value : y,
                 text: y.text ? y.text : y,
@@ -113,7 +199,10 @@ export const extractFields = async (
             }),
           };
         }),
-        choices: (element.choices ?? []).map((x) => {
+        choices: (element.choices ?? []).map((x: ChoiceItem | string) => {
+          if (typeof x === 'string') {
+            return { value: x, text: x };
+          }
           return {
             value: x.value ? x.value : x,
             text: x.text ? x.text : x,
@@ -124,13 +213,19 @@ export const extractFields = async (
     // ** Single choice matrix **
     if (field.type === 'matrix') {
       Object.assign(field, {
-        rows: element.rows.map((x) => {
+        rows: (element.rows ?? []).map((x: RowItem | string) => {
+          if (typeof x === 'string') {
+            return { name: x, label: x };
+          }
           return {
             name: x.value ? x.value : x,
             label: x.text ? x.text : x,
           };
         }),
-        columns: element.columns.map((x) => {
+        columns: (element.columns ?? []).map((x: ColumnItem | string) => {
+          if (typeof x === 'string') {
+            return { name: x, label: x };
+          }
           return {
             name: x.value ? x.value : x,
             label: x.text ? x.text : x,
@@ -141,12 +236,15 @@ export const extractFields = async (
     // ** Dynamic rows matrix **
     if (field.type === 'matrixdynamic') {
       Object.assign(field, {
-        columns: element.columns.map((x) => {
+        columns: (element.columns ?? []).map((x: ColumnItem) => {
           return {
             name: x.name,
             type: x.cellType,
             label: x.title,
-            choices: x.choices?.map((y) => {
+            choices: x.choices?.map((y: ChoiceItem | string) => {
+              if (typeof y === 'string') {
+                return { value: y, text: y };
+              }
               return {
                 value: y.value ? y.value : y,
                 text: y.text ? y.text : y,
@@ -154,7 +252,10 @@ export const extractFields = async (
             }),
           };
         }),
-        choices: (element.choices ?? []).map((x) => {
+        choices: (element.choices ?? []).map((x: ChoiceItem | string) => {
+          if (typeof x === 'string') {
+            return { value: x, text: x };
+          }
           return {
             value: x.value ? x.value : x,
             text: x.text ? x.text : x,
@@ -172,20 +273,18 @@ export const extractFields = async (
       if (element.choicesExpression) {
         // We can't save the choices in this case, just do nothing
       } else if (element.choicesByUrl) {
+        const choicesByUrl =
+          typeof element.choicesByUrl === 'string'
+            ? { url: element.choicesByUrl }
+            : element.choicesByUrl;
         Object.assign(field, {
           choicesByUrl: {
-            url: element.choicesByUrl.url
-              ? element.choicesByUrl.url
-              : element.choicesByUrl,
-            ...(element.choicesByUrl.path && {
-              path: element.choicesByUrl.path,
+            url: choicesByUrl.url ? choicesByUrl.url : element.choicesByUrl,
+            ...(choicesByUrl.path && {
+              path: choicesByUrl.path,
             }),
-            value: element.choicesByUrl.valueName
-              ? element.choicesByUrl.valueName
-              : 'name',
-            text: element.choicesByUrl.titleName
-              ? element.choicesByUrl.titleName
-              : 'name',
+            value: choicesByUrl.valueName ? choicesByUrl.valueName : 'name',
+            text: choicesByUrl.titleName ? choicesByUrl.titleName : 'name',
             hasOther: element.hasOther,
             otherText: element.otherText ? element.otherText : 'Other',
           },
@@ -198,12 +297,17 @@ export const extractFields = async (
           },
         });
       } else {
-        const choices = element.choices.map((x) => {
-          return {
-            value: x.value || x,
-            text: x.text || x.value || x,
-          };
-        });
+        const choices = (element.choices ?? []).map(
+          (x: ChoiceItem | string) => {
+            if (typeof x === 'string') {
+              return { value: x, text: x };
+            }
+            return {
+              value: x.value || x,
+              text: x.text || x.value || x,
+            };
+          }
+        );
         if (element.hasOther) {
           Object.assign(field, {
             hasOther: true,

--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -17,234 +17,237 @@ export const extractFields = async (
   fields: Field[],
   core
 ): Promise<void> => {
-  if (object.elements) {
-    for (const element of object.elements) {
-      if (element.omitField) {
-        continue;
-      }
-      if (element.type === 'panel') {
-        await extractFields(element, fields, core);
+  if (!object.elements) {
+    return;
+  }
+
+  for (const element of object.elements) {
+    if (element.omitField) {
+      continue;
+    }
+    if (element.type === 'panel') {
+      await extractFields(element, fields, core);
+      continue;
+    }
+    if (element.type === 'resources' && element.displayOnly) {
+      // Don't store as field if question is display only
+      continue;
+    }
+    if (!element.valueName) {
+      throw new GraphQLError(
+        i18next.t('utils.form.extractFields.errors.missingDataField')
+      );
+    }
+
+    validateGraphQLFieldName(element.valueName, i18next);
+    const type = await getFieldType(element);
+    const field: Form['fields'][number] = {
+      type,
+      name: element.valueName,
+      unique: !!element.unique,
+      isRequired: !!element.isRequired,
+      showOnXlsxTemplate: !element.omitOnXlsxTemplate,
+      readOnly: !!element.readOnly,
+      isCore: core,
+      kobo: element.kobo,
+      ...(element.hasOwnProperty('defaultValue')
+        ? { defaultValue: element.defaultValue }
+        : {}),
+    };
+    // ** Resource **
+    if (element.type === 'resource' || element.type === 'resources') {
+      if (element.relatedName) {
+        validateGraphQLFieldName(element.relatedName, i18next);
+        Object.assign(
+          field,
+          {
+            resource: element.resource,
+            displayField: element.displayField,
+            relatedName: element.relatedName,
+          },
+          element.displayAsGrid && { displayAsGrid: element.displayAsGrid },
+          element.canAddNew && { canAddNew: element.canAddNew },
+          element.addTemplate && { addTemplate: element.addTemplate },
+          element.gridFieldsSettings && {
+            gridFieldsSettings: element.gridFieldsSettings,
+          }
+        );
       } else {
-        if (element.type === 'resources' && element.displayOnly) {
-          // Don't store as field if question is display only
-          continue;
-        }
-        if (!element.valueName) {
-          throw new GraphQLError(
-            i18next.t('utils.form.extractFields.errors.missingDataField')
-          );
-        }
-        validateGraphQLFieldName(element.valueName, i18next);
-        const type = await getFieldType(element);
-        const field: Form['fields'][number] = {
-          type,
-          name: element.valueName,
-          unique: !!element.unique,
-          isRequired: !!element.isRequired,
-          showOnXlsxTemplate: !element.omitOnXlsxTemplate,
-          readOnly: !!element.readOnly,
-          isCore: core,
-          kobo: element.kobo,
-          ...(element.hasOwnProperty('defaultValue')
-            ? { defaultValue: element.defaultValue }
-            : {}),
-        };
-        // ** Resource **
-        if (element.type === 'resource' || element.type === 'resources') {
-          if (element.relatedName) {
-            validateGraphQLFieldName(element.relatedName, i18next);
-            Object.assign(
-              field,
-              {
-                resource: element.resource,
-                displayField: element.displayField,
-                relatedName: element.relatedName,
-              },
-              element.displayAsGrid && { displayAsGrid: element.displayAsGrid },
-              element.canAddNew && { canAddNew: element.canAddNew },
-              element.addTemplate && { addTemplate: element.addTemplate },
-              element.gridFieldsSettings && {
-                gridFieldsSettings: element.gridFieldsSettings,
-              }
-            );
-          } else {
-            throw new GraphQLError(
-              i18next.t('utils.form.extractFields.errors.missingRelatedField', {
-                name: element.valueName,
-              })
-            );
-          }
-        }
-        // ** Multiple texts **
-        if (field.type === 'multipletext') {
-          Object.assign(field, {
-            items: element.items.map((x) => {
-              return {
-                name: x.name,
-                label: x.title ? x.title : x.name,
-              };
-            }),
-          });
-        }
-        // ** Dynamic matrix **
-        if (field.type === 'matrixdropdown') {
-          Object.assign(field, {
-            rows: element.rows.map((x) => {
-              return {
-                name: x.value ? x.value : x,
-                label: x.text ? x.text : x,
-              };
-            }),
-            columns: element.columns.map((x) => {
-              return {
-                name: x.name,
-                label: x.title,
-                type: x.cellType ? x.cellType : element.cellType,
-                choices: x.choices?.map((y) => {
-                  return {
-                    value: y.value ? y.value : y,
-                    text: y.text ? y.text : y,
-                  };
-                }),
-              };
-            }),
-            choices: (element.choices ?? []).map((x) => {
-              return {
-                value: x.value ? x.value : x,
-                text: x.text ? x.text : x,
-              };
-            }),
-          });
-        }
-        // ** Single choice matrix **
-        if (field.type === 'matrix') {
-          Object.assign(field, {
-            rows: element.rows.map((x) => {
-              return {
-                name: x.value ? x.value : x,
-                label: x.text ? x.text : x,
-              };
-            }),
-            columns: element.columns.map((x) => {
-              return {
-                name: x.value ? x.value : x,
-                label: x.text ? x.text : x,
-              };
-            }),
-          });
-        }
-        // ** Dynamic rows matrix **
-        if (field.type === 'matrixdynamic') {
-          Object.assign(field, {
-            columns: element.columns.map((x) => {
-              return {
-                name: x.name,
-                type: x.cellType,
-                label: x.title,
-                choices: x.choices?.map((y) => {
-                  return {
-                    value: y.value ? y.value : y,
-                    text: y.text ? y.text : y,
-                  };
-                }),
-              };
-            }),
-            choices: (element.choices ?? []).map((x) => {
-              return {
-                value: x.value ? x.value : x,
-                text: x.text ? x.text : x,
-              };
-            }),
-          });
-        }
-        // ** Dropdown / Radio / Checkbox / Tagbox **
-        if (
-          field.type === 'dropdown' ||
-          field.type === 'radiogroup' ||
-          field.type === 'checkbox' ||
-          field.type === 'tagbox'
-        ) {
-          if (element.choicesExpression) {
-            // We can't save the choices in this case, just do nothing
-          } else if (element.choicesByUrl) {
-            Object.assign(field, {
-              choicesByUrl: {
-                url: element.choicesByUrl.url
-                  ? element.choicesByUrl.url
-                  : element.choicesByUrl,
-                ...(element.choicesByUrl.path && {
-                  path: element.choicesByUrl.path,
-                }),
-                value: element.choicesByUrl.valueName
-                  ? element.choicesByUrl.valueName
-                  : 'name',
-                text: element.choicesByUrl.titleName
-                  ? element.choicesByUrl.titleName
-                  : 'name',
-                hasOther: element.hasOther,
-                otherText: element.otherText ? element.otherText : 'Other',
-              },
-            });
-          } else if (element.referenceData) {
-            Object.assign(field, {
-              referenceData: {
-                id: element.referenceData,
-                displayField: element.referenceDataDisplayField,
-              },
-            });
-          } else {
-            const choices = element.choices.map((x) => {
-              return {
-                value: x.value || x,
-                text: x.text || x.value || x,
-              };
-            });
-            if (element.hasOther) {
-              Object.assign(field, {
-                hasOther: true,
-                otherText: element.otherText,
-                otherPlaceHolder: element.otherPlaceHolder,
-              });
-              choices.push({
-                value: 'other',
-                text: element.otherText ? element.otherText : 'Other',
-              });
-            }
-            Object.assign(field, {
-              choices,
-            });
-          }
-        }
-        // ** Owner **
-        if (field.type === 'owner') {
-          Object.assign(field, { applications: element.applications });
-        }
-        // ** Comments **
-        if (
-          element.hasComment ||
-          element.hasOther ||
-          element.showCommentArea ||
-          element.showOtherItem
-        ) {
-          fields.push({
-            type: 'text',
-            name: `${element.valueName}_comment`,
-            isCore: core,
-            generated: true,
-          });
-        }
-        // ** Users **
-        if (field.type === 'users') {
-          Object.assign(field, { applications: element.applications });
-        }
-        // ** Geospatial **
-        if (field.type === 'geospatial') {
-          Object.assign(field, {
-            geometry: element.geometry ?? 'Point',
-          });
-        }
-        fields.push(field);
+        throw new GraphQLError(
+          i18next.t('utils.form.extractFields.errors.missingRelatedField', {
+            name: element.valueName,
+          })
+        );
       }
     }
+    // ** Multiple texts **
+    if (field.type === 'multipletext') {
+      Object.assign(field, {
+        items: element.items.map((x) => {
+          return {
+            name: x.name,
+            label: x.title ? x.title : x.name,
+          };
+        }),
+      });
+    }
+    // ** Dynamic matrix **
+    if (field.type === 'matrixdropdown') {
+      Object.assign(field, {
+        rows: element.rows.map((x) => {
+          return {
+            name: x.value ? x.value : x,
+            label: x.text ? x.text : x,
+          };
+        }),
+        columns: element.columns.map((x) => {
+          return {
+            name: x.name,
+            label: x.title,
+            type: x.cellType ? x.cellType : element.cellType,
+            choices: x.choices?.map((y) => {
+              return {
+                value: y.value ? y.value : y,
+                text: y.text ? y.text : y,
+              };
+            }),
+          };
+        }),
+        choices: (element.choices ?? []).map((x) => {
+          return {
+            value: x.value ? x.value : x,
+            text: x.text ? x.text : x,
+          };
+        }),
+      });
+    }
+    // ** Single choice matrix **
+    if (field.type === 'matrix') {
+      Object.assign(field, {
+        rows: element.rows.map((x) => {
+          return {
+            name: x.value ? x.value : x,
+            label: x.text ? x.text : x,
+          };
+        }),
+        columns: element.columns.map((x) => {
+          return {
+            name: x.value ? x.value : x,
+            label: x.text ? x.text : x,
+          };
+        }),
+      });
+    }
+    // ** Dynamic rows matrix **
+    if (field.type === 'matrixdynamic') {
+      Object.assign(field, {
+        columns: element.columns.map((x) => {
+          return {
+            name: x.name,
+            type: x.cellType,
+            label: x.title,
+            choices: x.choices?.map((y) => {
+              return {
+                value: y.value ? y.value : y,
+                text: y.text ? y.text : y,
+              };
+            }),
+          };
+        }),
+        choices: (element.choices ?? []).map((x) => {
+          return {
+            value: x.value ? x.value : x,
+            text: x.text ? x.text : x,
+          };
+        }),
+      });
+    }
+    // ** Dropdown / Radio / Checkbox / Tagbox **
+    if (
+      field.type === 'dropdown' ||
+      field.type === 'radiogroup' ||
+      field.type === 'checkbox' ||
+      field.type === 'tagbox'
+    ) {
+      if (element.choicesExpression) {
+        // We can't save the choices in this case, just do nothing
+      } else if (element.choicesByUrl) {
+        Object.assign(field, {
+          choicesByUrl: {
+            url: element.choicesByUrl.url
+              ? element.choicesByUrl.url
+              : element.choicesByUrl,
+            ...(element.choicesByUrl.path && {
+              path: element.choicesByUrl.path,
+            }),
+            value: element.choicesByUrl.valueName
+              ? element.choicesByUrl.valueName
+              : 'name',
+            text: element.choicesByUrl.titleName
+              ? element.choicesByUrl.titleName
+              : 'name',
+            hasOther: element.hasOther,
+            otherText: element.otherText ? element.otherText : 'Other',
+          },
+        });
+      } else if (element.referenceData) {
+        Object.assign(field, {
+          referenceData: {
+            id: element.referenceData,
+            displayField: element.referenceDataDisplayField,
+          },
+        });
+      } else {
+        const choices = element.choices.map((x) => {
+          return {
+            value: x.value || x,
+            text: x.text || x.value || x,
+          };
+        });
+        if (element.hasOther) {
+          Object.assign(field, {
+            hasOther: true,
+            otherText: element.otherText,
+            otherPlaceHolder: element.otherPlaceHolder,
+          });
+          choices.push({
+            value: 'other',
+            text: element.otherText ? element.otherText : 'Other',
+          });
+        }
+        Object.assign(field, {
+          choices,
+        });
+      }
+    }
+    // ** Owner **
+    if (field.type === 'owner') {
+      Object.assign(field, { applications: element.applications });
+    }
+    // ** Comments **
+    if (
+      element.hasComment ||
+      element.hasOther ||
+      element.showCommentArea ||
+      element.showOtherItem
+    ) {
+      fields.push({
+        type: 'text',
+        name: `${element.valueName}_comment`,
+        isCore: core,
+        generated: true,
+      });
+    }
+    // ** Users **
+    if (field.type === 'users') {
+      Object.assign(field, { applications: element.applications });
+    }
+    // ** Geospatial **
+    if (field.type === 'geospatial') {
+      Object.assign(field, {
+        geometry: element.geometry ?? 'Point',
+      });
+    }
+    fields.push(field);
   }
 };

--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -25,6 +25,10 @@ export const extractFields = async (
       if (element.type === 'panel') {
         await extractFields(element, fields, core);
       } else {
+        if (element.type === 'resources' && element.displayOnly) {
+          // Don't store as field if question is display only
+          continue;
+        }
         if (!element.valueName) {
           throw new GraphQLError(
             i18next.t('utils.form.extractFields.errors.missingDataField')


### PR DESCRIPTION
# Description

Backend support for display-only resources grids in SurveyJS forms. This feature allows forms to display previous form data without storing the display-only questions as database fields.

The fix prevents validation errors when saving forms with display-only resources questions that don't have a relatedName property, as these questions are meant only for display purposes and should not be persisted.

## Useful links

- Frontend PR: https://github.com/ReliefApplications/oort-frontend/pull/226
- Ticket: https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=2c5d463fd8c480d28eedf0f1ba360e0b&pm=s

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Test A: Add display-only resources question

- Created a new form in the form builder
- Added a resources question
- Selected a resource and display field
- Checked the "Display only" checkbox (in general category)
- Verified that "Related Name" field is hidden when display-only is enabled
- Saved the form successfully without relatedName validation error

Test B: Display-only grid rendering

- Enabled "Display As Grid" option on the display-only resources question
- Configured grid fields settings
- Previewed the form
- Verified that the grid displays resource records
- Confirmed that no "Search" or "Add" buttons appear
- Verified that the grid is read-only (no selection checkboxes)

Test C: Form submission

- Filled out a form with a display-only resources question
- Submitted the form
- Verified that display-only question data is NOT saved to the database
- Confirmed other form fields save correctly

## Screenshots

N/A

# Checklist:

( \* == Mandatory )

- [x] - I have set myself as assignee of the pull request
- [x] - My code follows the style guidelines of this project
- [x] - Linting does not generate new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] - I have commented my code, particularly in hard-to-understand areas
- [x] - I have put JSDoc comment in all required places
- [x] - My changes generate no new warnings
- [x] - I have included screenshots describing my changes if relevant
- [x] - I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation

https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
