### PR TITLE
MAB-736: Users invited by other users don’t have country in their profile

### DIFF
--- a/src/utils/user/updateUserAttributes.ts
+++ b/src/utils/user/updateUserAttributes.ts
@@ -11,7 +11,7 @@ import { Types } from 'mongoose';
  */
 export const updateUserAttributes = async (user: User): Promise<boolean> => {
   try {
-    const userCountry = user.attributes?.country;
+    let userCountry = user.attributes?.country;
     const userRoles = user.roles || [];
 
     // todo: not suitable at all as it will only work for MAB!
@@ -30,6 +30,16 @@ export const updateUserAttributes = async (user: User): Promise<boolean> => {
         },
       },
     ]);
+    const editableBRCountries: string[] = uniq(
+      editableBRs.flatMap((doc) => doc.countries || [])
+    ).filter(Boolean);
+
+    // Keep profile country aligned with BR assignment.
+    if (!userCountry && editableBRCountries.length === 1) {
+      userCountry = editableBRCountries[0];
+      set(user, 'attributes.country', userCountry);
+    }
+
     let countries: string[] = [];
     // Biosphere manager
     if (

--- a/src/utils/user/updateUserAttributes.ts
+++ b/src/utils/user/updateUserAttributes.ts
@@ -11,6 +11,9 @@ import { Types } from 'mongoose';
  */
 export const updateUserAttributes = async (user: User): Promise<boolean> => {
   try {
+    const userCountry = user.attributes?.country;
+    const userRoles = user.roles || [];
+
     // todo: not suitable at all as it will only work for MAB!
     // Update profile with all BRs it can view
     let editableBRs = await Record.aggregate([
@@ -30,30 +33,30 @@ export const updateUserAttributes = async (user: User): Promise<boolean> => {
     let countries: string[] = [];
     // Biosphere manager
     if (
-      user.roles.find((x) => x._id.toString() === '677298832fc2a0c65c171418')
+      userRoles.find((x) => x._id.toString() === '677298832fc2a0c65c171418')
     ) {
       countries = uniq([
         ...editableBRs.flatMap((doc) => doc.countries || []),
-        user.attributes.country,
+        userCountry,
       ]).filter(Boolean);
     }
     // National commission
     if (
-      user.roles.find((x) => x._id.toString() === '6772988c2fc2a0c65c171444')
+      userRoles.find((x) => x._id.toString() === '6772988c2fc2a0c65c171444')
     ) {
-      countries = [user.attributes.country].filter((c) => c);
+      countries = [userCountry].filter((c) => c);
     }
     // National Focal Point
     if (
-      user.roles.find((x) => x._id.toString() === '69971593bc875afe08a8dd6f')
+      userRoles.find((x) => x._id.toString() === '69971593bc875afe08a8dd6f')
     ) {
       // Editable BRs are all BRs in same country
-      if (user.attributes.country) {
+      if (userCountry) {
         editableBRs = await Record.aggregate([
           {
             $match: {
               resource: new Types.ObjectId('682e1d63839fa743ca474aa0'),
-              'data.countries': user.attributes.country,
+              'data.countries': userCountry,
             },
           },
           {
@@ -66,7 +69,7 @@ export const updateUserAttributes = async (user: User): Promise<boolean> => {
       } else {
         editableBRs = [];
       }
-      countries = [user.attributes.country].filter((c) => c);
+      countries = [userCountry].filter((c) => c);
     }
     const viewableBRs = await Record.aggregate([
       {
@@ -83,19 +86,17 @@ export const updateUserAttributes = async (user: User): Promise<boolean> => {
         },
       },
     ]);
-    set(
-      user,
-      'attributes._can_edit_brs',
-      editableBRs.map((doc) => doc._id.toString())
-    );
-    set(
-      user,
-      'attributes._can_view_brs',
-      viewableBRs.map((doc) => doc._id.toString())
-    );
+    const editableBRIds = editableBRs.map((doc) => doc._id.toString());
+    const viewableBRIds = uniq([
+      ...viewableBRs.map((doc) => doc._id.toString()),
+      ...editableBRIds,
+    ]);
+
+    set(user, 'attributes._can_edit_brs', editableBRIds);
+    set(user, 'attributes._can_view_brs', viewableBRIds);
     user.markModified('attributes');
     return true;
-  } catch {
+  } catch (err) {
     logger.error('Fail to update user attributes');
     return false;
   }

--- a/src/utils/user/updateUserAttributes.ts
+++ b/src/utils/user/updateUserAttributes.ts
@@ -11,7 +11,7 @@ import { Types } from 'mongoose';
  */
 export const updateUserAttributes = async (user: User): Promise<boolean> => {
   try {
-    let userCountry = user.attributes?.country;
+    const userCountry = user.attributes?.country;
     const userRoles = user.roles || [];
 
     // todo: not suitable at all as it will only work for MAB!
@@ -30,16 +30,6 @@ export const updateUserAttributes = async (user: User): Promise<boolean> => {
         },
       },
     ]);
-    const editableBRCountries: string[] = uniq(
-      editableBRs.flatMap((doc) => doc.countries || [])
-    ).filter(Boolean);
-
-    // Keep profile country aligned with BR assignment.
-    if (!userCountry && editableBRCountries.length === 1) {
-      userCountry = editableBRCountries[0];
-      set(user, 'attributes.country', userCountry);
-    }
-
     let countries: string[] = [];
     // Biosphere manager
     if (


### PR DESCRIPTION
# Description

Invited users were linked to the BR, but their profile access data wasn’t synced correctly, so they couldn’t see the Site Profile after first login (BR and country could stay empty). Fixed by updating backend user-attribute sync to always include linked BRs in view permissions, handle missing profile attributes safely, and auto-set country when the linked BR has a single clear country.

## Useful links

- https://www.notion.so/Users-invited-by-other-users-don-t-have-country-in-their-profile-313d463fd8c48056a437e929baaa7bd1?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( \* == Mandatory )

- [X] - I have set myself as assignee of the pull request
- [X] - My code follows the style guidelines of this project
- [X] - Linting does not generate new warnings
- [X] - I have performed a self-review of my own code
- [X] - I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] - I have commented my code, particularly in hard-to-understand areas
- [X] - I have put JSDoc comment in all required places
- [X] - My changes generate no new warnings
- [X] - I have included screenshots describing my changes if relevant
- [X] - I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules