### PR TITLE
MAB-624: Remove non visible questions from _progress

### DIFF
--- a/src/utils/form/getNextId.ts
+++ b/src/utils/form/getNextId.ts
@@ -25,6 +25,19 @@ const cache = new NodeCache();
 const CACHE_DURATION = 10;
 
 /**
+ * Extracts the first alphabetic character from a string.
+ * Skips special characters, numbers, and whitespace.
+ *
+ * @param str The string to extract from.
+ * @returns The first alphabetic character in uppercase, or empty string if none found.
+ */
+const getFirstAlphabeticChar = (str: string | undefined): string => {
+  if (!str) return '';
+  const match = str.match(/[a-zA-Z]/);
+  return match ? match[0].toUpperCase() : '';
+};
+
+/**
  * Builds the incremental ID from the the shape string and an object with all the variables.
  *
  * @param idShape The shape id object.
@@ -139,7 +152,7 @@ export const updateIncrementalIds = async (
     const newIncrementalId = buildIncrementalId(newShape, {
       incremental: inc.toString(),
       year: createdAt.getFullYear().toString(),
-      resourceInitial: resource.name?.charAt(0).toUpperCase() || '',
+      resourceInitial: getFirstAlphabeticChar(resource.name),
       resourceName: resource.name?.toUpperCase() || '',
     });
 
@@ -182,7 +195,7 @@ export const getNextId = async (structureId: string | Form) => {
     const incrementalId = buildIncrementalId(idShape, {
       incremental: id.toString(),
       year: new Date().getFullYear().toString(),
-      resourceInitial: name?.charAt(0).toUpperCase() || '',
+      resourceInitial: getFirstAlphabeticChar(name),
       resourceName: name?.toUpperCase() || '',
     });
     cache.set(
@@ -249,7 +262,7 @@ export const getNextId = async (structureId: string | Form) => {
   let incrementalId = buildIncrementalId(idShape, {
     incremental: incID.toString(),
     year: new Date().getFullYear().toString(),
-    resourceInitial: name?.charAt(0).toUpperCase() || '',
+    resourceInitial: getFirstAlphabeticChar(name),
     resourceName: name?.toUpperCase() || '',
   });
 
@@ -263,7 +276,7 @@ export const getNextId = async (structureId: string | Form) => {
     incrementalId = buildIncrementalId(idShape, {
       incremental: incID.toString(),
       year: new Date().getFullYear().toString(),
-      resourceInitial: name?.charAt(0).toUpperCase() || '',
+      resourceInitial: getFirstAlphabeticChar(name),
       resourceName: name?.toUpperCase() || '',
     });
   }


### PR DESCRIPTION
# Description

Fixed the progress bar calculation on forms to exclude invisible questions from the percentage. 

The issue was that required questions hidden by isVisibleIf were still being counted. Created a isQuestionVisible() helper function that checks both the question and its parent visibility (it was already implemented locally), and we use it on the progress filter to update the value. 

Now, only visible required questions count for completion.

## Useful links

- https://www.notion.so/Remove-non-visible-questions-from-_progress-2edd463fd8c480e38c34ea3d4c707d6c?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [X] I have made corresponding changes to the documentation ( if required )
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
