### PR TITLE
MAB-737: API throwing error if user calls some specific query without edges

### DIFF
--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -75,21 +75,24 @@ export const buildProjectAggregation = (
         username: 1,
       },
     },
-    data: 0,
   };
-  const data = {};
-  if (queryFields && Array.isArray(queryFields)) {
+  const data: { [key: string]: number } = {};
+  if (queryFields && Array.isArray(queryFields) && queryFields.length > 0) {
     queryFields.forEach((field) => {
       data[field.name] = 1;
     });
-    staticProject.data = data;
   }
   calculatedFields.forEach((field) => {
-    staticProject.data[field.name] = 1;
+    data[field.name] = 1;
   });
   sort?.forEach((item: any) => {
-    staticProject.data[item.name] = 1;
+    if (item?.name) {
+      data[item.name] = 1;
+    }
   });
+  if (Object.keys(data).length > 0) {
+    staticProject.data = data;
+  }
   return [{ $project: staticProject }];
 };
 


### PR DESCRIPTION
# Description

The issue was that our Mongo aggregation "$project" was mixing inclusion fields (like "id", "createdAt", etc.) with an exclusion ("data: 0"), which Mongo doesn’t allow, so the "totalCount" query crashed. It is now fixed by removing the default "data: 0" exclusion and only adding "data" to the projection when the query actually asks for node fields (or when calculated/sort fields need it).

## Useful links

- https://www.notion.so/API-throwing-error-if-user-calls-some-specific-query-without-edges-313d463fd8c4801fa78fcf808ece94b5?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

( \* == Mandatory )

- [X] - I have set myself as assignee of the pull request
- [X] - My code follows the style guidelines of this project
- [X] - Linting does not generate new warnings
- [X] - I have performed a self-review of my own code
- [X] - I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] - I have commented my code, particularly in hard-to-understand areas
- [X] - I have put JSDoc comment in all required places
- [X] - My changes generate no new warnings
- [X] - I have included screenshots describing my changes if relevant
- [X] - I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules