### PR TITLE
MAB-493 Adding shapefiles of all BR inside country details

### DIFF
--- a/src/models/layer.model.ts
+++ b/src/models/layer.model.ts
@@ -130,6 +130,7 @@ export interface LayerDatasource {
   latitudeField?: string;
   longitudeField?: string;
   type: GeometryType;
+  requiredFilterFields?: string;
 }
 
 /** Layer documents interface declaration */
@@ -212,6 +213,7 @@ const layerSchema = new Schema(
         type: String,
         enum: Object.values(GeometryType),
       },
+      requiredFilterFields: String,
     },
     contextFilters: String,
     at: String,

--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -416,6 +416,42 @@ router.get('/feature', async (req, res) => {
       get(req, 'query.graphQLVariables', null)
     );
 
+    // Check if required filter fields are present
+    const requiredFilterFields = get(req, 'query.requiredFilterFields') as
+      | string
+      | undefined;
+    if (requiredFilterFields) {
+      const requiredFields = requiredFilterFields
+        .split(',')
+        .map((f) => f.trim());
+      const hasRequiredFilters = requiredFields.every((field) => {
+        return contextFilters?.filters?.some((f: FilterDescriptor) => {
+          const fieldMatches = f.field === field;
+          const hasValue =
+            f.value !== null &&
+            f.value !== undefined &&
+            f.value !== '' &&
+            (Array.isArray(f.value) ? f.value.length > 0 : true);
+          return fieldMatches && hasValue;
+        });
+      });
+
+      if (!hasRequiredFilters) {
+        // Return empty result instead of querying
+        logger.info(
+          `Skipping layer query - required filter fields not satisfied: ${requiredFilterFields}`
+        );
+        if (layerType === GeometryType.SHAPEFILE) {
+          return res.send([]);
+        } else {
+          return res.send({
+            type: 'FeatureCollection',
+            features: [],
+          });
+        }
+      }
+    }
+
     // used to filter features by property values only
     const propertyFilters: { prop: string; value: unknown }[] = [];
 

--- a/src/schema/inputs/layer.input.ts
+++ b/src/schema/inputs/layer.input.ts
@@ -148,6 +148,7 @@ const LayerDataSourceInputType = new GraphQLInputObjectType({
     latitudeField: { type: GraphQLString },
     longitudeField: { type: GraphQLString },
     type: { type: GraphQLString },
+    requiredFilterFields: { type: GraphQLString },
   }),
 });
 

--- a/src/schema/types/layer.type.ts
+++ b/src/schema/types/layer.type.ts
@@ -33,6 +33,7 @@ const LayerDatasource = new GraphQLObjectType({
       type: new GraphQLNonNull(GraphQLString),
       resolve: (parent) => parent.type ?? GeometryType.POINT,
     },
+    requiredFilterFields: { type: GraphQLString },
   }),
 });
 


### PR DESCRIPTION
# Description

This PR implements a backend validation mechanism to prevent loading heavy GIS layers when required dashboard filters are not set.

Previously, the dashboard would attempt to load all shapefiles even if no country was selected, leading to significant performance degradation  and unnecessary database queries.

## Useful links

- **Ticket:** https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=2a0d463fd8c480239fe4c20921ff7d72&pm=s

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- Test A: Verified that calling /gis/feature with requiredFilterFields=related_biosphere.id but no matching filter returns [] immediately.
- Test B: Verified that providing the required filter in contextFilters allows the query to proceed and returns the expected shapefile URLs.
- Test C: Tested with empty strings, null values, and empty arrays in filters to ensure they are correctly treated.

## Screenshots

N/A

# Checklist:

( \* == Mandatory )

- [x] - I have set myself as assignee of the pull request
- [x] - My code follows the style guidelines of this project
- [x] - Linting does not generate new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] - I have commented my code, particularly in hard-to-understand areas
- [x] - I have put JSDoc comment in all required places
- [x] - My changes generate no new warnings
- [x] - I have included screenshots describing my changes if relevant
- [x] - I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation

https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
