### PR TITLE
MAB-728: Improve role invite permission

### DIFF
--- a/src/schema/query/assignableRoles.query.ts
+++ b/src/schema/query/assignableRoles.query.ts
@@ -1,0 +1,97 @@
+import { GraphQLList, GraphQLID, GraphQLError } from 'graphql';
+import { Role } from '@models';
+import { RoleType } from '../types';
+import { logger } from '@lib/logger';
+import { graphQLAuthCheck } from '@schema/shared';
+import { Types } from 'mongoose';
+import { Context } from '@server/apollo/context';
+import permissions from '@const/permissions';
+
+/** Arguments for the assignableRoles query */
+type AssignableRolesArgs = {
+  application?: string | Types.ObjectId;
+};
+
+/**
+ * List roles that the logged user can assign to other users.
+ * Uses can_add_users.{roleId} granular permissions to filter.
+ * If the user has can_see_users for the application, returns all app roles.
+ * Throw GraphQL error if not logged or not authorized.
+ */
+export default {
+  type: new GraphQLList(RoleType),
+  args: {
+    application: { type: GraphQLID },
+  },
+  async resolve(parent, args: AssignableRolesArgs, context: Context) {
+    graphQLAuthCheck(context);
+    try {
+      const user = context.user;
+
+      // Get all roles for the application (or global roles if no app specified)
+      const filter: Record<string, any> = args.application
+        ? { application: args.application }
+        : { application: null };
+      const allRoles = await Role.find(filter);
+
+      if (!allRoles.length) {
+        return [];
+      }
+
+      // Check if user has global canSeeUsers permission
+      const hasGlobalSeeUsers = user.roles
+        .flatMap((r) => r.permissions)
+        .some((p) => p.type === permissions.canSeeUsers && p.global);
+
+      if (hasGlobalSeeUsers) {
+        return allRoles;
+      }
+
+      // Check if user has canSeeUsers for this specific application
+      if (args.application) {
+        const hasAppSeeUsers = user.roles
+          .filter((r) =>
+            r.application
+              ? new Types.ObjectId(r.application).equals(args.application)
+              : false
+          )
+          .flatMap((r) => r.permissions)
+          .some((p) => p.type === permissions.canSeeUsers);
+
+        if (hasAppSeeUsers) {
+          return allRoles;
+        }
+      }
+
+      // Get the user's can_add_users.{roleId} permissions
+      const addUserPermissions = user.roles
+        .filter((r) =>
+          args.application
+            ? r.application
+              ? new Types.ObjectId(r.application).equals(args.application)
+              : false
+            : true
+        )
+        .flatMap((r) => r.permissions)
+        .filter((p) => p.type?.startsWith(`${permissions.canAddUsers}.`))
+        .map((p) => (p.type || '').replace(`${permissions.canAddUsers}.`, ''));
+
+      if (!addUserPermissions.length) {
+        return [];
+      }
+
+      // Return only roles the user can assign
+      return allRoles.filter((role) =>
+        addUserPermissions.includes(role._id.toString())
+      );
+    } catch (err) {
+      logger.error(err.message, { stack: err.stack });
+      if (err instanceof GraphQLError) {
+        throw new GraphQLError(err.message);
+      }
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
+    }
+  },
+};

--- a/src/schema/query/index.ts
+++ b/src/schema/query/index.ts
@@ -40,6 +40,7 @@ import draftRecords from './draftRecords.query';
 import referenceDataAggregation from './referenceDataAggregation.query';
 import types from './types.query';
 import comments from './comments.query';
+import assignableRoles from './assignableRoles.query';
 
 /** GraphQL query type definition */
 const Query = new GraphQLObjectType({
@@ -47,6 +48,7 @@ const Query = new GraphQLObjectType({
   fields: {
     apiConfiguration,
     apiConfigurations,
+    assignableRoles,
     application,
     applications,
     channels,


### PR DESCRIPTION
# Description

When inviting users, the role dropdown showed all available roles regardless of the inviting user's permissions, meaning any user with invite access could assign roles they shouldn't be able to. Added a new assignableRoles GraphQL query on the backend that filters the role list based on the user's permissions: users with can_see_users still see all roles, but others only see roles they've been explicitly authorized to assign. The invite button is hidden entirely when the user has no assignable roles.

## Useful links

- https://www.notion.so/Improve-role-invite-permission-311d463fd8c4803dab41cb04a63b2b1f?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( \* == Mandatory )

- [X] - I have set myself as assignee of the pull request
- [X] - My code follows the style guidelines of this project
- [X] - Linting does not generate new warnings
- [X] - I have performed a self-review of my own code
- [X] - I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] - I have commented my code, particularly in hard-to-understand areas
- [X] - I have put JSDoc comment in all required places
- [X] - My changes generate no new warnings
- [X] - I have included screenshots describing my changes if relevant
- [X] - I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules